### PR TITLE
Reflect new prediction in CP and graph on save

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
@@ -150,6 +150,7 @@ export default async function IndividualQuestion({
             )}
             {!!postData.group_of_questions && (
               <DetailedGroupCard
+                actualCloseTime={postData.actual_close_time}
                 questions={postData.group_of_questions.questions}
                 preselectedQuestionId={preselectedGroupQuestionId}
                 isClosed={isClosed}

--- a/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
@@ -62,12 +62,14 @@ type Props = {
   questions: QuestionWithNumericForecasts[];
   timestamps: number[];
   isClosed?: boolean;
+  actualCloseTime: number | null;
 };
 
 const ContinuousGroupTimeline: FC<Props> = ({
   questions,
   timestamps,
   isClosed,
+  actualCloseTime,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -180,6 +182,7 @@ const ContinuousGroupTimeline: FC<Props> = ({
       </div>
       <div ref={refs.setReference} {...getReferenceProps()}>
         <MultipleChoiceChart
+          actualCloseTime={actualCloseTime}
           timestamps={timestamps}
           choiceItems={choiceItems}
           yLabel={t("communityPredictionLabel")}

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/index.tsx
@@ -18,6 +18,7 @@ type Props = {
   graphType: string;
   preselectedQuestionId?: number;
   isClosed?: boolean;
+  actualCloseTime: string | null;
 };
 
 const DetailedGroupCard: FC<Props> = ({
@@ -25,6 +26,7 @@ const DetailedGroupCard: FC<Props> = ({
   preselectedQuestionId,
   isClosed,
   graphType,
+  actualCloseTime,
 }) => {
   const groupType = questions.at(0)?.type;
 
@@ -42,6 +44,9 @@ const DetailedGroupCard: FC<Props> = ({
         case QuestionType.Binary: {
           return (
             <BinaryGroupChart
+              actualCloseTime={
+                actualCloseTime ? new Date(actualCloseTime).getTime() : null
+              }
               questions={sortedQuestions}
               timestamps={timestamps}
               preselectedQuestionId={preselectedQuestionId}
@@ -53,6 +58,9 @@ const DetailedGroupCard: FC<Props> = ({
         case QuestionType.Date:
           return (
             <ContinuousGroupTimeline
+              actualCloseTime={
+                actualCloseTime ? new Date(actualCloseTime).getTime() : null
+              }
               questions={sortedQuestions}
               timestamps={timestamps}
               isClosed={isClosed}

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
@@ -48,15 +48,30 @@ const MultipleChoiceChartCard: FC<Props> = ({
   const [choiceItems, setChoiceItems] = useState<ChoiceItem[]>(
     generateList(question)
   );
-  const userForecasts = generateUserForecastsForMultipleQuestion(question);
+  const userForecasts = user
+    ? generateUserForecastsForMultipleQuestion(question)
+    : undefined;
   const timestampsCount = timestamps.length;
   const prevTimestampsCount = usePrevious(timestampsCount);
+
+
+  const userTimestampsCount = question.my_forecasts?.history.length;
+  const prevUserTimestampsCount = usePrevious(userTimestampsCount);
   // sync BE driven data with local state
   useEffect(() => {
-    if (prevTimestampsCount && prevTimestampsCount !== timestampsCount) {
+    if (
+      (prevTimestampsCount && prevTimestampsCount !== timestampsCount) ||
+      (userTimestampsCount && userTimestampsCount !== prevUserTimestampsCount)
+    ) {
       setChoiceItems(generateList(question));
     }
-  }, [prevTimestampsCount, question, timestampsCount]);
+  }, [
+    prevTimestampsCount,
+    question,
+    timestampsCount,
+    userTimestampsCount,
+    prevUserTimestampsCount,
+  ]);
 
   const [cursorTimestamp, tooltipDate, handleCursorChange] =
     useTimestampCursor(timestamps);
@@ -159,6 +174,11 @@ const MultipleChoiceChartCard: FC<Props> = ({
       )}
       <div ref={refs.setReference} {...getReferenceProps()}>
         <MultipleChoiceChart
+          actualCloseTime={
+            question.actual_close_time
+              ? new Date(question.actual_close_time).getTime()
+              : null
+          }
           timestamps={timestamps}
           choiceItems={choiceItems}
           yLabel={t("communityPredictionLabel")}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_timeline_drawer.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_timeline_drawer.tsx
@@ -38,6 +38,11 @@ const ForecastTimelineDrawer: FC<Props> = ({ post, preselectedQuestionId }) => {
     case QuestionType.Binary: {
       return (
         <BinaryGroupChart
+          actualCloseTime={
+            post.actual_close_time
+              ? new Date(post.actual_close_time).getTime()
+              : null
+          }
           questions={sortedQuestions}
           timestamps={timestamps}
           preselectedQuestionId={preselectedQuestionId}
@@ -49,6 +54,11 @@ const ForecastTimelineDrawer: FC<Props> = ({ post, preselectedQuestionId }) => {
     case QuestionType.Date:
       return (
         <ContinuousGroupTimeline
+         actualCloseTime={
+            post.actual_close_time
+              ? new Date(post.actual_close_time).getTime()
+              : null
+          }
           questions={sortedQuestions}
           timestamps={timestamps}
           isClosed={isClosed}

--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -50,6 +50,7 @@ import { QuestionType, Scaling } from "@/types/question";
 
 type Props = {
   timestamps: number[];
+  actualCloseTime?: number | null;
   choiceItems: ChoiceItem[];
   defaultZoom?: TimelineChartZoomOption;
   withZoomPicker?: boolean;
@@ -66,6 +67,7 @@ type Props = {
 
 const MultipleChoiceChart: FC<Props> = ({
   timestamps,
+  actualCloseTime,
   choiceItems,
   defaultZoom = TimelineChartZoomOption.All,
   withZoomPicker = false,
@@ -106,8 +108,16 @@ const MultipleChoiceChart: FC<Props> = ({
         zoom,
         questionType,
         scaling,
+        actualCloseTime,
       }),
-    [timestamps, choiceItems, chartWidth, chartHeight, zoom, userForecasts]
+    [
+      timestamps,
+      choiceItems,
+      chartWidth,
+      chartHeight,
+      zoom,
+      userForecasts,
+    ]
   );
 
   const isHighlightActive = useMemo(
@@ -315,11 +325,13 @@ function buildChartData({
   width,
   choiceItems,
   timestamps,
+  actualCloseTime,
   zoom,
   questionType,
   scaling,
 }: {
   timestamps: number[];
+  actualCloseTime?: number | null;
   choiceItems: ChoiceItem[];
   width: number;
   height: number;
@@ -327,7 +339,10 @@ function buildChartData({
   questionType?: QuestionType;
   scaling?: Scaling;
 }): ChartData {
-  const xDomain = generateNumericDomain(timestamps, zoom);
+  const latestTimestamp = actualCloseTime
+    ? Math.min(actualCloseTime / 1000, Date.now() / 1000)
+    : Date.now() / 1000;
+  const xDomain = generateNumericDomain([...timestamps, latestTimestamp], zoom);
 
   const graphs: ChoiceGraph[] = choiceItems.map(
     ({


### PR DESCRIPTION
- adjusted sync of client and BE data for group and multiple choice questions
- fixed xDomain (timestamps) for this graphs