### PR TITLE
Color for "my forecasts" are off on multiple choice / groups

### DIFF
--- a/front_end/src/components/post_card/group_of_questions_tile/index.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/index.tsx
@@ -56,7 +56,7 @@ const GroupOfQuestionsTile: FC<Props> = ({ questions, curationStatus }) => {
           userForecasts={
             user
               ? generateUserForecasts(
-                  questions as QuestionWithNumericForecasts[]
+                  sortedQuestions as QuestionWithNumericForecasts[]
                 )
               : undefined
           }

--- a/front_end/src/components/post_card/question_chart_tile/index.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/index.tsx
@@ -11,6 +11,7 @@ import { generateChoiceItemsFromMultipleChoiceForecast } from "@/utils/charts";
 
 import QuestionNumericTile from "./question_numeric_tile";
 import { useTranslations } from "next-intl";
+import { generateUserForecastsForMultipleQuestion } from "@/utils/questions";
 
 type Props = {
   question: QuestionWithForecasts;
@@ -62,6 +63,8 @@ const QuestionChartTile: FC<Props> = ({
       const choices = generateChoiceItemsFromMultipleChoiceForecast(question, {
         activeCount: visibleChoicesCount,
       });
+      const userForecasts = generateUserForecastsForMultipleQuestion(question);
+
       return (
         <MultipleChoiceTile
           timestamps={question.aggregations.recency_weighted.history.map(
@@ -71,6 +74,7 @@ const QuestionChartTile: FC<Props> = ({
           visibleChoicesCount={visibleChoicesCount}
           defaultChartZoom={defaultChartZoom}
           question={question}
+          userForecasts={userForecasts}
         />
       );
     }


### PR DESCRIPTION
* Fixed mismatch for user forecast and question line colors
* Implemented `generateUserForecastsForMultipleQuestion` helper
* Added user forecasts for multiple choice questions (feed and individual page)
* Added user forecast value for multiple choice cursor overlay (individual page)