### PR TITLE
zero_point of 0 is still log scaling

### DIFF
--- a/utils/the_math/formulas.py
+++ b/utils/the_math/formulas.py
@@ -74,7 +74,7 @@ def unscaled_location_to_scaled_location(
         question.range_max,
         question.range_min,
     )
-    if zero_point:
+    if zero_point is not None:
         deriv_ratio = (range_max - zero_point) / max(
             (range_min - zero_point), 0.0000001
         )
@@ -96,7 +96,7 @@ def scaled_location_to_unscaled_location(
         question.range_max,
         question.range_min,
     )
-    if zero_point:
+    if zero_point is not None:
         deriv_ratio = (range_max - zero_point) / max(
             (range_min - zero_point), 0.0000001
         )


### PR DESCRIPTION
Must run:
```
questions = Question.objects.filter(
    zero_point=0, resolution_set_time__isnull=False
).exclude(
    resolution__in=["ambiguous", "annulled", "below_lower_bound", "above_upper_bound"]
)
for question in questions:
    resolution = float(question.resolution)
    zero_point, range_max, range_min = (
        question.zero_point,
        question.range_max,
        question.range_min,
    )
    deriv_ratio = (range_max - zero_point) / max((range_min - zero_point), 0.0000001)
    unscaled_location = (resolution - range_min) / (range_max - range_min)
    scaled_resolution = range_min + (range_max - range_min) * (
        deriv_ratio**unscaled_location - 1
    ) / (deriv_ratio - 1)
    question.resolution = str(scaled_resolution)
    question.save()
```
manually to fix incorrectly stored resolutions