### PR TITLE
Fix sub-menu text color and jumping

### DIFF
--- a/front_end/src/app/(main)/components/header.tsx
+++ b/front_end/src/app/(main)/components/header.tsx
@@ -92,7 +92,7 @@ const Header: FC = () => {
             </MenuButton>
             <MenuItems
               anchor="bottom"
-              className="text-gray-0 z-50 lg:border lg:border-blue-200-dark lg:bg-blue-900 lg:text-sm"
+              className="z-50 text-gray-0 lg:border lg:border-blue-200-dark lg:bg-blue-900 lg:text-sm"
             >
               <LinkMenuItem href="/about/" label={t("aboutMetaculus")} />
               <LinkMenuItem href="/press/" label={t("forJournalists")} />

--- a/front_end/src/app/(main)/components/header.tsx
+++ b/front_end/src/app/(main)/components/header.tsx
@@ -92,7 +92,7 @@ const Header: FC = () => {
             </MenuButton>
             <MenuItems
               anchor="bottom"
-              className="text-bg-gray-0 z-50 lg:border lg:border-blue-200-dark lg:bg-blue-900 lg:text-sm"
+              className="text-gray-0 z-50 lg:border lg:border-blue-200-dark lg:bg-blue-900 lg:text-sm"
             >
               <LinkMenuItem href="/about/" label={t("aboutMetaculus")} />
               <LinkMenuItem href="/press/" label={t("forJournalists")} />

--- a/front_end/src/app/layout.tsx
+++ b/front_end/src/app/layout.tsx
@@ -123,7 +123,7 @@ export default async function RootLayout({
   return (
     <html
       lang={locale}
-      className={`${interVariable.variable} ${inter.variable} ${sourceSerifPro.variable} ${leagueGothic.variable} font-sans`}
+      className={`${interVariable.variable} ${inter.variable} ${sourceSerifPro.variable} ${leagueGothic.variable} font-sans [scrollbar-gutter:stable] !pe-0`}
       // required by next-themes
       // https://github.com/pacocoursey/next-themes?tab=readme-ov-file#with-app
       suppressHydrationWarning

--- a/front_end/src/app/layout.tsx
+++ b/front_end/src/app/layout.tsx
@@ -123,7 +123,7 @@ export default async function RootLayout({
   return (
     <html
       lang={locale}
-      className={`${interVariable.variable} ${inter.variable} ${sourceSerifPro.variable} ${leagueGothic.variable} font-sans [scrollbar-gutter:stable] !pe-0`}
+      className={`${interVariable.variable} ${inter.variable} ${sourceSerifPro.variable} ${leagueGothic.variable} !pe-0 font-sans [scrollbar-gutter:stable]`}
       // required by next-themes
       // https://github.com/pacocoursey/next-themes?tab=readme-ov-file#with-app
       suppressHydrationWarning


### PR DESCRIPTION
* fix #325 by using the same text color in sub-menu as in the main menu (the issue implies to change background, but this looked more consistent IMHO)
* also fix the jumping menu (now there is empty background behind the removed scroll bar when headlessui adds the `overflow: hidden` inline style to &lt;html&gt; element while sub-menu is open)   * only reproducible when using visible scrollbars - mostly on Windows, but [there is a setting](https://www.macrumors.com/how-to/make-scroll-bars-always-visible/) for it on Mac too..
   * no idea if the fix to work correctly in Safari (but I don't expect any Safari user would enable always visible scroll bars in the first place, so hopefully not a high priority that would prevent merging this PR ... if it's broken in Safari, it should be equally broken before and after adding `scrollbar-gutter:stable`)
   
![fixed menu](https://github.com/user-attachments/assets/acb6ad82-09c6-4e0c-80fe-9955d8e0068c)

