### PR TITLE
deleting a component changes the location of other component weight sliders

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
@@ -103,6 +103,7 @@ const ContinuousSlider: FC<Props> = ({
                         onChange(forecast, newWeights);
                       }}
                       disabled={disabled}
+                      shouldSyncWithDefault
                     />
                   </div>
                   <FontAwesomeIcon


### PR DESCRIPTION
* fixed weight sliders didn’t update after removing a component on the forecast maker