### PR TITLE
FE SocketError: other side closed

### DIFF
--- a/front_end/src/utils/fetch.ts
+++ b/front_end/src/utils/fetch.ts
@@ -127,7 +127,10 @@ const appFetch = async <T>(
 
   try {
     const response = await fetch(finalUrl, finalOptions);
-    return await handleResponse<T>(response);
+    // consume response in order to fix SocketError: other side is closed
+    // https://stackoverflow.com/questions/76931498/typeerror-terminated-cause-socketerror-other-side-closed-in-fetch-nodejs
+    const clonedRes = response.clone();
+    return await handleResponse<T>(clonedRes);
   } catch (error) {
     console.error("Fetch error:", error);
     throw error;


### PR DESCRIPTION
- utilized response in order to fix SocketError: other side is closed
- another possible solution is to modify keep alive timeout by running next start --keepAliveTimeout 61000
- point to check - disable keepAlive at all and test app on dev server