### PR TITLE
Pending and non-news notebooks shouldn't appear in news

### DIFF
--- a/front_end/src/app/(main)/news/helpers/filters.ts
+++ b/front_end/src/app/(main)/news/helpers/filters.ts
@@ -27,6 +27,7 @@ export function generateFiltersFromSearchParams(
 ): PostsParams {
   const filters: PostsParams = {
     forecast_type: NotebookType.Notebook,
+    notebook_type: "news",
   };
 
   if (typeof searchParams[POST_TEXT_SEARCH_FILTER] === "string") {


### PR DESCRIPTION
* applied `notebook_type` filtering on the news page