### PR TITLE
Improve on post forecast trigger execution

### DIFF
--- a/questions/services.py
+++ b/questions/services.py
@@ -663,9 +663,9 @@ def create_forecast_bulk(*, user: User = None, forecasts: list[dict] = None):
         # `run_on_post_forecast` is triggered. To maintain the correct sequence of execution,
         # we need to ensure that `run_on_post_forecast` runs only after all forecasts have been processed.
         #
-        # As a temporary solution, we introduce a 7-second delay before execution
+        # As a temporary solution, we introduce a 10-second delay before execution
         # to ensure all forecasts are processed.
-        run_on_post_forecast.send_with_options(args=(post.id, ), delay=7_000)
+        run_on_post_forecast.send_with_options(args=(post.id, ), delay=10_000)
 
 
 def get_recency_weighted_for_questions(

--- a/questions/services.py
+++ b/questions/services.py
@@ -663,9 +663,9 @@ def create_forecast_bulk(*, user: User = None, forecasts: list[dict] = None):
         # `run_on_post_forecast` is triggered. To maintain the correct sequence of execution,
         # we need to ensure that `run_on_post_forecast` runs only after all forecasts have been processed.
         #
-        # As a temporary solution, we introduce a 10-second delay before execution
+        # As a temporary solution, we introduce a 7-second delay before execution
         # to ensure all forecasts are processed.
-        run_on_post_forecast.send_with_options(args=(post.id, ), delay=10_000)
+        run_on_post_forecast.send_with_options(args=(post.id, ), delay=7_000)
 
 
 def get_recency_weighted_for_questions(

--- a/questions/views.py
+++ b/questions/views.py
@@ -22,7 +22,6 @@ from questions.serializers import (
 from questions.services import (
     resolve_question,
     unresolve_question,
-    create_forecast,
     create_forecast_bulk,
 )
 
@@ -147,7 +146,10 @@ def create_binary_forecast_oldapi_view(request, pk: int):
     )
     serializer_new.is_valid(raise_exception=True)
 
-    create_forecast(question=question, user=request.user, probability_yes=probability)
+    create_forecast_bulk(
+        user=request.user,
+        forecasts=[{"question": question, "probability_yes": probability}],
+    )
 
     return Response({}, status=status.HTTP_201_CREATED)
 


### PR DESCRIPTION
There may be situations where async jobs from `create_forecast` complete after `run_on_post_forecast` is triggered. To maintain the correct sequence of execution, we need to ensure that `run_on_post_forecast` runs only after all forecasts have been processed.

As a temporary solution, we introduce a 10-second delay before execution to ensure all forecasts are processed.