### PR TITLE
Upcoming questions show "closes in x days" instead of "opens in x day"

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/sidebar_question_info.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/sidebar_question_info.tsx
@@ -13,6 +13,7 @@ const SidebarQuestionInfo: FC<Props> = ({ postData }) => {
   const locale = useLocale();
   const t = useTranslations();
 
+  const isUpcoming = new Date(postData.open_time).getTime() > Date.now();
   return (
     <div className="flex flex-col items-start gap-4 self-stretch @container">
       <div className="flex flex-col justify-between gap-3 self-stretch @lg:grid @lg:grid-cols-4 @lg:gap-1">
@@ -30,11 +31,13 @@ const SidebarQuestionInfo: FC<Props> = ({ postData }) => {
 
         <div className="flex justify-between gap-4 @lg:flex-col @lg:justify-start @lg:gap-1">
           <span className="text-xs font-medium uppercase text-gray-700 dark:text-gray-700-dark">
-            {t("opened")}:
+            {t(isUpcoming ? "opens" : "opened")}:
           </span>
           <span className="text-sm font-medium leading-4 text-gray-900 dark:text-gray-900-dark">
-            {postData.published_at &&
-              formatDate(locale, new Date(postData.published_at))}
+            {formatDate(
+              locale,
+              new Date(isUpcoming ? postData.open_time : postData.published_at)
+            )}
           </span>
         </div>
 

--- a/front_end/src/components/post_status/index.tsx
+++ b/front_end/src/components/post_status/index.tsx
@@ -14,7 +14,7 @@ type Props = {
 const PostStatus: FC<Props> = ({ resolution, post }) => {
   const t = useTranslations();
   const locale = useLocale();
-  const { status, scheduled_close_time, scheduled_resolve_time } = post;
+  const { status, scheduled_close_time, scheduled_resolve_time, open_time } = post;
 
   const statusInfo = useMemo(() => {
     if (status === PostStatusEnum.CLOSED) {
@@ -22,6 +22,14 @@ const PostStatus: FC<Props> = ({ resolution, post }) => {
     }
 
     if (status === PostStatusEnum.APPROVED) {
+      if (new Date(open_time).getTime() > Date.now()) {
+        return [
+          t("opens"),
+          formatRelativeDate(locale, new Date(open_time), {
+            short: true,
+          }),
+        ];
+      }
       return [
         t("closes"),
         formatRelativeDate(locale, new Date(scheduled_close_time), {


### PR DESCRIPTION
- Handle open_time in question status component
- Fixed opened/opens status in question sidebar