### PR TITLE
Fixed rendering of closed group subquestions

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
@@ -55,6 +55,7 @@ type QuestionOption = {
   isDirty: boolean;
   color: ThemeColor;
   menu: ReactNode;
+  is_open?: boolean;
 };
 
 type Props = {
@@ -241,7 +242,7 @@ const ForecastMakerGroupBinary: FC<Props> = ({
               isDirty={questionOption.isDirty}
               isRowDirty={questionOption.isDirty}
               menu={questionOption.menu}
-              disabled={!canPredict || !!questionOption.resolution}
+              disabled={!canPredict || !questionOption.is_open}
               optionResolution={{
                 resolution: questionOption.resolution,
                 type: "group_question",
@@ -323,6 +324,7 @@ function generateChoiceOptions(
       resolution: question.resolution,
       isDirty: false,
       color: MULTIPLE_CHOICE_COLOR_SCALE[index] ?? METAC_COLORS.gray["400"],
+      is_open: question.is_open,
       menu: (
         <ForecastMakerGroupControls
           question={question}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
@@ -24,7 +24,11 @@ import {
   getNumericForecastDataset,
 } from "@/utils/forecasts";
 import { computeQuartilesFromCDF } from "@/utils/math";
-import { extractQuestionGroupName, formatResolution } from "@/utils/questions";
+import {
+  extractQuestionGroupName,
+  formatResolution,
+  getSubquestionPredictionInputMessage,
+} from "@/utils/questions";
 
 import ForecastMakerGroupControls from "./forecast_maker_group_menu";
 import { SLUG_POST_SUB_QUESTION_ID } from "../../../search_params";
@@ -108,6 +112,13 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
   const isPickerDirty = useMemo(
     () => groupOptions.some((option) => option.isDirty),
     [groupOptions]
+  );
+  const activeGroupOptionPredictionMessage = useMemo(
+    () =>
+      activeGroupOption
+        ? getSubquestionPredictionInputMessage(activeGroupOption)
+        : null,
+    [activeGroupOption]
   );
 
   const handleChange = useCallback(
@@ -281,7 +292,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
               onChange={(forecast, weight) =>
                 handleChange(option.id, forecast, weight)
               }
-              disabled={!canPredict || !!option.resolution}
+              disabled={!canPredict || !option.question.is_open}
             />
           </div>
         );
@@ -291,7 +302,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
           {t(predictionMessage)}
         </div>
       )}
-      {!!activeGroupOption && !activeGroupOption?.resolution && (
+      {!!activeGroupOption && activeGroupOption.question.is_open && (
         <div className="my-5 flex flex-wrap items-center justify-center gap-3 px-4">
           {canPredict &&
             (user ? (
@@ -329,6 +340,11 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
                 {t("signUpToPredict")}
               </Button>
             ))}
+        </div>
+      )}
+      {activeGroupOptionPredictionMessage && (
+        <div className="mb-2 text-center text-sm italic text-gray-700 dark:text-gray-700-dark">
+          {t(activeGroupOptionPredictionMessage)}
         </div>
       )}
       {!!activeGroupOption && (

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/group_forecast_table.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/group_forecast_table.tsx
@@ -55,8 +55,8 @@ const GroupForecastTable: FC<Props> = ({
 
   const { resolvedOptions, pendingOptions } = useMemo(
     () => ({
-      resolvedOptions: options.filter((option) => option.resolution !== null),
-      pendingOptions: options.filter((option) => option.resolution === null),
+      resolvedOptions: options.filter((option) => !option.question.is_open),
+      pendingOptions: options.filter((option) => option.question.is_open),
     }),
     [options]
   );

--- a/front_end/src/types/question.ts
+++ b/front_end/src/types/question.ts
@@ -197,6 +197,8 @@ export type Question = {
   display_divergences?: number[][];
   aggregations: Aggregations;
   my_forecasts?: UserForecastHistory;
+  // Used for GroupOfQuestions
+  is_open?: boolean;
 };
 
 export type QuestionWithNumericForecasts = Question & {

--- a/front_end/src/utils/questions.ts
+++ b/front_end/src/utils/questions.ts
@@ -4,6 +4,7 @@ import { capitalize, isNil } from "lodash";
 import { remark } from "remark";
 import strip from "strip-markdown";
 
+import { ConditionalTableOption } from "@/app/(main)/questions/[id]/components/forecast_maker/group_forecast_table";
 import { METAC_COLORS, MULTIPLE_CHOICE_COLOR_SCALE } from "@/constants/colors";
 import { UserChoiceItem } from "@/types/choices";
 import {
@@ -136,11 +137,11 @@ export function formatResolution(
   questionType: QuestionType,
   locale: string
 ) {
-  resolution = String(resolution);
-
-  if (resolution === "null" || resolution === "undefined") {
-    return "Annulled";
+  if (resolution === null || resolution === undefined) {
+    return "-";
   }
+
+  resolution = String(resolution);
 
   if (["yes", "no"].includes(resolution)) {
     return capitalize(resolution);
@@ -342,6 +343,16 @@ export function getPredictionInputMessage(post: Post) {
     default:
       return null;
   }
+}
+
+export function getSubquestionPredictionInputMessage(
+  option: ConditionalTableOption
+) {
+  if (!option.question.is_open && !isResolved(option.resolution)) {
+    return "predictionClosedMessage";
+  }
+
+  return null;
 }
 
 export function parseQuestionId(questionUrlOrId: string) {

--- a/questions/models.py
+++ b/questions/models.py
@@ -134,6 +134,24 @@ class Question(TimeStampedModel):
         if len(posts) > 1:
             raise ValueError(f"Question {self.id} has more than one post: {posts}")
 
+    @property
+    def is_open(self) -> bool:
+        """
+        Indicates whether question is open for new forecasts.
+        """
+
+        now = timezone.now()
+
+        if (
+            (self.open_time and self.open_time <= now)
+            and self.resolution is None
+            and (not self.actual_close_time or self.actual_close_time > now)
+            and (not self.actual_resolve_time or self.actual_resolve_time > now)
+        ):
+            return True
+
+        return False
+
     def get_global_leaderboard_dates(self) -> tuple[datetime, datetime] | None:
         # returns the global leaderboard dates that this question counts for
         from scoring.models import global_leaderboard_dates

--- a/questions/serializers.py
+++ b/questions/serializers.py
@@ -38,6 +38,9 @@ class QuestionSerializer(serializers.ModelSerializer):
             "actual_close_time",
             "type",
             "options",
+            # Used for Group Of Questions to determine
+            # whether question is eligible for forecasting
+            "is_open",
             "possibilities",
             "resolution",
             "resolution_criteria",


### PR DESCRIPTION
Initially, there was a bug where the frontend incorrectly rendered closed but unresolved subquestions, displaying forecasting controls to users, which caused confusion. This PR resolves the issue by handling this intermediate state correctly, ensuring that users no longer see the forecasting controls for such subquestions.

Related: #992