### PR TITLE
New predictions aren't registered immediately under "My Prediction"

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/numeric_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/numeric_chart_card.tsx
@@ -30,15 +30,40 @@ const NumericChartCard: FC<Props> = ({ question }) => {
     const index = aggregate.history.findIndex(
       (f) => f.start_time === cursorTimestamp
     );
-    const forecast = aggregate.history[index];
+
+    const forecast = index === -1 ? aggregate.history[aggregate.history.length - 1] : aggregate.history[index];
+    let timestamp = cursorTimestamp;
+    const lastAggregate = aggregate.history[aggregate.history.length - 1];
+    console.log("RECALCULATE CURSOR DATA");
+    if (
+      lastAggregate &&
+      timestamp === lastAggregate.start_time &&
+      question.my_forecasts?.latest?.start_time &&
+      lastAggregate.start_time < question.my_forecasts.latest.start_time
+    ) {
+      console.log("SETTING TO MY FORECASTS LATEST");
+      timestamp = question.my_forecasts.latest.start_time;
+      return {
+        timestamp,
+        forecasterCount: forecast.forecaster_count,
+        interval_lower_bound: forecast.interval_lower_bounds![0],
+        center: forecast.centers![0],
+        interval_upper_bound: forecast.interval_upper_bounds![0],
+      };
+    }
     return {
-      timestamp: forecast.start_time,
+      timestamp: forecast.start_time ?? cursorTimestamp,
       forecasterCount: forecast.forecaster_count,
       interval_lower_bound: forecast.interval_lower_bounds![0],
       center: forecast.centers![0],
       interval_upper_bound: forecast.interval_upper_bounds![0],
     };
-  }, [cursorTimestamp, aggregate.history]);
+  }, [
+    cursorTimestamp,
+    aggregate.history,
+    question.my_forecasts,
+    question.aggregations.recency_weighted,
+  ]);
 
   const handleCursorChange = useCallback((value: number) => {
     setCursorTimestamp(value);
@@ -47,6 +72,7 @@ const NumericChartCard: FC<Props> = ({ question }) => {
   const handleChartReady = useCallback(() => {
     setIsChartReady(true);
   }, []);
+
 
   return (
     <div

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/numeric_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/numeric_chart_card.tsx
@@ -23,8 +23,8 @@ const NumericChartCard: FC<Props> = ({ question }) => {
 
   const aggregate = question.aggregations.recency_weighted;
 
-  const [cursorTimestamp, setCursorTimestamp] = useState(
-    aggregate.latest?.start_time
+  const [cursorTimestamp, setCursorTimestamp] = useState<number | null>(
+    null
   );
   const cursorData = useMemo(() => {
     const index = aggregate.history.findIndex(
@@ -34,14 +34,12 @@ const NumericChartCard: FC<Props> = ({ question }) => {
     const forecast = index === -1 ? aggregate.history[aggregate.history.length - 1] : aggregate.history[index];
     let timestamp = cursorTimestamp;
     const lastAggregate = aggregate.history[aggregate.history.length - 1];
-    console.log("RECALCULATE CURSOR DATA");
     if (
       lastAggregate &&
-      timestamp === lastAggregate.start_time &&
+      timestamp === null &&
       question.my_forecasts?.latest?.start_time &&
       lastAggregate.start_time < question.my_forecasts.latest.start_time
     ) {
-      console.log("SETTING TO MY FORECASTS LATEST");
       timestamp = question.my_forecasts.latest.start_time;
       return {
         timestamp,
@@ -65,7 +63,7 @@ const NumericChartCard: FC<Props> = ({ question }) => {
     question.aggregations.recency_weighted,
   ]);
 
-  const handleCursorChange = useCallback((value: number) => {
+  const handleCursorChange = useCallback((value: number | null) => {
     setCursorTimestamp(value);
   }, []);
 

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
@@ -37,6 +37,7 @@ import {
   BINARY_MIN_VALUE,
 } from "../binary_slider";
 import ForecastChoiceOption from "../forecast_choice_option";
+import LoadingIndicator from "@/components/ui/loading_indicator";
 
 type QuestionOption = {
   id: number;
@@ -162,7 +163,9 @@ const ForecastMakerGroupBinary: FC<Props> = ({
     setQuestionOptions((prev) =>
       prev.map((prevQuestion) => ({ ...prevQuestion, isDirty: false }))
     );
-    setIsSubmitting(false);
+    setTimeout(() => {
+      setIsSubmitting(false);
+    }, 1500);
 
     const errors: ErrorResponse[] = [];
     if (response && "errors" in response && !!response.errors) {
@@ -237,36 +240,41 @@ const ForecastMakerGroupBinary: FC<Props> = ({
         </div>
       )}
       {canPredict && (
-        <div className="my-5 flex flex-wrap items-center justify-center gap-3 px-4">
-          {user ? (
-            <>
-              <Button
-                variant="secondary"
-                type="reset"
-                onClick={resetForecasts}
-                disabled={!isPickerDirty}
-              >
-                {t("discardChangesButton")}
-              </Button>
+        <>
+          <div className="mt-5 flex flex-wrap items-center justify-center gap-3 px-4">
+            {user ? (
+              <>
+                <Button
+                  variant="secondary"
+                  type="reset"
+                  onClick={resetForecasts}
+                  disabled={!isPickerDirty}
+                >
+                  {t("discardChangesButton")}
+                </Button>
+                <Button
+                  variant="primary"
+                  type="submit"
+                  onClick={handlePredictSubmit}
+                  disabled={!submitIsAllowed}
+                >
+                  {t("saveChange")}
+                </Button>
+              </>
+            ) : (
               <Button
                 variant="primary"
-                type="submit"
-                onClick={handlePredictSubmit}
-                disabled={!submitIsAllowed}
+                type="button"
+                onClick={() => setCurrentModal({ type: "signup" })}
               >
-                {t("saveChange")}
+                {t("signUpToPredict")}
               </Button>
-            </>
-          ) : (
-            <Button
-              variant="primary"
-              type="button"
-              onClick={() => setCurrentModal({ type: "signup" })}
-            >
-              {t("signUpToPredict")}
-            </Button>
-          )}
-        </div>
+            )}
+          </div>
+          <div className="h-[32px] w-full">
+            {isSubmitting && <LoadingIndicator />}
+          </div>
+        </>
       )}
       {submitErrors.map((errResponse, index) => (
         <FormErrorMessage key={`error-${index}`} errors={errResponse} />

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
@@ -20,6 +20,7 @@ import BinarySlider, { BINARY_FORECAST_PRECISION } from "../binary_slider";
 import QuestionResolutionButton from "../resolution";
 import { useRouter } from "next/navigation";
 import LoadingIndicator from "@/components/ui/loading_indicator";
+import { useServerAction } from "@/hooks/use_server_action";
 
 type Props = {
   postId: number;
@@ -53,7 +54,6 @@ const ForecastMakerBinary: FC<Props> = ({
 
   const [isForecastDirty, setIsForecastDirty] = useState(false);
 
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<ErrorResponse>();
 
   useEffect(() => {
@@ -72,7 +72,6 @@ const ForecastMakerBinary: FC<Props> = ({
 
     const forecastValue = round(forecast / 100, BINARY_FORECAST_PRECISION);
 
-    setIsSubmitting(true);
     const response = await createForecasts(postId, [
       {
         questionId: question.id,
@@ -88,11 +87,8 @@ const ForecastMakerBinary: FC<Props> = ({
     if (response && "errors" in response && !!response.errors) {
       setSubmitError(response.errors[0]);
     }
-    setTimeout(() => {
-      setIsSubmitting(false);
-    }, 1500);
   };
-
+  const [submit, isPending] = useServerAction(handlePredictSubmit);
   return (
     <>
       <BinarySlider
@@ -113,16 +109,15 @@ const ForecastMakerBinary: FC<Props> = ({
       <div className="flex flex-col items-center justify-center">
         {canPredict && (
           <>
-            {" "}
             <Button
               variant="primary"
-              disabled={!!user && (!isForecastDirty || isSubmitting)}
-              onClick={handlePredictSubmit}
+              disabled={!!user && (!isForecastDirty || isPending)}
+              onClick={submit}
             >
               {user ? t("predict") : t("signUpToPredict")}
             </Button>
             <div className="h-[32px] w-full">
-              {isSubmitting && <LoadingIndicator />}
+              {isPending && <LoadingIndicator />}
             </div>
           </>
         )}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
@@ -19,7 +19,7 @@ import { extractPrevBinaryForecastValue } from "@/utils/forecasts";
 import BinarySlider, { BINARY_FORECAST_PRECISION } from "../binary_slider";
 import QuestionResolutionButton from "../resolution";
 import { useRouter } from "next/navigation";
-import { post } from "@/utils/fetch";
+import LoadingIndicator from "@/components/ui/loading_indicator";
 
 type Props = {
   postId: number;
@@ -88,8 +88,9 @@ const ForecastMakerBinary: FC<Props> = ({
     if (response && "errors" in response && !!response.errors) {
       setSubmitError(response.errors[0]);
     }
-    setIsSubmitting(false);
-    router.push(`/questions/${postId}/refresh${Date.now()}`);
+    setTimeout(() => {
+      setIsSubmitting(false);
+    }, 1500);
   };
 
   return (
@@ -111,19 +112,24 @@ const ForecastMakerBinary: FC<Props> = ({
       )}
       <div className="flex flex-col items-center justify-center">
         {canPredict && (
-          <Button
-            variant="primary"
-            disabled={!!user && (!isForecastDirty || isSubmitting)}
-            onClick={handlePredictSubmit}
-          >
-            {user ? t("predict") : t("signUpToPredict")}
-          </Button>
+          <>
+            {" "}
+            <Button
+              variant="primary"
+              disabled={!!user && (!isForecastDirty || isSubmitting)}
+              onClick={handlePredictSubmit}
+            >
+              {user ? t("predict") : t("signUpToPredict")}
+            </Button>
+            <div className="h-[32px] w-full">
+              {isSubmitting && <LoadingIndicator />}
+            </div>
+          </>
         )}
         {canResolve && (
           <QuestionResolutionButton
             question={question}
             permission={permission}
-            className="mt-4"
           />
         )}
       </div>

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
@@ -22,6 +22,7 @@ import ContinuousSlider from "../continuous_slider";
 import NumericForecastTable from "../numeric_table";
 import QuestionResolutionButton from "../resolution";
 import LoadingIndicator from "@/components/ui/loading_indicator";
+import { useServerAction } from "@/hooks/use_server_action";
 
 type Props = {
   postId: number;
@@ -44,11 +45,7 @@ const ForecastMakerContinuous: FC<Props> = ({
 }) => {
   const { user } = useAuth();
   const { setCurrentModal } = useModal();
-
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
-
-  const submitIsAllowed = !isSubmitting && isDirty;
 
   const prevForecastValue = extractPrevNumericForecastValue(prevForecast);
   const t = useTranslations();
@@ -93,7 +90,6 @@ const ForecastMakerContinuous: FC<Props> = ({
   };
 
   const handlePredictSubmit = async () => {
-    setIsSubmitting(true);
     const response = await createForecasts(postId, [
       {
         questionId: question.id,
@@ -113,11 +109,9 @@ const ForecastMakerContinuous: FC<Props> = ({
     }
 
     setIsDirty(false);
-    setTimeout(() => {
-      setIsSubmitting(false);
-    }, 1500);
   };
-
+  const [submit, isPending] = useServerAction(handlePredictSubmit);
+  const submitIsAllowed = !isPending && isDirty;
   return (
     <>
       <ContinuousSlider
@@ -148,7 +142,7 @@ const ForecastMakerContinuous: FC<Props> = ({
                 <Button
                   variant="primary"
                   type="submit"
-                  onClick={handlePredictSubmit}
+                  onClick={submit}
                   disabled={!submitIsAllowed}
                 >
                   {t("saveChange")}
@@ -164,7 +158,7 @@ const ForecastMakerContinuous: FC<Props> = ({
               </Button>
             )}
           </div>
-          <div className="h-[32px]">{isSubmitting && <LoadingIndicator />}</div>
+          <div className="h-[32px]">{isPending && <LoadingIndicator />}</div>
         </>
       )}
       {predictionMessage && (

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
@@ -21,6 +21,7 @@ import { computeQuartilesFromCDF } from "@/utils/math";
 import ContinuousSlider from "../continuous_slider";
 import NumericForecastTable from "../numeric_table";
 import QuestionResolutionButton from "../resolution";
+import LoadingIndicator from "@/components/ui/loading_indicator";
 
 type Props = {
   postId: number;
@@ -112,7 +113,9 @@ const ForecastMakerContinuous: FC<Props> = ({
     }
 
     setIsDirty(false);
-    setIsSubmitting(false);
+    setTimeout(() => {
+      setIsSubmitting(false);
+    }, 1500);
   };
 
   return (
@@ -131,35 +134,38 @@ const ForecastMakerContinuous: FC<Props> = ({
       />
 
       {canPredict && (
-        <div className="my-5 flex flex-wrap items-center justify-center gap-3 px-4">
-          {user ? (
-            <>
-              <Button
-                variant="secondary"
-                type="reset"
-                onClick={handleAddComponent}
-              >
-                {t("addComponentButton")}
-              </Button>
+        <>
+          <div className="mt-5 flex flex-wrap items-center justify-center gap-3 px-4">
+            {user ? (
+              <>
+                <Button
+                  variant="secondary"
+                  type="reset"
+                  onClick={handleAddComponent}
+                >
+                  {t("addComponentButton")}
+                </Button>
+                <Button
+                  variant="primary"
+                  type="submit"
+                  onClick={handlePredictSubmit}
+                  disabled={!submitIsAllowed}
+                >
+                  {t("saveChange")}
+                </Button>
+              </>
+            ) : (
               <Button
                 variant="primary"
-                type="submit"
-                onClick={handlePredictSubmit}
-                disabled={!submitIsAllowed}
+                type="button"
+                onClick={() => setCurrentModal({ type: "signup" })}
               >
-                {t("saveChange")}
+                {t("signUpToPredict")}
               </Button>
-            </>
-          ) : (
-            <Button
-              variant="primary"
-              type="button"
-              onClick={() => setCurrentModal({ type: "signup" })}
-            >
-              {t("signUpToPredict")}
-            </Button>
-          )}
-        </div>
+            )}
+          </div>
+          <div className="h-[32px]">{isSubmitting && <LoadingIndicator />}</div>
+        </>
       )}
       {predictionMessage && (
         <div className="text-center text-sm italic text-gray-700 dark:text-gray-700-dark">

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_multiple_choice.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_multiple_choice.tsx
@@ -30,6 +30,7 @@ import {
 } from "../binary_slider";
 import ForecastChoiceOption from "../forecast_choice_option";
 import QuestionResolutionButton from "../resolution";
+import LoadingIndicator from "@/components/ui/loading_indicator";
 
 type ChoiceOption = {
   name: string;
@@ -188,7 +189,9 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
     if (response && "errors" in response && !!response.errors) {
       setSubmitError(response.errors[0]);
     }
-    setIsSubmitting(false);
+    setTimeout(() => {
+      setIsSubmitting(false);
+    }, 1500);
   };
 
   return (
@@ -241,7 +244,7 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
         </tbody>
       </table>
 
-      <div className="my-5 flex flex-wrap items-center justify-center gap-4 border-b border-b-blue-400 pb-5 dark:border-b-blue-400-dark">
+      <div className="mt-5 flex flex-wrap items-center justify-center gap-4 border-b border-b-blue-400 pb-5 dark:border-b-blue-400-dark">
         <div className="mx-auto text-center sm:ml-0 sm:text-left">
           <div>
             <span className="text-2xl font-bold">
@@ -284,6 +287,9 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
           </div>
         )}
         <FormErrorMessage errors={submitError} />
+      </div>
+      <div className="h-[32px] w-full">
+        {isSubmitting && <LoadingIndicator />}
       </div>
       <div className="flex flex-col items-center justify-center">
         <QuestionResolutionButton question={question} permission={permission} />

--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -107,7 +107,7 @@ const MultipleChoiceChart: FC<Props> = ({
         questionType,
         scaling,
       }),
-    [timestamps, choiceItems, chartWidth, chartHeight, zoom]
+    [timestamps, choiceItems, chartWidth, chartHeight, zoom, userForecasts]
   );
 
   const isHighlightActive = useMemo(

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -90,7 +90,8 @@ const NumericChart: FC<Props> = ({
     ? merge({}, chartTheme, extraTheme)
     : chartTheme;
 
-  const defaultCursor = Date.now();
+  const defaultCursor = Date.now() / 1000;
+
   const [isCursorActive, setIsCursorActive] = useState(false);
 
   const [zoom, setZoom] = useState(defaultZoom);
@@ -106,7 +107,7 @@ const NumericChart: FC<Props> = ({
         width: chartWidth,
         zoom,
       }),
-    [height, chartWidth, zoom]
+    [height, chartWidth, zoom, aggregations]
   );
 
   const prevWidth = usePrevious(chartWidth);

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -57,7 +57,7 @@ type Props = {
   withZoomPicker?: boolean;
   yLabel?: string;
   height?: number;
-  onCursorChange?: (value: number) => void;
+  onCursorChange?: (value: number | null) => void;
   onChartReady?: () => void;
   questionType: QuestionType;
   actualCloseTime: number | null;
@@ -184,6 +184,10 @@ const NumericChart: FC<Props> = ({
                 onMouseOutCapture: () => {
                   if (!onCursorChange) return;
                   setIsCursorActive(false);
+                },
+                onMouseLeave: () => {
+                  if (!onCursorChange) return;
+                  onCursorChange(null);
                 },
               },
             },

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -107,7 +107,16 @@ const NumericChart: FC<Props> = ({
         width: chartWidth,
         zoom,
       }),
-    [height, chartWidth, zoom, aggregations]
+    [
+      height,
+      chartWidth,
+      zoom,
+      aggregations,
+      actualCloseTime,
+      myForecasts,
+      questionType,
+      scaling,
+    ]
   );
 
   const prevWidth = usePrevious(chartWidth);

--- a/front_end/src/hooks/use_server_action.ts
+++ b/front_end/src/hooks/use_server_action.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect, useTransition, useRef } from 'react';
+
+export const useServerAction = <P extends any[], R>(
+  action: (...args: P) => Promise<R>,
+  onFinished?: (_: R | undefined) => void,
+): [(...args: P) => Promise<R | undefined>, boolean] => {
+  const [isPending, startTransition] = useTransition();
+  const [result, setResult] = useState<R>();
+  const [finished, setFinished] = useState(false);
+  const resolver = useRef<(value?: R | PromiseLike<R>) => void>();
+
+  useEffect(() => {
+    if (!finished) return;
+
+    if (onFinished) onFinished(result);
+    resolver.current?.(result);
+  }, [result, finished]);
+
+  const runAction = async (...args: P): Promise<R | undefined> => {
+    startTransition(() => {
+      action(...args).then((data) => {
+        setResult(data);
+        setFinished(true);
+      });
+    });
+
+    return new Promise((resolve) => {
+      resolver.current = resolve;
+    });
+  };
+
+  return [runAction, isPending];
+};

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -282,7 +282,6 @@ export function getDisplayUserValue(
   let rMin: number | null;
   let rMax: number | null;
   let zPoint: number | null;
-
   let closestUserForecastIndex = -1;
   myForecasts?.history.forEach((forecast, index) => {
     if (forecast.start_time <= valueTimestamp) {

--- a/front_end/src/utils/questions.ts
+++ b/front_end/src/utils/questions.ts
@@ -231,7 +231,7 @@ export const generateUserForecastsForMultipleQuestion = (
         userForecasts?.map((forecast) => forecast.forecast_values[index]) ?? [],
       timestamps: userForecasts?.map((forecast) => forecast.start_time) ?? [],
       color:
-        MULTIPLE_CHOICE_COLOR_SCALE[choiceOrdering[index]] ??
+        MULTIPLE_CHOICE_COLOR_SCALE[choiceOrdering.indexOf(index)] ??
         METAC_COLORS.gray["400"],
     };
   });


### PR DESCRIPTION
- Fixed bug with default cursor for continuous charts
- Added workaround to display newly made user forecast under the chart
- Added loading indicator for forecast makers
- Implemented useServerAction hook to display loading prediction state properly
- Fixed color mismatch for multiple choice lines and user predictions