### PR TITLE
Anonymise embedding questions

### DIFF
--- a/front_end/src/app/(embed)/questions/embed/[id]/page.tsx
+++ b/front_end/src/app/(embed)/questions/embed/[id]/page.tsx
@@ -20,7 +20,7 @@ export default async function GenerateQuestionPreview({
   searchParams: SearchParams;
 }) {
   const t = await getTranslations();
-  const post = await PostsApi.getPost(params.id);
+  const post = await PostsApi.getPostAnonymous(params.id);
   if (!post) {
     return null;
   }

--- a/front_end/src/app/(main)/experiments/elections/components/state_by_forecast/index.tsx
+++ b/front_end/src/app/(main)/experiments/elections/components/state_by_forecast/index.tsx
@@ -33,7 +33,7 @@ const StateByForecast: FC<Props> = async ({
   isEmbed,
 }) => {
   const t = await getTranslations();
-  const post = await PostsApi.getPost(questionGroupId);
+  const post = await PostsApi.getPostAnonymous(questionGroupId);
   if (!post?.group_of_questions) {
     return null;
   }
@@ -42,8 +42,8 @@ const StateByForecast: FC<Props> = async ({
   let republicanPrediction = null;
   if (democratPostId && republicanPostId) {
     const [demPost, repPost] = await Promise.all([
-      PostsApi.getPost(democratPostId),
-      PostsApi.getPost(republicanPostId),
+      PostsApi.getPostAnonymous(democratPostId),
+      PostsApi.getPostAnonymous(republicanPostId),
     ]);
     const predictions = getDemocratRepublicanPrediction({ demPost, repPost });
     if (predictions) {

--- a/front_end/src/services/posts.ts
+++ b/front_end/src/services/posts.ts
@@ -49,6 +49,14 @@ class PostsApi {
     );
   }
 
+  static async getPostAnonymous(id: number): Promise<PostWithForecasts> {
+    return await get<PostWithForecasts>(
+      `/posts/${id}/`,
+      {},
+      { passAuthHeader: false }
+    );
+  }
+
   static async removePostFromProject(postId: number, projectId: number) {
     await post<any>(`/posts/${postId}/remove_from_project/`, {
       project_id: projectId,

--- a/front_end/src/types/fetch.ts
+++ b/front_end/src/types/fetch.ts
@@ -1,5 +1,6 @@
 export type FetchOptions = RequestInit & {
   headers?: HeadersInit;
+  passToken?: boolean;
 };
 
 /**

--- a/front_end/src/utils/fetch.ts
+++ b/front_end/src/utils/fetch.ts
@@ -84,15 +84,16 @@ const defaultOptions: FetchOptions = {
 
 type FetchConfig = {
   emptyContentType?: boolean;
+  passAuthHeader?: boolean;
 };
 const appFetch = async <T>(
   url: string,
   options: FetchOptions = {},
   config?: FetchConfig
 ): Promise<T> => {
-  const { emptyContentType = false } = config ?? {};
+  const { emptyContentType = false, passAuthHeader = true } = config ?? {};
 
-  const authToken = getServerSession();
+  const authToken = passAuthHeader ? getServerSession() : null;
   const alphaToken = getAlphaTokenSession();
 
   // Default values are configured in the next.config.mjs
@@ -137,8 +138,12 @@ const appFetch = async <T>(
   }
 };
 
-const get = async <T>(url: string, options: FetchOptions = {}): Promise<T> => {
-  return appFetch<T>(url, { ...options, method: "GET" });
+const get = async <T>(
+  url: string,
+  options: FetchOptions = {},
+  config?: FetchConfig
+): Promise<T> => {
+  return appFetch<T>(url, { ...options, method: "GET" }, config);
 };
 
 const post = async <T, B = Record<string, any>>(


### PR DESCRIPTION
Initially, we were rendering embedding window with user session awareness. So it might be cached by cdn and other users could see cached personalized version of the given question with forecasts in it