### PR TITLE
The timeline x axis goes to today instead of stopping at the close date for closed questions

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
@@ -137,6 +137,12 @@ export default async function IndividualQuestion({
               <DetailedGroupCard
                 questions={postData.group_of_questions.questions}
                 preselectedQuestionId={preselectedGroupQuestionId}
+                isClosed={
+                  postData.actual_close_time
+                    ? new Date(postData.actual_close_time).getTime() <
+                      Date.now()
+                    : false
+                }
               />
             )}
 
@@ -145,6 +151,12 @@ export default async function IndividualQuestion({
               <ConditionalTimeline
                 conditional={
                   postData.conditional as PostConditional<QuestionWithNumericForecasts>
+                }
+                isClosed={
+                  postData.actual_close_time
+                    ? new Date(postData.actual_close_time).getTime() <
+                      Date.now()
+                    : false
                 }
               />
             )}

--- a/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
@@ -57,9 +57,14 @@ function generateList(
 type Props = {
   questions: QuestionWithNumericForecasts[];
   timestamps: number[];
+  isClosed?: boolean;
 };
 
-const ContinuousGroupTimeline: FC<Props> = ({ questions, timestamps }) => {
+const ContinuousGroupTimeline: FC<Props> = ({
+  questions,
+  timestamps,
+  isClosed,
+}) => {
   const t = useTranslations();
   const { user } = useAuth();
   const [isChartReady, setIsChartReady] = useState(false);
@@ -163,6 +168,7 @@ const ContinuousGroupTimeline: FC<Props> = ({ questions, timestamps }) => {
           userForecasts={userForecasts}
           questionType={questions[0].type}
           scaling={questions[0].scaling}
+          isClosed={isClosed}
         />
       </div>
 

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/binary_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/binary_group_chart.tsx
@@ -70,6 +70,7 @@ type Props = {
   timestamps: number[];
   preselectedQuestionId?: number;
   defaultZoom?: TimelineChartZoomOption;
+  isClosed?: boolean;
 };
 
 const BinaryGroupChart: FC<Props> = ({
@@ -77,6 +78,7 @@ const BinaryGroupChart: FC<Props> = ({
   timestamps,
   preselectedQuestionId,
   defaultZoom,
+  isClosed
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -205,6 +207,7 @@ const BinaryGroupChart: FC<Props> = ({
           }
           withZoomPicker
           userForecasts={userForecasts}
+          isClosed={isClosed}
         />
       </div>
 

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/index.tsx
@@ -14,9 +14,14 @@ import BinaryGroupChart from "./binary_group_chart";
 type Props = {
   questions: QuestionWithForecasts[];
   preselectedQuestionId?: number;
+  isClosed?: boolean;
 };
 
-const DetailedGroupCard: FC<Props> = ({ questions, preselectedQuestionId }) => {
+const DetailedGroupCard: FC<Props> = ({
+  questions,
+  preselectedQuestionId,
+  isClosed,
+}) => {
   const groupType = questions.at(0)?.type;
 
   if (!groupType) {
@@ -35,6 +40,7 @@ const DetailedGroupCard: FC<Props> = ({ questions, preselectedQuestionId }) => {
           questions={sortedQuestions}
           timestamps={timestamps}
           preselectedQuestionId={preselectedQuestionId}
+          isClosed={isClosed}
         />
       );
     }

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
@@ -145,6 +145,11 @@ const MultipleChoiceChartCard: FC<Props> = ({
               : TimelineChartZoomOption.TwoMonths
           }
           withZoomPicker
+          isClosed={
+            question.actual_close_time
+              ? new Date(question.actual_close_time).getTime() < Date.now()
+              : false
+          }
         />
       </div>
 

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_timeline_drawer.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_timeline_drawer.tsx
@@ -31,6 +31,12 @@ const ForecastTimelineDrawer: FC<Props> = ({ post }) => {
     <ContinuousGroupTimeline
       questions={sortedQuestions}
       timestamps={timestamps}
+      isClosed={
+        post.actual_close_time
+          ? new Date(post.actual_close_time).getTime() <
+            Date.now()
+          : false
+      }
     />
   );
 };

--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -59,6 +59,7 @@ type Props = {
   userForecasts?: UserChoiceItem[];
   questionType?: QuestionType;
   scaling?: Scaling;
+  isClosed?: boolean;
 };
 
 const MultipleChoiceChart: FC<Props> = ({
@@ -74,6 +75,7 @@ const MultipleChoiceChart: FC<Props> = ({
   userForecasts,
   questionType,
   scaling,
+  isClosed,
 }) => {
   const t = useTranslations();
   const {
@@ -129,7 +131,9 @@ const MultipleChoiceChart: FC<Props> = ({
       cursorLabel={({ datum }: VictoryLabelProps) => {
         if (datum) {
           return datum.x === defaultCursor
-            ? t("now")
+            ? isClosed
+              ? ""
+              : t("now")
             : xScale.cursorFormat?.(datum.x) ?? xScale.tickFormat(datum.x);
         }
       }}
@@ -381,11 +385,6 @@ function buildChartData({
   );
   let yScale = generatePercentageYScale(height);
   if (!!scaling && !!questionType) {
-    console.log(choiceItems);
-    const minChoiceRange = choiceItems[0].rangeMin ?? 0;
-    const maxChoiceRange = choiceItems[0].rangeMax ?? 1;
-    console.log(minChoiceRange);
-    console.log(maxChoiceRange);
     const { ticks, majorTicks } = generateTicksY(
       height,
       [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -297,7 +297,7 @@ function buildChartData({
     y: forecast.interval_upper_bounds![0],
   }));
   const latestTimestamp = actualCloseTime
-    ? Math.min(actualCloseTime, Date.now() / 1000)
+    ? Math.min(actualCloseTime / 1000, Date.now() / 1000)
     : Date.now() / 1000;
   if (aggregation.latest) {
     line.push({

--- a/front_end/src/components/conditional_timeline.tsx
+++ b/front_end/src/components/conditional_timeline.tsx
@@ -8,16 +8,23 @@ import { getGroupQuestionsTimestamps } from "@/utils/charts";
 
 type Props = {
   conditional: PostConditional<QuestionWithNumericForecasts>;
+  isClosed?: boolean;
 };
 
-const ConditionalTimeline: FC<Props> = ({ conditional }) => {
+const ConditionalTimeline: FC<Props> = ({ conditional, isClosed }) => {
   const groupType = conditional.question_no.type;
   const questions = [conditional.question_yes, conditional.question_no];
 
   switch (groupType) {
     case QuestionType.Binary: {
       const timestamps = getGroupQuestionsTimestamps(questions);
-      return <BinaryGroupChart questions={questions} timestamps={timestamps} />;
+      return (
+        <BinaryGroupChart
+          questions={questions}
+          timestamps={timestamps}
+          isClosed={isClosed}
+        />
+      );
     }
     case QuestionType.Numeric:
     case QuestionType.Date:

--- a/front_end/src/types/post.ts
+++ b/front_end/src/types/post.ts
@@ -114,6 +114,7 @@ export type Post<QT = Question> = {
   updated_at: string;
   published_at: string;
   curation_status_updated_at: string | null;
+  actual_close_time: string;
   scheduled_close_time: string;
   scheduled_resolve_time: string;
   vote: PostVote;


### PR DESCRIPTION
Fixed chart issue for closed questions:

- Limited timestamps to close time instead of the current time
- Removed label from default cursor in main question graph
- Removed label from default cursor in Forecast Timeline question graph