### PR TITLE
Don't show "Forecast data is empty" on upcoming questions

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
@@ -191,6 +191,7 @@ export default async function IndividualQuestion({
 
             {!!postData.question && (
               <DetailedQuestionCard
+                postStatus={postData.status}
                 question={postData.question}
                 nrForecasters={postData.nr_forecasters}
               />
@@ -205,6 +206,7 @@ export default async function IndividualQuestion({
                 isClosed={isClosed}
                 graphType={postData.group_of_questions.graph_type}
                 nrForecasters={postData.nr_forecasters}
+                postStatus={postData.status}
               />
             )}
 

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/index.tsx
@@ -7,6 +7,7 @@ import Button from "@/app/(main)/about/components/Button";
 import NumericGroupChart from "@/app/(main)/questions/[id]/components/detailed_group_card/numeric_group_chart";
 import { useAuth } from "@/contexts/auth_context";
 import { GroupOfQuestionsGraphType } from "@/types/charts";
+import { PostStatus } from "@/types/post";
 import {
   QuestionType,
   QuestionWithForecasts,
@@ -25,6 +26,7 @@ type Props = {
   preselectedQuestionId?: number;
   isClosed?: boolean;
   actualCloseTime: string | null;
+  postStatus: PostStatus;
 };
 
 const DetailedGroupCard: FC<Props> = ({
@@ -34,6 +36,7 @@ const DetailedGroupCard: FC<Props> = ({
   graphType,
   nrForecasters,
   actualCloseTime,
+  postStatus,
 }) => {
   const t = useTranslations();
   const groupType = questions.at(0)?.type;
@@ -65,6 +68,9 @@ const DetailedGroupCard: FC<Props> = ({
   });
 
   if (isForecastEmpty) {
+    if (postStatus !== PostStatus.OPEN) {
+      return null;
+    }
     return (
       <>
         {nrForecasters > 0 ? (

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/index.tsx
@@ -4,6 +4,7 @@ import React, { FC, useState } from "react";
 
 import Button from "@/app/(main)/about/components/Button";
 import { useAuth } from "@/contexts/auth_context";
+import { PostStatus, PostWithForecasts } from "@/types/post";
 import { QuestionType, QuestionWithForecasts } from "@/types/question";
 
 import DetailsQuestionCardErrorBoundary from "./error_boundary";
@@ -11,11 +12,16 @@ import MultipleChoiceChartCard from "./multiple_choice_chart_card";
 import NumericChartCard from "./numeric_chart_card";
 
 type Props = {
+  postStatus: PostStatus;
   question: QuestionWithForecasts;
   nrForecasters: number;
 };
 
-const DetailedQuestionCard: FC<Props> = ({ question, nrForecasters }) => {
+const DetailedQuestionCard: FC<Props> = ({
+  postStatus,
+  question,
+  nrForecasters,
+}) => {
   const isForecastEmpty =
     question.aggregations.recency_weighted.history.length === 0;
   const { user } = useAuth();
@@ -23,7 +29,11 @@ const DetailedQuestionCard: FC<Props> = ({ question, nrForecasters }) => {
     user && user.hide_community_prediction
   );
   const t = useTranslations();
+
   if (isForecastEmpty) {
+    if (postStatus !== PostStatus.OPEN) {
+      return null;
+    }
     return (
       <>
         {nrForecasters > 0 ? (

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
@@ -11,7 +11,10 @@ import { useAuth } from "@/contexts/auth_context";
 import { useModal } from "@/contexts/modal_context";
 import { ErrorResponse } from "@/types/fetch";
 import { PostConditional } from "@/types/post";
-import { QuestionWithNumericForecasts } from "@/types/question";
+import {
+  PredictionInputMessage,
+  QuestionWithNumericForecasts,
+} from "@/types/question";
 import { extractPrevBinaryForecastValue } from "@/utils/forecasts";
 
 import BinarySlider, { BINARY_FORECAST_PRECISION } from "../binary_slider";
@@ -27,6 +30,7 @@ type Props = {
   prevYesForecast?: any;
   prevNoForecast?: any;
   canPredict: boolean;
+  predictionMessage: PredictionInputMessage;
 };
 
 const ForecastMakerConditionalBinary: FC<Props> = ({
@@ -36,6 +40,7 @@ const ForecastMakerConditionalBinary: FC<Props> = ({
   prevYesForecast,
   prevNoForecast,
   canPredict,
+  predictionMessage,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -263,6 +268,11 @@ const ForecastMakerConditionalBinary: FC<Props> = ({
         </div>
       ))}
       <div className="my-5 flex flex-wrap items-center justify-center gap-3 px-4">
+        {predictionMessage && (
+          <div className="mb-2 text-center text-sm italic text-gray-700 dark:text-gray-700-dark">
+            {t(predictionMessage)}
+          </div>
+        )}
         {canPredict &&
           (user ? (
             <>

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_continuous.tsx
@@ -11,7 +11,11 @@ import { useAuth } from "@/contexts/auth_context";
 import { useModal } from "@/contexts/modal_context";
 import { ErrorResponse } from "@/types/fetch";
 import { PostConditional } from "@/types/post";
-import { Quartiles, QuestionWithNumericForecasts } from "@/types/question";
+import {
+  PredictionInputMessage,
+  Quartiles,
+  QuestionWithNumericForecasts,
+} from "@/types/question";
 import {
   extractPrevNumericForecastValue,
   getNumericForecastDataset,
@@ -32,6 +36,7 @@ type Props = {
   prevYesForecast?: any;
   prevNoForecast?: any;
   canPredict: boolean;
+  predictionMessage: PredictionInputMessage;
 };
 
 const ForecastMakerConditionalContinuous: FC<Props> = ({
@@ -41,6 +46,7 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
   prevYesForecast,
   prevNoForecast,
   canPredict,
+  predictionMessage,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -351,7 +357,11 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
           />
         </div>
       ))}
-
+      {predictionMessage && (
+        <div className="mb-2 text-center text-sm italic text-gray-700 dark:text-gray-700-dark">
+          {t(predictionMessage)}
+        </div>
+      )}
       {canPredict && (
         <div className="my-5 flex flex-wrap items-center justify-center gap-3 px-4">
           {user ? (

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/index.tsx
@@ -3,6 +3,7 @@ import { FC } from "react";
 
 import { PostConditional, PostWithForecasts } from "@/types/post";
 import {
+  PredictionInputMessage,
   QuestionType,
   QuestionWithForecasts,
   QuestionWithNumericForecasts,
@@ -16,12 +17,14 @@ type Props = {
   post: PostWithForecasts;
   conditional: PostConditional<QuestionWithForecasts>;
   canPredict: boolean;
+  predictionMessage: PredictionInputMessage;
 };
 
 const ForecastMakerConditional: FC<Props> = ({
   post,
   conditional,
   canPredict,
+  predictionMessage,
 }) => {
   const t = useTranslations();
 
@@ -72,6 +75,7 @@ const ForecastMakerConditional: FC<Props> = ({
             conditional.condition_child.open_time !== undefined &&
             new Date(conditional.condition_child.open_time) <= new Date()
           }
+          predictionMessage={predictionMessage}
         />
       )}
       {(question_yes.type === QuestionType.Date ||
@@ -90,6 +94,7 @@ const ForecastMakerConditional: FC<Props> = ({
             conditional.condition_child.open_time !== undefined &&
             new Date(conditional.condition_child.open_time) <= new Date()
           }
+          predictionMessage={predictionMessage}
         />
       )}
     </ForecastMakerContainer>

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
@@ -28,7 +28,10 @@ import {
   ProjectPermissions,
   Resolution,
 } from "@/types/post";
-import { QuestionWithNumericForecasts } from "@/types/question";
+import {
+  PredictionInputMessage,
+  QuestionWithNumericForecasts,
+} from "@/types/question";
 import { ThemeColor } from "@/types/theme";
 import { extractPrevBinaryForecastValue } from "@/utils/forecasts";
 import { extractQuestionGroupName } from "@/utils/questions";
@@ -59,6 +62,7 @@ type Props = {
   questions: QuestionWithNumericForecasts[];
   canPredict: boolean;
   canResolve: boolean;
+  predictionMessage: PredictionInputMessage;
 };
 
 const ForecastMakerGroupBinary: FC<Props> = ({
@@ -66,6 +70,7 @@ const ForecastMakerGroupBinary: FC<Props> = ({
   questions,
   canPredict,
   canResolve,
+  predictionMessage,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -245,6 +250,11 @@ const ForecastMakerGroupBinary: FC<Props> = ({
           ))}
         </tbody>
       </table>
+      {predictionMessage && (
+        <div className="mb-2 text-center text-sm italic text-gray-700 dark:text-gray-700-dark">
+          {t(predictionMessage)}
+        </div>
+      )}
       {!!highlightedQuestion?.resolution && (
         <div className="flex flex-row items-center justify-center gap-1.5 truncate py-2 text-gray-900 dark:text-gray-900-dark">
           <PostStatusComponent

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
@@ -15,7 +15,10 @@ import { useAuth } from "@/contexts/auth_context";
 import { useModal } from "@/contexts/modal_context";
 import { ErrorResponse } from "@/types/fetch";
 import { PostWithForecasts, ProjectPermissions } from "@/types/post";
-import { QuestionWithNumericForecasts } from "@/types/question";
+import {
+  PredictionInputMessage,
+  QuestionWithNumericForecasts,
+} from "@/types/question";
 import {
   extractPrevNumericForecastValue,
   getNumericForecastDataset,
@@ -37,6 +40,7 @@ type Props = {
   questions: QuestionWithNumericForecasts[];
   canPredict: boolean;
   canResolve: boolean;
+  predictionMessage: PredictionInputMessage;
 };
 
 const ForecastMakerGroupContinuous: FC<Props> = ({
@@ -44,6 +48,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
   questions,
   canPredict,
   canResolve,
+  predictionMessage,
 }) => {
   const t = useTranslations();
   const locale = useLocale();
@@ -281,6 +286,11 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
           </div>
         );
       })}
+      {predictionMessage && (
+        <div className="mb-2 text-center text-sm italic text-gray-700 dark:text-gray-700-dark">
+          {t(predictionMessage)}
+        </div>
+      )}
       {!!activeGroupOption && !activeGroupOption?.resolution && (
         <div className="my-5 flex flex-wrap items-center justify-center gap-3 px-4">
           {canPredict &&

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/index.tsx
@@ -3,6 +3,7 @@ import { FC } from "react";
 
 import { PostWithForecasts } from "@/types/post";
 import {
+  PredictionInputMessage,
   QuestionType,
   QuestionWithForecasts,
   QuestionWithNumericForecasts,
@@ -20,6 +21,7 @@ type Props = {
   post: PostWithForecasts;
   canPredict: boolean;
   canResolve: boolean;
+  predictionMessage: PredictionInputMessage;
 };
 
 const ForecastMakerGroup: FC<Props> = ({
@@ -29,6 +31,7 @@ const ForecastMakerGroup: FC<Props> = ({
   questions,
   canResolve,
   canPredict,
+  predictionMessage,
 }) => {
   const t = useTranslations();
 
@@ -56,6 +59,7 @@ const ForecastMakerGroup: FC<Props> = ({
           )}
           canResolve={canResolve}
           canPredict={canPredict}
+          predictionMessage={predictionMessage}
         />
       )}
       {(tileType === QuestionType.Date ||
@@ -65,6 +69,7 @@ const ForecastMakerGroup: FC<Props> = ({
           questions={questions as QuestionWithNumericForecasts[]}
           canResolve={canResolve}
           canPredict={canPredict}
+          predictionMessage={predictionMessage}
         />
       )}
     </ForecastMakerContainer>

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
@@ -103,7 +103,7 @@ const ForecastMakerBinary: FC<Props> = ({
         disabled={!canPredict}
       />
       {predictionMessage && (
-        <div className="text-center text-sm italic text-gray-700 dark:text-gray-700-dark">
+        <div className="mb-2 text-center text-sm italic text-gray-700 dark:text-gray-700-dark">
           {t(predictionMessage)}
         </div>
       )}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
@@ -163,7 +163,7 @@ const ForecastMakerContinuous: FC<Props> = ({
         </>
       )}
       {predictionMessage && (
-        <div className="text-center text-sm italic text-gray-700 dark:text-gray-700-dark">
+        <div className="mb-2 text-center text-sm italic text-gray-700 dark:text-gray-700-dark">
           {t(predictionMessage)}
         </div>
       )}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_multiple_choice.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_multiple_choice.tsx
@@ -17,6 +17,7 @@ import { ErrorResponse } from "@/types/fetch";
 import { ProjectPermissions } from "@/types/post";
 import {
   AggregateForecastHistory,
+  PredictionInputMessage,
   Question,
   QuestionWithMultipleChoiceForecasts,
   UserForecastHistory,
@@ -45,6 +46,7 @@ type Props = {
   permission?: ProjectPermissions;
   canPredict: boolean;
   canResolve: boolean;
+  predictionMessage: PredictionInputMessage;
 };
 
 const ForecastMakerMultipleChoice: FC<Props> = ({
@@ -53,6 +55,7 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
   permission,
   canPredict,
   canResolve,
+  predictionMessage,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -242,7 +245,11 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
           ))}
         </tbody>
       </table>
-
+      {predictionMessage && (
+        <div className="my-2 text-center text-sm italic text-gray-700 dark:text-gray-700-dark">
+          {t(predictionMessage)}
+        </div>
+      )}
       <div className="mt-5 flex flex-wrap items-center justify-center gap-4 border-b border-b-blue-400 pb-5 dark:border-b-blue-400-dark">
         <div className="mx-auto text-center sm:ml-0 sm:text-left">
           <div>

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/index.tsx
@@ -94,6 +94,7 @@ const QuestionForecastMaker: FC<Props> = ({
               parseISO(question.open_time) < new Date()
             }
             canResolve={canResolve}
+            predictionMessage={predictionMessage}
           />
           <QuestionResolutionText question={question} />
         </>

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/index.tsx
@@ -47,6 +47,7 @@ const ForecastMaker: FC<Props> = ({ post }) => {
         questions={groupOfQuestions.questions}
         canPredict={canPredict}
         canResolve={canResolve}
+        predictionMessage={predictionMessage}
       />
     );
   }
@@ -57,6 +58,7 @@ const ForecastMaker: FC<Props> = ({ post }) => {
         post={post}
         conditional={conditional}
         canPredict={canPredict}
+        predictionMessage={predictionMessage}
       />
     );
   }

--- a/front_end/src/components/post_card/question_chart_tile/index.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/index.tsx
@@ -39,7 +39,10 @@ const QuestionChartTile: FC<Props> = ({
   }
 
   if (question.aggregations.recency_weighted.history.length === 0) {
-    return <div>{t("forecastDataIsEmpty")}</div>;
+    if (curationStatus === PostStatus.OPEN) {
+      return <div>{t("forecastDataIsEmpty")}</div>;
+    }
+    return null;
   }
 
   const defaultChartZoom: TimelineChartZoomOption = user

--- a/front_end/src/utils/questions.ts
+++ b/front_end/src/utils/questions.ts
@@ -293,6 +293,12 @@ export function getPredictionInputMessage(post: Post) {
     case PostStatus.UPCOMING: {
       return "predictionUpcomingMessage";
     }
+    case PostStatus.APPROVED: {
+      if (Date.parse(post.open_time) > Date.now()) {
+        return "predictionUpcomingMessage";
+      }
+      return null;
+    }
     case PostStatus.REJECTED:
     case PostStatus.PENDING:
     case PostStatus.DRAFT: {


### PR DESCRIPTION
- adjust "empty forecasts" and "upcoming question" messages render
- add predictionMessage to all questions