### PR TITLE
Child question group links backward compatibility

### DIFF
--- a/front_end/src/app/(main)/experiments/elections/components/state_by_forecast/elections_map/state_hover_card.tsx
+++ b/front_end/src/app/(main)/experiments/elections/components/state_by_forecast/elections_map/state_hover_card.tsx
@@ -118,7 +118,7 @@ const StateHoverCard: FC<Props> = ({
         {mapArea.link && (
           <div className="flex w-full flex-col items-start">
             <Link
-              className="text-left text-blue-800 hover:text-blue-900 dark:text-blue-800-dark dark:hover:text-blue-900-dark"
+              className="text-left capitalize text-blue-800 hover:text-blue-900 dark:text-blue-800-dark dark:hover:text-blue-900-dark"
               href={`/questions/${mapArea.link.groupId}?${SLUG_POST_SUB_QUESTION_ID}=${mapArea.link.questionId}`}
             >
               {t("partyWinProbability", { party: favouritePartyName })}

--- a/front_end/src/app/(main)/experiments/elections/components/state_by_forecast/index.tsx
+++ b/front_end/src/app/(main)/experiments/elections/components/state_by_forecast/index.tsx
@@ -6,6 +6,7 @@ import { getTranslations } from "next-intl/server";
 import { FC } from "react";
 
 import ElectionsEmbedModal from "@/app/(main)/experiments/elections/components/elections_embed_modal";
+import WithServerComponentErrorBoundary from "@/components/server_component_error_boundary";
 import Button from "@/components/ui/button";
 import PostsApi from "@/services/posts";
 import { StateByForecastItem } from "@/types/experiments";
@@ -17,7 +18,6 @@ import { extractQuestionGroupName } from "@/utils/questions";
 import MiddleVotesArrow from "./middle_votes_arrow";
 import StateByForecastCharts from "./state_by_forecast_charts";
 import { US_MAP_AREAS } from "./us_areas";
-import WithServerComponentErrorBoundary from "@/components/server_component_error_boundary";
 
 type Props = {
   questionGroupId: number;

--- a/misc/jobs.py
+++ b/misc/jobs.py
@@ -2,7 +2,11 @@ import logging
 import time
 
 from misc.models import ITNArticle
-from misc.services.itn import update_article_embedding_vector, sync_itn_news
+from misc.services.itn import (
+    update_article_embedding_vector,
+    sync_itn_news,
+    clear_old_itn_news,
+)
 from utils.management import parallel_command_executor
 
 logger = logging.getLogger(__name__)
@@ -23,6 +27,9 @@ def generate_embedding_vectors__worker(ids, worker_idx):
 def sync_itn_articles(num_processes: int = 1):
     # Sync fresh ITN news
     sync_itn_news()
+
+    # Remove old articles
+    clear_old_itn_news()
 
     # Generate embedding vectors
     article_ids = list(

--- a/misc/services/itn.py
+++ b/misc/services/itn.py
@@ -62,6 +62,12 @@ def itn_db():
                     yield cursor
 
 
+def clear_old_itn_news():
+    min_date = timezone.now() - timedelta(days=10)
+
+    ITNArticle.objects.filter(created_at__lt=min_date).delete()
+
+
 def sync_itn_news():
     articles_count = ITNArticle.objects.count()
     last_fetch_date = ITNArticle.objects.order_by("-created_at").values_list(

--- a/posts/views.py
+++ b/posts/views.py
@@ -173,11 +173,16 @@ def post_detail_oldapi_view(request: Request, pk):
 def post_detail(request: Request, pk):
     user = request.user if request.user.is_authenticated else None
 
+    # Extra params
+    with_cp = serializers.BooleanField(allow_null=True).run_validation(
+        request.query_params.get("with_cp", True)
+    )
+
     qs = Post.objects.filter_permission(user=user).filter(pk=pk)
     posts = serialize_post_many(
         qs,
         current_user=request.user,
-        with_cp=True,
+        with_cp=with_cp,
         with_subscriptions=True,
     )
 

--- a/questions/urls.py
+++ b/questions/urls.py
@@ -16,16 +16,16 @@ urlpatterns = [
         views.unresolve_api_view,
         name="question-unresolve",
     ),
+    path(
+        "questions/<int:pk>/post/",
+        views.legacy_question_api_view,
+        name="oldapi-get-question-post",
+    ),
 ]
 old_api = [
     path(
         "questions/<int:pk>/predict/",
         views.create_binary_forecast_oldapi_view,
         name="oldapi-create-forecast",
-    ),
-    path(
-        "questions/<int:pk>/post/",
-        views.legacy_question_api_view,
-        name="oldapi-get-question-post",
     ),
 ]

--- a/questions/urls.py
+++ b/questions/urls.py
@@ -22,5 +22,10 @@ old_api = [
         "questions/<int:pk>/predict/",
         views.create_binary_forecast_oldapi_view,
         name="oldapi-create-forecast",
-    )
+    ),
+    path(
+        "questions/<int:pk>/post/",
+        views.legacy_question_api_view,
+        name="oldapi-get-question-post",
+    ),
 ]


### PR DESCRIPTION
A backward compatibility workaround. Initially, all group question links were generated as `/questions/<child_question_id>`, which redirected to `/questions/<post_id>/?sub-question=<child_question_id>`. Now that posts and questions are differentiated, these redirects are no longer supported.

This workaround tracks the last known legacy question ID. If a 404 lookup contains an ID lower than the last legacy question ID, we assume it may refer to a child question in a group. If so, we attempt to replace its ID with the original post_id when possible.

This works because our post ids were migrated from question ids and these 2 models do not have ids collision upon the release date, that's why we need `LAST_LEGACY_QUESTION_ID`

closes #662