### PR TITLE
Nexjs fetch caching

### DIFF
--- a/front_end/src/services/auth.ts
+++ b/front_end/src/services/auth.ts
@@ -12,7 +12,12 @@ class AuthApi {
   ): Promise<SocialProvider[]> {
     try {
       return await get<SocialProvider[]>(
-        `/auth/social?redirect_uri=${redirect_uri}`
+        `/auth/social?redirect_uri=${redirect_uri}`,
+        {
+          next: {
+            revalidate: 3600,
+          },
+        }
       );
     } catch (err) {
       console.error("Error getting social providers:", err);

--- a/front_end/src/services/posts.ts
+++ b/front_end/src/services/posts.ts
@@ -94,7 +94,11 @@ class PostsApi {
   static async getPostsForHomepage(): Promise<
     (PostWithForecasts | PostWithNotebook)[]
   > {
-    return await get(`/posts/homepage/`);
+    return await get(`/posts/homepage/`, {
+      next: {
+        revalidate: 900,
+      },
+    });
   }
 
   static async createQuestionPost(body: any): Promise<PostWithForecasts> {

--- a/front_end/src/services/projects.ts
+++ b/front_end/src/services/projects.ts
@@ -1,4 +1,4 @@
-import { PostSubscription, ProjectPermissions } from "@/types/post";
+import { ProjectPermissions } from "@/types/post";
 import {
   Category,
   Tag,
@@ -23,7 +23,9 @@ export type TournamentFilterParams = {
 
 class ProjectsApi {
   static async getTopics(): Promise<Topic[]> {
-    return await get<Topic[]>("/projects/topics");
+    return await get<Topic[]>("/projects/topics", {
+      next: { revalidate: 3600 },
+    });
   }
 
   static async getCategories(): Promise<Category[]> {
@@ -37,7 +39,9 @@ class ProjectsApi {
   }
 
   static async getSiteMain(): Promise<Tournament> {
-    return await get<Tournament>("/projects/site_main");
+    return await get<Tournament>("/projects/site_main", {
+      next: { revalidate: 3600 },
+    });
   }
 
   static async getTournaments(

--- a/front_end/src/types/fetch.ts
+++ b/front_end/src/types/fetch.ts
@@ -1,6 +1,5 @@
 export type FetchOptions = RequestInit & {
   headers?: HeadersInit;
-  passToken?: boolean;
 };
 
 /**

--- a/front_end/src/utils/fetch.ts
+++ b/front_end/src/utils/fetch.ts
@@ -95,7 +95,7 @@ const appFetch = async <T>(
 
   // Warning: caching could be only applied to anonymised requests
   // To prevent user token leaks and storage spam.
-  // NextJS cache every request variant including headers (auth token) diff
+  // NextJS caches every request variant including headers (auth token) diff
   if (options.next?.revalidate !== undefined) {
     passAuthHeader = false;
   }

--- a/front_end/src/utils/fetch.ts
+++ b/front_end/src/utils/fetch.ts
@@ -91,7 +91,14 @@ const appFetch = async <T>(
   options: FetchOptions = {},
   config?: FetchConfig
 ): Promise<T> => {
-  const { emptyContentType = false, passAuthHeader = true } = config ?? {};
+  let { emptyContentType = false, passAuthHeader = true } = config ?? {};
+
+  // Warning: caching could be only applied to anonymised requests
+  // To prevent user token leaks and storage spam.
+  // NextJS cache every request variant including headers (auth token) diff
+  if (options.next?.revalidate !== undefined) {
+    passAuthHeader = false;
+  }
 
   const authToken = passAuthHeader ? getServerSession() : null;
   const alphaToken = getAlphaTokenSession();


### PR DESCRIPTION
- Added caching to some popular fetch endpoints
- Fixed middleware: now we ignore `prefetch` requests in prod mode and significantly reduce amount of BE requests (token check endpoint)
- Fetch service fixes: next invalidate support 
- Significantly reduced amount of requests to the backend