### PR TITLE
fixes broken build_forecasts

### DIFF
--- a/migrator/services/migrate_questions.py
+++ b/migrator/services/migrate_questions.py
@@ -57,7 +57,7 @@ def create_question(question: dict, **kwargs) -> Question:
         open_lower_bound = possibilities.get("high", None) == "tail"
     elif question["option_labels"] is not None:
         question_type = "multiple_choice"
-        options = question["option_labels"]
+        options = list(set(question["option_labels"]))
     else:
         return None
 

--- a/questions/management/commands/build_forecasts.py
+++ b/questions/management/commands/build_forecasts.py
@@ -24,14 +24,18 @@ class Command(BaseCommand):
 
             try:
                 run_build_question_forecasts(question.id)
-            except:
+            except Exception:
                 logger.exception(
-                    f"Failed to generate forecast for question {question.id}"
+                    "Failed to generate forecast for question %s", question.id
                 )
 
             processed += 1
-            if not processed % 100:
-                print(
-                    f"Processed {round(processed / total * 100)}% ({processed}/{total}) questions. "
-                    f"Overall duration: {round(time.time() - tm, 2)}s"
-                )
+            print(
+                f"Processed {int(processed / total * 100)}% ({processed}/{total})"
+                f" questions. Overall duration: {round(time.time() - tm)}s",
+                end="\r",
+            )
+        print(
+            f"Processed {int(processed / total * 100)}% ({processed}/{total})"
+            f" questions. Overall duration: {round(time.time() - tm)}s",
+        )

--- a/questions/services.py
+++ b/questions/services.py
@@ -66,7 +66,7 @@ def build_question_forecasts(question: Question) -> dict:
         forecasts_data["latest_cdf"] = None
         forecasts_data["latest_pmf"] = (
             None
-            if len(forecasts_data[option]) == 0
+            if len(list(forecasts_data.values())[0]) == 0
             else [
                 forecasts_data[option][-1]["value_mean"] / 100
                 for option in question.options
@@ -106,7 +106,9 @@ def build_question_forecasts(question: Question) -> dict:
     return forecasts_data
 
 
-def build_question_forecasts_for_user(question: Question, user_forecasts: list[Forecast]) -> dict:
+def build_question_forecasts_for_user(
+    question: Question, user_forecasts: list[Forecast]
+) -> dict:
     """
     Builds forecasts of a specific user
     """


### PR DESCRIPTION
Adds support for multiple choice questions with no forecasts.
Manually culls duplicate option labels for multiple choice questions.
minor quality of life printing improvement for `build_forecasts` command