### PR TITLE
Add timeline chart for continuous group questions

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
@@ -23,6 +23,7 @@ import QuestionHeaderInfo from "../components/question_header_info";
 import QuestionResolutionStatus from "../components/question_resolution_status";
 import Sidebar from "../components/sidebar";
 import { SLUG_POST_SUB_QUESTION_ID } from "../search_params";
+import ContinuousGroupTimeline from "../components/forecast_timeline_drawer";
 
 type Props = {
   params: { id: number; slug: string[] };
@@ -147,6 +148,11 @@ export default async function IndividualQuestion({
                 }
               />
             )}
+
+            {!!postData.group_of_questions && (
+              <ContinuousGroupTimeline post={postData} />
+            )}
+            
             <BackgroundInfo post={postData} />
             <HistogramDrawer post={postData} />
             <Sidebar

--- a/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import classNames from "classnames";
+import { useTranslations } from "next-intl";
+import React, { FC, useCallback, useEffect, useMemo, useState } from "react";
+
+import MultipleChoiceChart from "@/components/charts/multiple_choice_chart";
+import { useAuth } from "@/contexts/auth_context";
+import useChartTooltip from "@/hooks/use_chart_tooltip";
+import usePrevious from "@/hooks/use_previous";
+import useTimestampCursor from "@/hooks/use_timestamp_cursor";
+import { ChoiceItem, ChoiceTooltipItem } from "@/types/choices";
+import { Question, QuestionWithNumericForecasts } from "@/types/question";
+import {
+  findPreviousTimestamp,
+  generateChoiceItemsFromBinaryGroup,
+  getDisplayValue,
+} from "@/utils/charts";
+import { generateUserForecasts } from "@/utils/questions";
+import ChoicesLegend from "./choices_legend";
+import ChoicesTooltip from "./choices_tooltip";
+
+const MAX_VISIBLE_CHECKBOXES = 6;
+
+function getQuestionTooltipLabel(
+  timestamps: number[],
+  values: number[],
+  cursorTimestamp: number,
+  question: Question
+) {
+  const hasValue =
+    cursorTimestamp >= Math.min(...timestamps) &&
+    cursorTimestamp <= Math.max(...timestamps);
+  if (!hasValue) {
+    return "?";
+  }
+
+  const closestTimestamp = findPreviousTimestamp(timestamps, cursorTimestamp);
+  const cursorIndex = timestamps.findIndex(
+    (timestamp) => timestamp === closestTimestamp
+  );
+
+  return getDisplayValue(values[cursorIndex], question);
+}
+
+function generateList(
+  questions: QuestionWithNumericForecasts[],
+  preselectedQuestionId?: number
+) {
+  return generateChoiceItemsFromBinaryGroup(questions, {
+    withMinMax: true,
+    activeCount: MAX_VISIBLE_CHECKBOXES,
+    preselectedQuestionId,
+  });
+}
+
+type Props = {
+  questions: QuestionWithNumericForecasts[];
+  timestamps: number[];
+};
+
+const ContinuousGroupTimeline: FC<Props> = ({ questions, timestamps }) => {
+  const t = useTranslations();
+  const { user } = useAuth();
+  const [isChartReady, setIsChartReady] = useState(false);
+  const handleChartReady = useCallback(() => {
+    setIsChartReady(true);
+  }, []);
+
+  const [choiceItems, setChoiceItems] = useState<ChoiceItem[]>(
+    generateList(questions)
+  );
+  const userForecasts = user ? generateUserForecasts(questions) : undefined;
+  const timestampsCount = timestamps.length;
+  const prevTimestampsCount = usePrevious(timestampsCount);
+  // sync BE driven data with local state
+  useEffect(() => {
+    if (prevTimestampsCount && prevTimestampsCount !== timestampsCount) {
+      setChoiceItems(generateList(questions));
+    }
+  }, [questions, prevTimestampsCount, timestampsCount]);
+
+  const [cursorTimestamp, tooltipDate, handleCursorChange] =
+    useTimestampCursor(timestamps);
+
+  const tooltipChoices = useMemo<ChoiceTooltipItem[]>(
+    () =>
+      choiceItems
+        .filter(({ active }) => active)
+        .map(
+          ({ choice, values, color, timestamps: optionTimestamps }, index) => {
+            return {
+              choiceLabel: choice,
+              color,
+              valueLabel: getQuestionTooltipLabel(
+                optionTimestamps ?? timestamps,
+                values,
+                cursorTimestamp,
+                questions[index]
+              ),
+            };
+          }
+        ),
+    [choiceItems, cursorTimestamp, timestamps]
+  );
+
+  const {
+    isActive: isTooltipActive,
+    getReferenceProps,
+    getFloatingProps,
+    refs,
+    floatingStyles,
+  } = useChartTooltip();
+
+  const handleChoiceChange = useCallback((choice: string, checked: boolean) => {
+    setChoiceItems((prev) =>
+      prev.map((item) =>
+        item.choice === choice
+          ? { ...item, active: checked, highlighted: false }
+          : item
+      )
+    );
+  }, []);
+  const handleChoiceHighlight = useCallback(
+    (choice: string, highlighted: boolean) => {
+      setChoiceItems((prev) =>
+        prev.map((item) =>
+          item.choice === choice ? { ...item, highlighted } : item
+        )
+      );
+    },
+    []
+  );
+  const toggleSelectAll = useCallback((isAllSelected: boolean) => {
+    if (isAllSelected) {
+      setChoiceItems((prev) =>
+        prev.map((item) => ({ ...item, active: false, highlighted: false }))
+      );
+    } else {
+      setChoiceItems((prev) => prev.map((item) => ({ ...item, active: true })));
+    }
+  }, []);
+
+  return (
+    <div
+      className={classNames(
+        "flex w-full flex-col",
+        isChartReady ? "opacity-100" : "opacity-0"
+      )}
+    >
+      <div className="flex items-center">
+        <h3 className="m-0 text-base font-normal leading-5">
+          {t("forecastTimelineHeading")}
+        </h3>
+      </div>
+      <div ref={refs.setReference} {...getReferenceProps()}>
+        <MultipleChoiceChart
+          timestamps={timestamps}
+          choiceItems={choiceItems}
+          yLabel={t("communityPredictionLabel")}
+          onChartReady={handleChartReady}
+          onCursorChange={handleCursorChange}
+          userForecasts={userForecasts}
+          questionType={questions[0].type}
+          scaling={questions[0].scaling}
+        />
+      </div>
+
+      <div className="mt-3">
+        <ChoicesLegend
+          choices={choiceItems}
+          onChoiceChange={handleChoiceChange}
+          onChoiceHighlight={handleChoiceHighlight}
+          maxLegendChoices={MAX_VISIBLE_CHECKBOXES}
+          onToggleAll={toggleSelectAll}
+        />
+      </div>
+
+      {isTooltipActive && !!tooltipChoices.length && (
+        <div
+          className="pointer-events-none z-20 rounded bg-gray-0 p-2 leading-4 shadow-lg dark:bg-gray-0-dark"
+          ref={refs.setFloating}
+          style={floatingStyles}
+          {...getFloatingProps()}
+        >
+          <ChoicesTooltip date={tooltipDate} choices={tooltipChoices} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ContinuousGroupTimeline;

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_timeline_drawer.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_timeline_drawer.tsx
@@ -1,0 +1,38 @@
+import { FC } from "react";
+
+import { QuestionType, QuestionWithNumericForecasts } from "@/types/question";
+import { PostWithForecasts } from "@/types/post";
+import { getGroupQuestionsTimestamps } from "@/utils/charts";
+import { sortGroupPredictionOptions } from "@/utils/questions";
+import ContinuousGroupTimeline from "./continuous_group_timeline";
+
+type Props = {
+  post: PostWithForecasts;
+};
+
+const ForecastTimelineDrawer: FC<Props> = ({ post }) => {
+  const questions = post.group_of_questions
+    ?.questions as QuestionWithNumericForecasts[];
+  const groupType = questions?.at(0)?.type;
+
+  if (
+    !groupType ||
+    ![QuestionType.Numeric, QuestionType.Date].includes(groupType)
+  ) {
+    return null;
+  }
+
+  const sortedQuestions = sortGroupPredictionOptions(
+    questions as QuestionWithNumericForecasts[]
+  );
+  const timestamps = getGroupQuestionsTimestamps(sortedQuestions);
+
+  return (
+    <ContinuousGroupTimeline
+      questions={sortedQuestions}
+      timestamps={timestamps}
+    />
+  );
+};
+
+export default ForecastTimelineDrawer;

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/types/question";
 import {
   generateNumericDomain,
+  generateTicksY,
   generateTimestampXScale,
   getDisplayValue,
   unscaleNominalLocation,
@@ -343,27 +344,13 @@ function buildChartData({
   const yDomain: Tuple<number> = [0, 1];
 
   const desiredMajorTicks = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0];
-  const minorTicksPerMajor = 9;
   const desiredMajorTickDistance = 20;
 
-  const maxMajorTicks = Math.floor(height / desiredMajorTickDistance);
-
-  let majorTicks = desiredMajorTicks;
-  if (maxMajorTicks < desiredMajorTicks.length) {
-    // adjust major ticks on small height
-    const step = 1 / (maxMajorTicks - 1);
-    majorTicks = Array.from({ length: maxMajorTicks }, (_, i) => i * step);
-  }
-  const ticks = [];
-  for (let i = 0; i < majorTicks.length - 1; i++) {
-    ticks.push(majorTicks[i]);
-    const step = (majorTicks[i + 1] - majorTicks[i]) / (minorTicksPerMajor + 1);
-    for (let j = 1; j <= minorTicksPerMajor; j++) {
-      ticks.push(majorTicks[i] + step * j);
-    }
-  }
-  ticks.push(majorTicks[majorTicks.length - 1]);
-
+  const { ticks, majorTicks } = generateTicksY(
+    height,
+    desiredMajorTicks,
+    desiredMajorTickDistance
+  );
   const tickFormat = (value: number): string => {
     if (!majorTicks.includes(value)) {
       return "";

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -410,18 +410,22 @@ export function generateChoiceItemsFromBinaryGroup(
       choice: label,
       values: history.map((forecast) => forecast.centers![0]),
       minValues: history.map(
-        (forecast) => forecast.interval_lower_bounds![order]
+        (forecast) =>
+          forecast.interval_lower_bounds![order] ??
+          forecast.interval_lower_bounds![0]
       ),
       maxValues: history.map(
-        (forecast) => forecast.interval_upper_bounds![order]
+        (forecast) =>
+          forecast.interval_upper_bounds![order] ??
+          forecast.interval_upper_bounds![0]
       ),
       timestamps: history.map((forecast) => forecast.start_time),
       color: MULTIPLE_CHOICE_COLOR_SCALE[index] ?? METAC_COLORS.gray["400"],
       active: !!activeCount ? index <= activeCount - 1 : true,
       highlighted: false,
       resolution: question.resolution,
-      rangeMin: 0,
-      rangeMax: 1,
+      rangeMin: question.scaling.range_min ?? 0,
+      rangeMax: question.scaling.range_min ?? 1,
     };
   });
 }
@@ -489,9 +493,9 @@ export const interpolateYValue = (xValue: number, line: Line) => {
   return p1.y + t * (p2.y - p1.y);
 };
 
-export function generateTicksY(height: number, desiredMajorTicks: number[]) {
+export function generateTicksY(height: number, desiredMajorTicks: number[], majorTickDistance?: number) {
   const minorTicksPerMajor = 9;
-  const desiredMajorTickDistance = 50;
+  const desiredMajorTickDistance = majorTickDistance ?? 50;
   let majorTicks = desiredMajorTicks;
   const maxMajorTicks = Math.floor(height / desiredMajorTickDistance);
 
@@ -514,5 +518,5 @@ export function generateTicksY(height: number, desiredMajorTicks: number[]) {
     }
     return value.toString();
   };
-  return { ticks, tickFormat };
+  return { ticks, tickFormat, majorTicks };
 }


### PR DESCRIPTION
- Implemented ContinuousGroupTimeline and GroupTimelineDrawer to render a timeline for continuous group questions
- Refactored MultipleChoiceChart to use it within ContinuousGroupTimeline
- Refactored generateTicksY and used it inside NumericChart to remove redundant code
- Fixed a bug where hover area on charts was displayed only for the first option