### PR TITLE
Continuous feed tiles have epoch seconds on the x axis instead of dates

### DIFF
--- a/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
@@ -95,6 +95,7 @@ const QuestionNumericTile: FC<Props> = ({
             scaling={question.scaling}
             data={continuousAreaChartData}
             height={HEIGHT}
+            questionType={question.type}
           />
         )}
       </div>


### PR DESCRIPTION
- fix chart x-axis labels for QuestionNumericTile