### PR TITLE
Change the information appearing in a question when CP is hidden

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
@@ -17,6 +17,7 @@ import { getPostLink } from "@/utils/navigation";
 import { getQuestionTitle } from "@/utils/questions";
 
 import BackgroundInfo from "../components/background_info";
+import HideCPProvider from "../components/cp_provider";
 import DetailedGroupCard from "../components/detailed_group_card";
 import DetailedQuestionCard from "../components/detailed_question_card";
 import ForecastMaker from "../components/forecast_maker";
@@ -150,107 +151,110 @@ export default async function IndividualQuestion({
   const isClosed = postData.status === PostStatus.CLOSED;
   return (
     <EmbedModalContextProvider>
-      <main className="mx-auto flex w-full max-w-max flex-col scroll-smooth py-4">
-        <div className="hidden gap-3 lg:flex">
-          <span className="bg-blue-400 px-1.5 py-1 text-sm font-bold uppercase text-blue-700 dark:bg-blue-400-dark dark:text-blue-700-dark">
-            {typeLabel}
-          </span>
-          {allowModifications && (
-            <a
-              className="bg-blue-400 px-1.5 py-1 text-sm font-bold uppercase text-blue-700 no-underline dark:bg-blue-400-dark dark:text-blue-700-dark"
-              href={`/questions/create/${edit_type}?post_id=${postData.id}`}
-            >
-              {t("edit")}
-            </a>
-          )}
-        </div>
-        <div className="flex gap-4">
-          <section className="w-[48rem] max-w-full border-transparent bg-gray-0 px-3 text-gray-900 after:mt-6 after:block after:w-full after:content-[''] dark:border-blue-200-dark dark:bg-gray-0-dark dark:text-gray-900-dark xs:px-4 lg:border">
-            <PostHeader post={postData} questionTitle={questionTitle} />
-            {!postData.conditional && (
-              <div className="mt-2 flex justify-between gap-2 xs:gap-4 sm:gap-8 lg:mb-2 lg:mt-4">
-                <h1 className="m-0 text-xl leading-tight sm:text-3xl">
-                  {postData.title}
-                </h1>
-                {postData.resolved && !!postData.question && (
-                  <QuestionResolutionStatus post={postData} />
-                )}
-              </div>
+      <HideCPProvider post={postData}>
+        <main className="mx-auto flex w-full max-w-max flex-col scroll-smooth py-4">
+          <div className="hidden gap-3 lg:flex">
+            <span className="bg-blue-400 px-1.5 py-1 text-sm font-bold uppercase text-blue-700 dark:bg-blue-400-dark dark:text-blue-700-dark">
+              {typeLabel}
+            </span>
+            {allowModifications && (
+              <a
+                className="bg-blue-400 px-1.5 py-1 text-sm font-bold uppercase text-blue-700 no-underline dark:bg-blue-400-dark dark:text-blue-700-dark"
+                href={`/questions/create/${edit_type}?post_id=${postData.id}`}
+              >
+                {t("edit")}
+              </a>
             )}
+          </div>
+          <div className="flex gap-4">
+            <section className="w-[48rem] max-w-full border-transparent bg-gray-0 px-3 text-gray-900 after:mt-6 after:block after:w-full after:content-[''] dark:border-blue-200-dark dark:bg-gray-0-dark dark:text-gray-900-dark xs:px-4 lg:border">
+              <PostHeader post={postData} questionTitle={questionTitle} />
+              {!postData.conditional && (
+                <div className="mt-2 flex justify-between gap-2 xs:gap-4 sm:gap-8 lg:mb-2 lg:mt-4">
+                  <h1 className="m-0 text-xl leading-tight sm:text-3xl">
+                    {postData.title}
+                  </h1>
+                  {postData.resolved && !!postData.question && (
+                    <QuestionResolutionStatus post={postData} />
+                  )}
+                </div>
+              )}
 
-            {!!postData.conditional && (
-              <ConditionalTile
-                postTitle={postData.title}
-                conditional={postData.conditional}
-                curationStatus={postData.status}
-                nrForecasters={postData.nr_forecasters}
-                withNavigation
-              />
-            )}
-            <QuestionHeaderInfo post={postData} />
+              {!!postData.conditional && (
+                <ConditionalTile
+                  postTitle={postData.title}
+                  conditional={postData.conditional}
+                  curationStatus={postData.status}
+                  nrForecasters={postData.nr_forecasters}
+                  withNavigation
+                  withCPRevealBtn
+                />
+              )}
+              <QuestionHeaderInfo post={postData} />
 
-            {!!postData.question && (
-              <DetailedQuestionCard
-                postStatus={postData.status}
-                question={postData.question}
-                nrForecasters={postData.nr_forecasters}
-              />
-            )}
-            {!!postData.group_of_questions && (
-              <DetailedGroupCard
-                actualCloseTime={
-                  postData.actual_close_time ?? postData.scheduled_close_time
-                }
-                questions={postData.group_of_questions.questions}
-                preselectedQuestionId={preselectedGroupQuestionId}
-                isClosed={isClosed}
-                graphType={postData.group_of_questions.graph_type}
-                nrForecasters={postData.nr_forecasters}
-                postStatus={postData.status}
-              />
-            )}
+              {!!postData.question && (
+                <DetailedQuestionCard
+                  postStatus={postData.status}
+                  question={postData.question}
+                  nrForecasters={postData.nr_forecasters}
+                />
+              )}
+              {!!postData.group_of_questions && (
+                <DetailedGroupCard
+                  actualCloseTime={
+                    postData.actual_close_time ?? postData.scheduled_close_time
+                  }
+                  questions={postData.group_of_questions.questions}
+                  preselectedQuestionId={preselectedGroupQuestionId}
+                  isClosed={isClosed}
+                  graphType={postData.group_of_questions.graph_type}
+                  nrForecasters={postData.nr_forecasters}
+                  postStatus={postData.status}
+                />
+              )}
 
-            <ForecastMaker post={postData} />
-            {!!postData.conditional && (
-              <ConditionalTimeline
-                conditional={
-                  postData.conditional as PostConditional<QuestionWithNumericForecasts>
-                }
-                isClosed={isClosed}
-              />
-            )}
+              <ForecastMaker post={postData} />
+              {!!postData.conditional && (
+                <ConditionalTimeline
+                  conditional={
+                    postData.conditional as PostConditional<QuestionWithNumericForecasts>
+                  }
+                  isClosed={isClosed}
+                />
+              )}
 
-            {!!postData.group_of_questions && (
-              <ContinuousGroupTimeline
-                post={postData}
-                preselectedQuestionId={preselectedGroupQuestionId}
-              />
-            )}
+              {!!postData.group_of_questions && (
+                <ContinuousGroupTimeline
+                  post={postData}
+                  preselectedQuestionId={preselectedGroupQuestionId}
+                />
+              )}
 
-            <BackgroundInfo post={postData} />
-            <HistogramDrawer post={postData} />
+              <BackgroundInfo post={postData} />
+              <HistogramDrawer post={postData} />
+              <Sidebar
+                postData={postData}
+                allowModifications={allowModifications}
+                layout="mobile"
+                questionTitle={questionTitle}
+              />
+
+              <CommentFeed
+                postData={postData}
+                postPermissions={postData.user_permission}
+              />
+            </section>
+
             <Sidebar
               postData={postData}
               allowModifications={allowModifications}
-              layout="mobile"
               questionTitle={questionTitle}
             />
+          </div>
+        </main>
 
-            <CommentFeed
-              postData={postData}
-              postPermissions={postData.user_permission}
-            />
-          </section>
-
-          <Sidebar
-            postData={postData}
-            allowModifications={allowModifications}
-            questionTitle={questionTitle}
-          />
-        </div>
-      </main>
-
-      <QuestionEmbedModal postId={postData.id} postTitle={postData.title} />
+        <QuestionEmbedModal postId={postData.id} postTitle={postData.title} />
+      </HideCPProvider>
     </EmbedModalContextProvider>
   );
 }

--- a/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
@@ -74,6 +74,7 @@ type Props = {
   chartTheme?: VictoryThemeDefinition;
   defaultZoom?: TimelineChartZoomOption;
   embedMode?: boolean;
+  hideCP?: boolean;
 };
 
 const ContinuousGroupTimeline: FC<Props> = ({
@@ -87,6 +88,7 @@ const ContinuousGroupTimeline: FC<Props> = ({
   defaultZoom,
   chartHeight,
   embedMode = false,
+  hideCP,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -185,8 +187,8 @@ const ContinuousGroupTimeline: FC<Props> = ({
 
   return (
     <MultiChoicesChartView
-      tooltipChoices={tooltipChoices}
-      choiceItems={choiceItems}
+      tooltipChoices={!!hideCP ? [] : tooltipChoices}
+      choiceItems={!!hideCP ? [] : choiceItems}
       timestamps={timestamps}
       userForecasts={userForecasts}
       tooltipDate={tooltipDate}

--- a/front_end/src/app/(main)/questions/[id]/components/cp_provider.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/cp_provider.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import {
+  createContext,
+  FC,
+  PropsWithChildren,
+  useContext,
+  useState,
+} from "react";
+
+import { useAuth } from "@/contexts/auth_context";
+import { PostStatus, PostWithForecasts } from "@/types/post";
+
+export type HideCPContextType = {
+  hideCP: boolean;
+  setCurrentHideCP: (hideCP: boolean) => void;
+};
+
+export const HideCPContext = createContext<HideCPContextType>({
+  hideCP: false,
+  setCurrentHideCP: () => {},
+});
+
+type CPProviderProps = {
+  post: PostWithForecasts;
+};
+const HideCPProvider: FC<PropsWithChildren<CPProviderProps>> = ({
+  post,
+  children,
+}) => {
+  const { user } = useAuth();
+  const hideCP =
+    user?.hide_community_prediction &&
+    ![PostStatus.CLOSED, PostStatus.RESOLVED].includes(post.status);
+  const [currentHideCP, setCurrentHideCP] = useState<boolean>(!!hideCP);
+
+  return (
+    <HideCPContext.Provider value={{ hideCP: currentHideCP, setCurrentHideCP }}>
+      {children}
+    </HideCPContext.Provider>
+  );
+};
+
+export default HideCPProvider;
+export const useHideCP = () => useContext(HideCPContext);

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/binary_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/binary_group_chart.tsx
@@ -71,6 +71,7 @@ type Props = {
   chartHeight?: number;
   chartTheme?: VictoryThemeDefinition;
   embedMode?: boolean;
+  hideCP?: boolean;
 };
 
 const BinaryGroupChart: FC<Props> = ({
@@ -83,6 +84,7 @@ const BinaryGroupChart: FC<Props> = ({
   chartTheme,
   chartHeight,
   embedMode = false,
+  hideCP,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -195,9 +197,9 @@ const BinaryGroupChart: FC<Props> = ({
 
   return (
     <MultiChoicesChartView
-      tooltipChoices={tooltipChoices}
+      tooltipChoices={!!hideCP ? [] : tooltipChoices}
       tooltipUserChoices={tooltipUserChoices}
-      choiceItems={choiceItems}
+      choiceItems={!!hideCP ? [] : choiceItems}
       timestamps={timestamps}
       userForecasts={userForecasts}
       tooltipDate={tooltipDate}

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import React, { FC, useState } from "react";
+import React, { FC } from "react";
 
 import Button from "@/app/(main)/about/components/Button";
 import NumericGroupChart from "@/app/(main)/questions/[id]/components/detailed_group_card/numeric_group_chart";
@@ -18,6 +18,7 @@ import { sortGroupPredictionOptions } from "@/utils/questions";
 
 import BinaryGroupChart from "./binary_group_chart";
 import ContinuousGroupTimeline from "../continuous_group_timeline";
+import { useHideCP } from "../cp_provider";
 
 type Props = {
   questions: QuestionWithForecasts[];
@@ -40,10 +41,7 @@ const DetailedGroupCard: FC<Props> = ({
 }) => {
   const t = useTranslations();
   const groupType = questions.at(0)?.type;
-  const { user } = useAuth();
-  const [hideCommunityPrediction, setHideCommunityPrediction] = useState(
-    user && user.hide_community_prediction
-  );
+  const { hideCP, setCurrentHideCP } = useHideCP();
 
   if (!groupType) {
     return (
@@ -84,17 +82,6 @@ const DetailedGroupCard: FC<Props> = ({
     );
   }
 
-  if (hideCommunityPrediction && !oneQuestionClosed) {
-    return (
-      <div className="text-center">
-        <div className="text-l m-4">{t("CPIsHidden")}</div>
-        <Button onClick={() => setHideCommunityPrediction(false)}>
-          {t("RevealTemporarily")}
-        </Button>
-      </div>
-    );
-  }
-
   switch (graphType) {
     case GroupOfQuestionsGraphType.MultipleChoiceGraph: {
       const sortedQuestions = sortGroupPredictionOptions(
@@ -104,29 +91,51 @@ const DetailedGroupCard: FC<Props> = ({
       switch (groupType) {
         case QuestionType.Binary: {
           return (
-            <BinaryGroupChart
-              actualCloseTime={
-                actualCloseTime ? new Date(actualCloseTime).getTime() : null
-              }
-              questions={sortedQuestions}
-              timestamps={timestamps}
-              preselectedQuestionId={preselectedQuestionId}
-              isClosed={isClosed}
-            />
+            <>
+              <BinaryGroupChart
+                actualCloseTime={
+                  actualCloseTime ? new Date(actualCloseTime).getTime() : null
+                }
+                questions={sortedQuestions}
+                timestamps={timestamps}
+                preselectedQuestionId={preselectedQuestionId}
+                isClosed={isClosed}
+                hideCP={hideCP}
+              />
+              {hideCP && (
+                <div className="text-center">
+                  <div className="text-l m-4">{t("CPIsHidden")}</div>
+                  <Button onClick={() => setCurrentHideCP(false)}>
+                    {t("RevealTemporarily")}
+                  </Button>
+                </div>
+              )}
+            </>
           );
         }
         case QuestionType.Numeric:
         case QuestionType.Date:
           return (
-            <ContinuousGroupTimeline
-              actualCloseTime={
-                actualCloseTime ? new Date(actualCloseTime).getTime() : null
-              }
-              questions={sortedQuestions}
-              timestamps={timestamps}
-              isClosed={isClosed}
-              preselectedQuestionId={preselectedQuestionId}
-            />
+            <>
+              <ContinuousGroupTimeline
+                actualCloseTime={
+                  actualCloseTime ? new Date(actualCloseTime).getTime() : null
+                }
+                questions={sortedQuestions}
+                timestamps={timestamps}
+                isClosed={isClosed}
+                preselectedQuestionId={preselectedQuestionId}
+                hideCP={hideCP}
+              />
+              {hideCP && (
+                <div className="text-center">
+                  <div className="text-l m-4">{t("CPIsHidden")}</div>
+                  <Button onClick={() => setCurrentHideCP(false)}>
+                    {t("RevealTemporarily")}
+                  </Button>
+                </div>
+              )}
+            </>
           );
         default:
           return null;

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/numeric_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/numeric_group_chart.tsx
@@ -13,6 +13,7 @@ type Props = {
   height?: number;
   pointSize?: number;
   withLabel?: boolean;
+  hideCP?: boolean;
 };
 
 const NumericGroupChart: FC<Props> = ({
@@ -20,6 +21,7 @@ const NumericGroupChart: FC<Props> = ({
   height,
   pointSize,
   withLabel,
+  hideCP,
 }) => {
   const t = useTranslations();
 
@@ -34,6 +36,7 @@ const NumericGroupChart: FC<Props> = ({
       pointSize={pointSize}
       yLabel={withLabel ? t("communityPredictionLabel") : undefined}
       withTooltip
+      hideCP={hideCP}
     />
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/index.tsx
@@ -1,15 +1,15 @@
 "use client";
 import { useTranslations } from "next-intl";
-import React, { FC, useState } from "react";
+import React, { FC } from "react";
 
 import Button from "@/app/(main)/about/components/Button";
-import { useAuth } from "@/contexts/auth_context";
-import { PostStatus, PostWithForecasts } from "@/types/post";
+import { PostStatus } from "@/types/post";
 import { QuestionType, QuestionWithForecasts } from "@/types/question";
 
 import DetailsQuestionCardErrorBoundary from "./error_boundary";
 import MultipleChoiceChartCard from "./multiple_choice_chart_card";
 import NumericChartCard from "./numeric_chart_card";
+import { useHideCP } from "../cp_provider";
 
 type Props = {
   postStatus: PostStatus;
@@ -24,10 +24,8 @@ const DetailedQuestionCard: FC<Props> = ({
 }) => {
   const isForecastEmpty =
     question.aggregations.recency_weighted.history.length === 0;
-  const { user } = useAuth();
-  const [hideCommunityPrediction, setHideCommunityPrediction] = useState(
-    user && user.hide_community_prediction
-  );
+  const { hideCP, setCurrentHideCP } = useHideCP();
+
   const t = useTranslations();
 
   if (isForecastEmpty) {
@@ -46,20 +44,6 @@ const DetailedQuestionCard: FC<Props> = ({
       </>
     );
   }
-  const questionIsClosed = question.actual_close_time
-    ? new Date(question.actual_close_time).getTime() < Date.now()
-    : false;
-
-  if (hideCommunityPrediction && !questionIsClosed) {
-    return (
-      <div className="text-center">
-        <div className="text-l m-4">{t("CPIsHidden")}</div>
-        <Button onClick={() => setHideCommunityPrediction(false)}>
-          {t("RevealTemporarily")}
-        </Button>
-      </div>
-    );
-  }
 
   switch (question.type) {
     case QuestionType.Numeric:
@@ -67,13 +51,29 @@ const DetailedQuestionCard: FC<Props> = ({
     case QuestionType.Binary:
       return (
         <DetailsQuestionCardErrorBoundary>
-          <NumericChartCard question={question} />
+          <NumericChartCard question={question} hideCP={hideCP} />
+          {hideCP && (
+            <div className="text-center">
+              <div className="text-l m-4">{t("CPIsHidden")}</div>
+              <Button onClick={() => setCurrentHideCP(false)}>
+                {t("RevealTemporarily")}
+              </Button>
+            </div>
+          )}
         </DetailsQuestionCardErrorBoundary>
       );
     case QuestionType.MultipleChoice:
       return (
         <DetailsQuestionCardErrorBoundary>
-          <MultipleChoiceChartCard question={question} />
+          <MultipleChoiceChartCard question={question} hideCP={hideCP} />
+          {hideCP && (
+            <div className="text-center">
+              <div className="text-l m-4">{t("CPIsHidden")}</div>
+              <Button onClick={() => setCurrentHideCP(false)}>
+                {t("RevealTemporarily")}
+              </Button>
+            </div>
+          )}
         </DetailsQuestionCardErrorBoundary>
       );
     default:

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
@@ -27,6 +27,7 @@ type Props = {
   chartHeight?: number;
   defaultZoom?: TimelineChartZoomOption;
   chartTheme?: VictoryThemeDefinition;
+  hideCP?: boolean;
 };
 
 const MultipleChoiceChartCard: FC<Props> = ({
@@ -35,6 +36,7 @@ const MultipleChoiceChartCard: FC<Props> = ({
   chartHeight,
   defaultZoom,
   chartTheme,
+  hideCP,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -151,9 +153,9 @@ const MultipleChoiceChartCard: FC<Props> = ({
 
   return (
     <MultiChoicesChartView
-      tooltipChoices={tooltipChoices}
+      tooltipChoices={hideCP ? [] : tooltipChoices}
       tooltipUserChoices={tooltipUserChoices}
-      choiceItems={choiceItems}
+      choiceItems={hideCP ? [] : choiceItems}
       timestamps={timestamps}
       userForecasts={userForecasts}
       tooltipDate={tooltipDate}

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/numeric_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/numeric_chart_card.tsx
@@ -13,9 +13,10 @@ import CursorDetailItem from "./numeric_cursor_item";
 
 type Props = {
   question: Question;
+  hideCP?: boolean;
 };
 
-const NumericChartCard: FC<Props> = ({ question }) => {
+const NumericChartCard: FC<Props> = ({ question, hideCP }) => {
   const t = useTranslations();
   const { user } = useAuth();
 
@@ -93,6 +94,7 @@ const NumericChartCard: FC<Props> = ({ question }) => {
           user ? TimelineChartZoomOption.All : TimelineChartZoomOption.TwoMonths
         }
         withZoomPicker
+        hideCP={hideCP}
       />
 
       <div
@@ -105,15 +107,17 @@ const NumericChartCard: FC<Props> = ({ question }) => {
           title={t("totalForecastersLabel")}
           text={cursorData.forecasterCount?.toString()}
         />
-        <CursorDetailItem
-          title={t("communityPredictionLabel")}
-          text={getDisplayValue(
-            cursorData.center,
-            question.type,
-            question.scaling
-          )}
-          variant="prediction"
-        />
+        {!hideCP && (
+          <CursorDetailItem
+            title={t("communityPredictionLabel")}
+            text={getDisplayValue(
+              cursorData.center,
+              question.type,
+              question.scaling
+            )}
+            variant="prediction"
+          />
+        )}
         {!!question.my_forecasts?.history.length && (
           <CursorDetailItem
             title={t("myPrediction")}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
@@ -14,6 +14,7 @@ import { ContinuousAreaGraphType } from "@/types/charts";
 import { QuestionWithNumericForecasts } from "@/types/question";
 
 import ContinuousPredictionChart from "./continuous_prediction_chart";
+import { useHideCP } from "../cp_provider";
 
 type Props = {
   forecast: MultiSliderValue[];
@@ -36,6 +37,7 @@ const ContinuousSlider: FC<Props> = ({
   disabled = false,
 }) => {
   const { user } = useAuth();
+  const { hideCP } = useHideCP();
   const t = useTranslations();
   const [graphType, setGraphType] = useState<ContinuousAreaGraphType>("pmf");
 
@@ -57,7 +59,7 @@ const ContinuousSlider: FC<Props> = ({
         graphType={graphType}
         question={question}
         readOnly={disabled}
-        showCP={!user || !user.hide_community_prediction}
+        showCP={!user || !hideCP || !!question.resolution}
       />
       {!disabled &&
         forecast.map((x, index) => {

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/types/question";
 import { extractPrevBinaryForecastValue } from "@/utils/forecasts";
 
+import { useHideCP } from "../../cp_provider";
 import BinarySlider, { BINARY_FORECAST_PRECISION } from "../binary_slider";
 import ConditionalForecastTable, {
   ConditionalTableOption,
@@ -44,6 +45,7 @@ const ForecastMakerConditionalBinary: FC<Props> = ({
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
+  const { hideCP } = useHideCP();
   const { setCurrentModal } = useModal();
 
   const prevYesForecastValue = extractPrevBinaryForecastValue(prevYesForecast);
@@ -259,9 +261,7 @@ const ForecastMakerConditionalBinary: FC<Props> = ({
             isDirty={option.isDirty}
             onBecomeDirty={() => handleBecomeDirty(option.id)}
             communityForecast={
-              !user || !user.hide_community_prediction
-                ? option.communitiesForecast
-                : null
+              !user || !hideCP ? option.communitiesForecast : null
             }
             disabled={!canPredict}
           />

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_continuous.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/utils/forecasts";
 import { computeQuartilesFromCDF } from "@/utils/math";
 
+import { useHideCP } from "../../cp_provider";
 import ConditionalForecastTable, {
   ConditionalTableOption,
 } from "../conditional_forecast_table";
@@ -51,6 +52,7 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
+  const { hideCP } = useHideCP();
   const { setCurrentModal } = useModal();
 
   const { condition, condition_child, question_yes, question_no } = conditional;
@@ -450,7 +452,7 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
           communityQuartiles={
             communityCdf && computeQuartilesFromCDF(communityCdf)
           }
-          withCommunityQuartiles={!user || !user.hide_community_prediction}
+          withCommunityQuartiles={!user || !hideCP}
           isDirty={activeOptionData.isDirty}
           hasUserForecast={
             activeTableOption === questionYesId

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
@@ -40,6 +40,7 @@ import { extractQuestionGroupName } from "@/utils/questions";
 
 import ForecastMakerGroupControls from "./forecast_maker_group_menu";
 import { SLUG_POST_SUB_QUESTION_ID } from "../../../search_params";
+import { useHideCP } from "../../cp_provider";
 import {
   BINARY_FORECAST_PRECISION,
   BINARY_MAX_VALUE,
@@ -77,6 +78,7 @@ const ForecastMakerGroupBinary: FC<Props> = ({
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
+  const { hideCP } = useHideCP();
   const params = useSearchParams();
   const subQuestionId = Number(params.get(SLUG_POST_SUB_QUESTION_ID));
   const { setCurrentModal } = useModal();
@@ -237,7 +239,9 @@ const ForecastMakerGroupBinary: FC<Props> = ({
               defaultSliderValue={50}
               choiceName={questionOption.name}
               choiceColor={questionOption.color}
-              communityForecast={questionOption.communityForecast}
+              communityForecast={
+                !user || !hideCP ? questionOption.communityForecast : null
+              }
               inputMin={BINARY_MIN_VALUE}
               inputMax={BINARY_MAX_VALUE}
               onChange={handleForecastChange}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
@@ -37,6 +37,7 @@ import {
 
 import ForecastMakerGroupControls from "./forecast_maker_group_menu";
 import { SLUG_POST_SUB_QUESTION_ID } from "../../../search_params";
+import { useHideCP } from "../../cp_provider";
 import ContinuousSlider from "../continuous_slider";
 import GroupForecastTable, {
   ConditionalTableOption,
@@ -62,6 +63,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
   const t = useTranslations();
   const locale = useLocale();
   const { user } = useAuth();
+  const { hideCP } = useHideCP();
   const params = useSearchParams();
   const { setCurrentModal } = useModal();
   const subQuestionId = Number(params.get(SLUG_POST_SUB_QUESTION_ID));
@@ -271,7 +273,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
         options={groupOptions}
         onChange={setActiveTableOption}
         questions={questions}
-        showCP={!user || !user.hide_community_prediction}
+        showCP={!user || !hideCP}
       />
       {groupOptions.map((option) => {
         const dataset = getNumericForecastDataset(
@@ -374,7 +376,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
             }
             communityQuartiles={activeGroupOption.communityQuartiles}
             withUserQuartiles={activeGroupOption.resolution === null}
-            withCommunityQuartiles={!user || !user.hide_community_prediction}
+            withCommunityQuartiles={!user || !hideCP}
             isDirty={activeGroupOption.isDirty}
             hasUserForecast={
               !!prevForecastValuesMap[activeTableOption!].forecast

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/types/question";
 import { extractPrevBinaryForecastValue } from "@/utils/forecasts";
 
+import { useHideCP } from "../../cp_provider";
 import BinarySlider, { BINARY_FORECAST_PRECISION } from "../binary_slider";
 import QuestionResolutionButton from "../resolution";
 import QuestionUnresolveButton from "../resolution/unresolve_button";
@@ -44,7 +45,7 @@ const ForecastMakerBinary: FC<Props> = ({
   const t = useTranslations();
   const { user } = useAuth();
   const { setCurrentModal } = useModal();
-
+  const { hideCP } = useHideCP();
   const communityForecast =
     question.aggregations.recency_weighted.latest?.centers![0];
 
@@ -94,9 +95,7 @@ const ForecastMakerBinary: FC<Props> = ({
         forecast={forecast}
         onChange={setForecast}
         isDirty={isForecastDirty}
-        communityForecast={
-          !!user && user.hide_community_prediction ? null : communityForecast
-        }
+        communityForecast={!!user && hideCP ? null : communityForecast}
         onBecomeDirty={() => {
           setIsForecastDirty(true);
         }}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useTranslations } from "next-intl";
-import React, { FC, use, useMemo, useState } from "react";
+import React, { FC, useMemo, useState } from "react";
 
 import { createForecasts } from "@/app/(main)/questions/actions";
 import { MultiSliderValue } from "@/components/sliders/multi_slider";
@@ -20,6 +20,7 @@ import {
 } from "@/utils/forecasts";
 import { computeQuartilesFromCDF } from "@/utils/math";
 
+import { useHideCP } from "../../cp_provider";
 import ContinuousSlider from "../continuous_slider";
 import NumericForecastTable from "../numeric_table";
 import QuestionResolutionButton from "../resolution";
@@ -46,8 +47,9 @@ const ForecastMakerContinuous: FC<Props> = ({
 }) => {
   const { user } = useAuth();
   const { setCurrentModal } = useModal();
+  const { hideCP } = useHideCP();
   const [isDirty, setIsDirty] = useState(false);
-
+  const withCommunityQuartiles = !user || !hideCP;
   const prevForecastValue = extractPrevNumericForecastValue(prevForecast);
   const t = useTranslations();
   const [forecast, setForecast] = useState<MultiSliderValue[]>(
@@ -185,7 +187,7 @@ const ForecastMakerContinuous: FC<Props> = ({
         communityQuartiles={
           communityCdf ? computeQuartilesFromCDF(communityCdf) : undefined
         }
-        withCommunityQuartiles={!user || !user.hide_community_prediction}
+        withCommunityQuartiles={withCommunityQuartiles}
         isDirty={isDirty}
         hasUserForecast={!!prevForecastValue.forecast}
       />

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_multiple_choice.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_multiple_choice.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/types/question";
 import { ThemeColor } from "@/types/theme";
 
+import { useHideCP } from "../../cp_provider";
 import {
   BINARY_FORECAST_PRECISION,
   BINARY_MAX_VALUE,
@@ -59,6 +60,7 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
+  const { hideCP } = useHideCP();
   const { setCurrentModal } = useModal();
 
   const [isDirty, setIsDirty] = useState(false);
@@ -228,9 +230,7 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
               choiceName={choice.name}
               choiceColor={choice.color}
               communityForecast={
-                !user || !user.hide_community_prediction
-                  ? choice.communityForecast
-                  : null
+                !user || !hideCP ? choice.communityForecast : null
               }
               inputMin={BINARY_MIN_VALUE}
               inputMax={BINARY_MAX_VALUE}

--- a/front_end/src/components/charts/continuous_area_chart.tsx
+++ b/front_end/src/components/charts/continuous_area_chart.tsx
@@ -55,6 +55,7 @@ type Props = {
   extraTheme?: VictoryThemeDefinition;
   resolution: Resolution | null;
   onCursorChange?: (value: ContinuousAreaHoverState | null) => void;
+  hideCP?: boolean;
 };
 
 const ContinuousAreaChart: FC<Props> = ({
@@ -67,6 +68,7 @@ const ContinuousAreaChart: FC<Props> = ({
   extraTheme,
   resolution,
   onCursorChange,
+  hideCP,
 }) => {
   const { ref: chartContainerRef, width: containerWidth } =
     useContainerSize<HTMLDivElement>();
@@ -78,22 +80,24 @@ const ContinuousAreaChart: FC<Props> = ({
     ? merge({}, chartTheme, extraTheme)
     : chartTheme;
 
-  const charts = useMemo(
-    () =>
-      data.reduce<NumericPredictionGraph[]>(
-        (acc, el) => [
-          ...acc,
-          generateNumericAreaGraph({
-            pmf: el.pmf,
-            cdf: el.cdf,
-            graphType,
-            type: el.type,
-          }),
-        ],
-        []
-      ),
-    [data, graphType]
-  );
+  const charts = useMemo(() => {
+    const parsedData = hideCP
+      ? [...data].filter((el) => el.type === "user")
+      : data;
+
+    return parsedData.reduce<NumericPredictionGraph[]>(
+      (acc, el) => [
+        ...acc,
+        generateNumericAreaGraph({
+          pmf: el.pmf,
+          cdf: el.cdf,
+          graphType,
+          type: el.type,
+        }),
+      ],
+      []
+    );
+  }, [data, graphType]);
   const { xDomain, yDomain } = useMemo<{
     xDomain: Tuple<number>;
     yDomain: Tuple<number>;

--- a/front_end/src/components/charts/fan_chart.tsx
+++ b/front_end/src/components/charts/fan_chart.tsx
@@ -43,6 +43,7 @@ type Props = {
   withTooltip?: boolean;
   extraTheme?: VictoryThemeDefinition;
   pointSize?: number;
+  hideCP?: boolean;
 };
 
 const FanChart: FC<Props> = ({
@@ -52,6 +53,7 @@ const FanChart: FC<Props> = ({
   withTooltip = false,
   extraTheme,
   pointSize,
+  hideCP,
 }) => {
   const { ref: chartContainerRef, width: chartWidth } =
     useContainerSize<HTMLDivElement>();
@@ -151,16 +153,18 @@ const FanChart: FC<Props> = ({
             },
           ]}
         >
-          <VictoryArea
-            name="fanArea"
-            data={area}
-            style={{
-              data: {
-                opacity: 0.3,
-              },
-            }}
-          />
-          <VictoryLine name="fanLine" data={line} />
+          {!hideCP && (
+            <VictoryArea
+              name="fanArea"
+              data={area}
+              style={{
+                data: {
+                  opacity: 0.3,
+                },
+              }}
+            />
+          )}
+          {!hideCP && <VictoryLine name="fanLine" data={line} />}
           <VictoryAxis
             dependentAxis
             label={yLabel}
@@ -175,24 +179,26 @@ const FanChart: FC<Props> = ({
             }
           />
           <VictoryAxis tickFormat={(_, index) => labels[index]} />
-          <VictoryScatter
-            data={points.map((point) => ({
-              ...point,
-              symbol: "square",
-            }))}
-            style={{
-              data: {
-                fill: () => getThemeColor(METAC_COLORS.olive["800"]),
-                stroke: () => getThemeColor(METAC_COLORS.olive["800"]),
-                strokeWidth: 6,
-                strokeOpacity: ({ datum }) =>
-                  activePoint === datum.x ? 0.3 : 0,
-              },
-            }}
-            dataComponent={
-              <FanPoint activePoint={activePoint} pointSize={pointSize} />
-            }
-          />
+          {!hideCP && (
+            <VictoryScatter
+              data={points.map((point) => ({
+                ...point,
+                symbol: "square",
+              }))}
+              style={{
+                data: {
+                  fill: () => getThemeColor(METAC_COLORS.olive["800"]),
+                  stroke: () => getThemeColor(METAC_COLORS.olive["800"]),
+                  strokeWidth: 6,
+                  strokeOpacity: ({ datum }) =>
+                    activePoint === datum.x ? 0.3 : 0,
+                },
+              }}
+              dataComponent={
+                <FanPoint activePoint={activePoint} pointSize={pointSize} />
+              }
+            />
+          )}
           <VictoryScatter
             data={resolutionPoints.map((point) => ({
               ...point,

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -66,6 +66,7 @@ type Props = {
   extraTheme?: VictoryThemeDefinition;
   resolution?: Resolution | null;
   resolveTime?: string | null;
+  hideCP?: boolean;
 };
 
 const NumericChart: FC<Props> = ({
@@ -83,6 +84,7 @@ const NumericChart: FC<Props> = ({
   extraTheme,
   resolution,
   resolveTime,
+  hideCP,
 }) => {
   const { ref: chartContainerRef, width: chartWidth } =
     useContainerSize<HTMLDivElement>();
@@ -217,24 +219,29 @@ const NumericChart: FC<Props> = ({
           ]}
           containerComponent={onCursorChange ? CursorContainer : undefined}
         >
-          <VictoryArea
-            data={area}
-            style={{
-              data: {
-                opacity: 0.3,
-              },
-            }}
-            interpolation="stepAfter"
-          />
-          <VictoryLine
-            data={line}
-            style={{
-              data: {
-                strokeWidth: 1.5,
-              },
-            }}
-            interpolation="stepAfter"
-          />
+          {!hideCP && (
+            <VictoryArea
+              data={area}
+              style={{
+                data: {
+                  opacity: 0.3,
+                },
+              }}
+              interpolation="stepAfter"
+            />
+          )}
+          {!hideCP && (
+            <VictoryLine
+              data={line}
+              style={{
+                data: {
+                  strokeWidth: 1.5,
+                },
+              }}
+              interpolation="stepAfter"
+            />
+          )}
+
           <VictoryScatter
             data={points}
             dataComponent={<PredictionWithRange />}

--- a/front_end/src/components/conditional_tile/conditional_chart.tsx
+++ b/front_end/src/components/conditional_tile/conditional_chart.tsx
@@ -21,9 +21,15 @@ type Props = {
   disabled: boolean;
   chartHeight?: number;
   chartTheme?: VictoryThemeDefinition;
+  hideCP?: boolean;
 };
 
-const ConditionalChart: FC<Props> = ({ question, disabled, chartTheme }) => {
+const ConditionalChart: FC<Props> = ({
+  question,
+  disabled,
+  chartTheme,
+  hideCP,
+}) => {
   const resolved = question.resolution !== null;
   const aggregate = question.aggregations.recency_weighted;
   const userForecasts = question.my_forecasts;
@@ -51,7 +57,9 @@ const ConditionalChart: FC<Props> = ({ question, disabled, chartTheme }) => {
                   </div>
                 );
               }
-
+              if (hideCP) {
+                return null;
+              }
               return (
                 <div className="flex items-center gap-1 pl-1">
                   <FontAwesomeIcon icon={faUserGroup} size="sm" /> {`${value}%`}
@@ -63,6 +71,7 @@ const ConditionalChart: FC<Props> = ({ question, disabled, chartTheme }) => {
                 ? themeProgressColor
                 : undefined
             }
+            hideCP={hideCP}
           />
           {resolved && (
             <PredictionChip
@@ -116,12 +125,14 @@ const ConditionalChart: FC<Props> = ({ question, disabled, chartTheme }) => {
       return (
         <>
           <div className="flex gap-2">
-            <div className="flex items-center gap-1 whitespace-nowrap text-xs font-semibold leading-none text-olive-700 dark:text-olive-700-dark">
-              <div>
-                <FontAwesomeIcon icon={faUserGroup} size="sm" />
+            {!hideCP && (
+              <div className="flex items-center gap-1 whitespace-nowrap text-xs font-semibold leading-none text-olive-700 dark:text-olive-700-dark">
+                <div>
+                  <FontAwesomeIcon icon={faUserGroup} size="sm" />
+                </div>
+                <span>{formattedPrediction}</span>
               </div>
-              <span>{formattedPrediction}</span>
-            </div>
+            )}
             <ContinuousAreaChart
               height={40}
               scaling={question.scaling}
@@ -129,6 +140,7 @@ const ConditionalChart: FC<Props> = ({ question, disabled, chartTheme }) => {
               extraTheme={chartTheme}
               questionType={question.type}
               resolution={question.resolution}
+              hideCP={hideCP}
             />
           </div>
           {resolved && (

--- a/front_end/src/components/conditional_tile/index.tsx
+++ b/front_end/src/components/conditional_tile/index.tsx
@@ -2,13 +2,11 @@
 
 import classNames from "classnames";
 import { useTranslations } from "next-intl";
-import React, { FC, useState } from "react";
+import React, { FC } from "react";
 import { VictoryThemeDefinition } from "victory";
 
-import Button from "@/app/(main)/about/components/Button";
 import { SLUG_POST_SUB_QUESTION_ID } from "@/app/(main)/questions/[id]/search_params";
 import PredictionChip from "@/components/prediction_chip";
-import { useAuth } from "@/contexts/auth_context";
 import { PostConditional, PostStatus } from "@/types/post";
 import { QuestionWithForecasts } from "@/types/question";
 import {
@@ -28,6 +26,7 @@ type Props = {
   withNavigation?: boolean;
   chartTheme?: VictoryThemeDefinition;
   nrForecasters?: number;
+  hideCP?: boolean;
 };
 
 const ConditionalTile: FC<Props> = ({
@@ -36,36 +35,9 @@ const ConditionalTile: FC<Props> = ({
   curationStatus,
   withNavigation,
   chartTheme,
+  hideCP,
 }) => {
   const t = useTranslations();
-  const { user } = useAuth();
-  const [hideCommunityPrediction, setHideCommunityPrediction] = useState(
-    user && user.hide_community_prediction
-  );
-  let oneQuestionClosed = false;
-  if (
-    conditional.question_no.actual_close_time &&
-    new Date(conditional.question_no.actual_close_time).getTime() < Date.now()
-  ) {
-    oneQuestionClosed = true;
-  }
-  if (
-    conditional.question_yes.actual_close_time &&
-    new Date(conditional.question_yes.actual_close_time).getTime() < Date.now()
-  ) {
-    oneQuestionClosed = true;
-  }
-
-  if (hideCommunityPrediction && !oneQuestionClosed) {
-    return (
-      <div className="text-center">
-        <div className="text-l m-4">{t("CPIsHidden")}</div>
-        <Button onClick={() => setHideCommunityPrediction(false)}>
-          {t("RevealTemporarily")}
-        </Button>
-      </div>
-    );
-  }
 
   const { condition, condition_child, question_yes, question_no } = conditional;
   const isEmbedded = !!chartTheme;
@@ -119,6 +91,7 @@ const ConditionalTile: FC<Props> = ({
                   : PostStatus.CLOSED
               }
               size="compact"
+              hideCP={hideCP}
             />
           )}
         </ConditionalCard>
@@ -163,6 +136,7 @@ const ConditionalTile: FC<Props> = ({
             question={question_yes}
             disabled={yesDisabled}
             chartTheme={chartTheme}
+            hideCP={hideCP}
           />
         </ConditionalCard>
         <ConditionalCard
@@ -173,6 +147,7 @@ const ConditionalTile: FC<Props> = ({
             question={question_no}
             disabled={noDisabled}
             chartTheme={chartTheme}
+            hideCP={hideCP}
           />
         </ConditionalCard>
       </div>

--- a/front_end/src/components/conditional_tile/index.tsx
+++ b/front_end/src/components/conditional_tile/index.tsx
@@ -5,6 +5,8 @@ import { useTranslations } from "next-intl";
 import React, { FC } from "react";
 import { VictoryThemeDefinition } from "victory";
 
+import Button from "@/app/(main)/about/components/Button";
+import { useHideCP } from "@/app/(main)/questions/[id]/components/cp_provider";
 import { SLUG_POST_SUB_QUESTION_ID } from "@/app/(main)/questions/[id]/search_params";
 import PredictionChip from "@/components/prediction_chip";
 import { PostConditional, PostStatus } from "@/types/post";
@@ -26,7 +28,7 @@ type Props = {
   withNavigation?: boolean;
   chartTheme?: VictoryThemeDefinition;
   nrForecasters?: number;
-  hideCP?: boolean;
+  withCPRevealBtn?: boolean;
 };
 
 const ConditionalTile: FC<Props> = ({
@@ -35,10 +37,10 @@ const ConditionalTile: FC<Props> = ({
   curationStatus,
   withNavigation,
   chartTheme,
-  hideCP,
+  withCPRevealBtn,
 }) => {
   const t = useTranslations();
-
+  const { hideCP, setCurrentHideCP } = useHideCP();
   const { condition, condition_child, question_yes, question_no } = conditional;
   const isEmbedded = !!chartTheme;
 
@@ -66,92 +68,104 @@ const ConditionalTile: FC<Props> = ({
     question_no.resolution === "ambiguous";
 
   return (
-    <div className="ConditionalSummary grid grid-cols-[72px_minmax(0,_1fr)] gap-y-3 md:grid-cols-[minmax(0,_1fr)_72px_minmax(0,_1fr)]">
-      <div
-        className={classNames(
-          "ConditionalSummary-condition col-span-2 flex flex-col justify-center",
-          {
-            "row-span-1 md:col-span-1 md:row-auto": !isEmbedded,
-            "xs:col-span-1": isEmbedded,
-          }
-        )}
-      >
-        <ConditionalCard
-          label={t("condition")}
-          title={getConditionTitle(postTitle, condition)}
-          resolved={parentSuccessfullyResolved}
-          href={withNavigation ? conditionHref : undefined}
-        >
-          {(parentSuccessfullyResolved || parentIsClosed) && (
-            <PredictionChip
-              question={condition}
-              status={
-                parentSuccessfullyResolved
-                  ? PostStatus.RESOLVED
-                  : PostStatus.CLOSED
-              }
-              size="compact"
-              hideCP={hideCP}
-            />
-          )}
-        </ConditionalCard>
-      </div>
-      <div
-        className={classNames(
-          "ConditionalSummary-arrows relative flex flex-col justify-start gap-0 md:row-auto md:justify-center md:gap-12",
-          { "row-span-2 ml-3 md:ml-0": !isEmbedded }
-        )}
-      >
-        <ConditionalArrow
-          label={t("ifYes")}
-          didHappen={yesHappened}
-          disabled={yesDisabled}
-          className={"flex-1 md:flex-none"}
-        />
-        <ConditionalArrow
-          label={t("ifNo")}
-          didHappen={noHappened}
-          disabled={noDisabled}
-          className={"flex-1 md:flex-none"}
-        />
-
+    <>
+      <div className="ConditionalSummary grid grid-cols-[72px_minmax(0,_1fr)] gap-y-3 md:grid-cols-[minmax(0,_1fr)_72px_minmax(0,_1fr)]">
         <div
           className={classNames(
-            "absolute left-0 top-0 h-3/4 w-px bg-blue-700 dark:bg-blue-700-dark md:hidden",
-            { "xs:hidden": isEmbedded }
+            "ConditionalSummary-condition col-span-2 flex flex-col justify-center",
+            {
+              "row-span-1 md:col-span-1 md:row-auto": !isEmbedded,
+              "xs:col-span-1": isEmbedded,
+            }
           )}
-        />
-      </div>
-      <div
-        className={classNames(
-          "ConditionalSummary-conditionals flex flex-col gap-3",
-          { "row-span-2 md:row-auto": !isEmbedded }
-        )}
-      >
-        <ConditionalCard
-          title={getConditionalQuestionTitle(question_yes)}
-          href={withNavigation ? conditionChildHref : undefined}
         >
-          <ConditionalChart
-            question={question_yes}
+          <ConditionalCard
+            label={t("condition")}
+            title={getConditionTitle(postTitle, condition)}
+            resolved={parentSuccessfullyResolved}
+            href={withNavigation ? conditionHref : undefined}
+          >
+            {(parentSuccessfullyResolved || parentIsClosed) && (
+              <PredictionChip
+                question={condition}
+                status={
+                  parentSuccessfullyResolved
+                    ? PostStatus.RESOLVED
+                    : PostStatus.CLOSED
+                }
+                size="compact"
+                hideCP={hideCP}
+              />
+            )}
+          </ConditionalCard>
+        </div>
+        <div
+          className={classNames(
+            "ConditionalSummary-arrows relative flex flex-col justify-start gap-0 md:row-auto md:justify-center md:gap-12",
+            { "row-span-2 ml-3 md:ml-0": !isEmbedded }
+          )}
+        >
+          <ConditionalArrow
+            label={t("ifYes")}
+            didHappen={yesHappened}
             disabled={yesDisabled}
-            chartTheme={chartTheme}
-            hideCP={hideCP}
+            className={"flex-1 md:flex-none"}
           />
-        </ConditionalCard>
-        <ConditionalCard
-          title={getConditionalQuestionTitle(question_no)}
-          href={withNavigation ? `/questions/${condition_child.id}` : undefined}
-        >
-          <ConditionalChart
-            question={question_no}
+          <ConditionalArrow
+            label={t("ifNo")}
+            didHappen={noHappened}
             disabled={noDisabled}
-            chartTheme={chartTheme}
-            hideCP={hideCP}
+            className={"flex-1 md:flex-none"}
           />
-        </ConditionalCard>
+
+          <div
+            className={classNames(
+              "absolute left-0 top-0 h-3/4 w-px bg-blue-700 dark:bg-blue-700-dark md:hidden",
+              { "xs:hidden": isEmbedded }
+            )}
+          />
+        </div>
+        <div
+          className={classNames(
+            "ConditionalSummary-conditionals flex flex-col gap-3",
+            { "row-span-2 md:row-auto": !isEmbedded }
+          )}
+        >
+          <ConditionalCard
+            title={getConditionalQuestionTitle(question_yes)}
+            href={withNavigation ? conditionChildHref : undefined}
+          >
+            <ConditionalChart
+              question={question_yes}
+              disabled={yesDisabled}
+              chartTheme={chartTheme}
+              hideCP={hideCP}
+            />
+          </ConditionalCard>
+          <ConditionalCard
+            title={getConditionalQuestionTitle(question_no)}
+            href={
+              withNavigation ? `/questions/${condition_child.id}` : undefined
+            }
+          >
+            <ConditionalChart
+              question={question_no}
+              disabled={noDisabled}
+              chartTheme={chartTheme}
+              hideCP={hideCP}
+            />
+          </ConditionalCard>
+        </div>
       </div>
-    </div>
+      {withCPRevealBtn && hideCP && (
+        <div className="text-center">
+          <div className="text-l m-4">{t("CPIsHidden")}</div>
+          <Button onClick={() => setCurrentHideCP(false)}>
+            {t("RevealTemporarily")}
+          </Button>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/front_end/src/components/multiple_choice_tile.tsx
+++ b/front_end/src/components/multiple_choice_tile.tsx
@@ -29,6 +29,7 @@ type Props = {
   userForecasts?: UserChoiceItem[];
   question?: Question;
   questionType?: QuestionType;
+  hideCP?: boolean;
 };
 
 const MultipleChoiceTile: FC<Props> = ({
@@ -42,6 +43,7 @@ const MultipleChoiceTile: FC<Props> = ({
   userForecasts,
   question,
   questionType,
+  hideCP,
 }) => {
   const t = useTranslations();
 
@@ -76,7 +78,7 @@ const MultipleChoiceTile: FC<Props> = ({
                   key={`choice-option-${choice}`}
                   choice={choice}
                   color={color}
-                  values={values}
+                  values={hideCP ? [null as unknown as number] : values}
                   resolution={resolution}
                   displayedResolution={displayedResolution}
                   questionType={questionType}
@@ -104,7 +106,7 @@ const MultipleChoiceTile: FC<Props> = ({
       {!isResolvedView && (
         <MultipleChoiceChart
           timestamps={timestamps}
-          choiceItems={choices}
+          choiceItems={hideCP ? [] : choices}
           height={chartHeight}
           extraTheme={chartTheme}
           defaultZoom={defaultChartZoom}

--- a/front_end/src/components/post_card/group_of_questions_tile/group_numeric_tile.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/group_numeric_tile.tsx
@@ -27,9 +27,15 @@ type Props = {
   questions: QuestionWithNumericForecasts[];
   curationStatus: PostStatus;
   post: PostWithForecasts;
+  hideCP?: boolean;
 };
 
-const GroupNumericTile: FC<Props> = ({ questions, curationStatus, post }) => {
+const GroupNumericTile: FC<Props> = ({
+  questions,
+  curationStatus,
+  post,
+  hideCP,
+}) => {
   const { user } = useAuth();
   const locale = useLocale();
 
@@ -50,6 +56,7 @@ const GroupNumericTile: FC<Props> = ({ questions, curationStatus, post }) => {
                 ?.centers![0]
             }
             status={curationStatus}
+            hideCP={hideCP}
           />
         </div>
         <div className="my-1 h-24 w-2/3 min-w-24 max-w-[500px] flex-1 overflow-visible">
@@ -57,6 +64,7 @@ const GroupNumericTile: FC<Props> = ({ questions, curationStatus, post }) => {
             questions={questions}
             height={CHART_HEIGHT}
             pointSize={8}
+            hideCP={hideCP}
           />
         </div>
       </div>
@@ -89,6 +97,7 @@ const GroupNumericTile: FC<Props> = ({ questions, curationStatus, post }) => {
             : undefined
         }
         questionType={questions[0].type}
+        hideCP={hideCP}
       />
     );
   }

--- a/front_end/src/components/post_card/group_of_questions_tile/index.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/index.tsx
@@ -3,7 +3,6 @@ import { useTranslations } from "next-intl";
 import { FC } from "react";
 
 import GroupNumericTile from "@/components/post_card/group_of_questions_tile/group_numeric_tile";
-import { GroupOfQuestionsGraphType } from "@/types/charts";
 import { PostWithForecasts, PostStatus } from "@/types/post";
 import {
   QuestionWithForecasts,
@@ -14,12 +13,14 @@ type Props = {
   questions: QuestionWithForecasts[];
   curationStatus: PostStatus;
   post: PostWithForecasts;
+  hideCP?: boolean;
 };
 
 const GroupOfQuestionsTile: FC<Props> = ({
   questions,
   curationStatus,
   post,
+  hideCP,
 }) => {
   const t = useTranslations();
   const groupType = questions.at(0)?.type;
@@ -33,6 +34,7 @@ const GroupOfQuestionsTile: FC<Props> = ({
       questions={questions as QuestionWithNumericForecasts[]}
       curationStatus={curationStatus}
       post={post}
+      hideCP={hideCP}
     />
   );
 };

--- a/front_end/src/components/post_card/index.tsx
+++ b/front_end/src/components/post_card/index.tsx
@@ -36,28 +36,21 @@ const PostCard: FC<Props> = ({ post }) => {
             hideCP={hideCP}
           />
         )}
-        {!!post.group_of_questions &&
-          (!hideCP || post.curation_status != PostStatus.APPROVED) && (
-            <GroupOfQuestionsTile
-              questions={post.group_of_questions.questions}
-              curationStatus={post.status}
-              post={post}
-            />
-          )}
-        {!!post.conditional &&
-        (!hideCP || post.curation_status != PostStatus.APPROVED) ? (
+        {!!post.group_of_questions && (
+          <GroupOfQuestionsTile
+            questions={post.group_of_questions.questions}
+            curationStatus={post.status}
+            post={post}
+            hideCP={hideCP}
+          />
+        )}
+        {!!post.conditional && (
           <ConditionalTile
             postTitle={post.title}
             conditional={post.conditional}
             curationStatus={post.status}
+            hideCP={hideCP}
           />
-        ) : (
-          !!post.conditional && (
-            <div>
-              {post.conditional?.condition_child.title} - Conditional on -{" "}
-              {post.conditional?.condition.title}
-            </div>
-          )
         )}
         {!!post.notebook && <NotebookTile notebook={post.notebook} />}
       </BasicPostCard>

--- a/front_end/src/components/post_card/index.tsx
+++ b/front_end/src/components/post_card/index.tsx
@@ -1,5 +1,6 @@
 import { FC } from "react";
 
+import HideCPProvider from "@/app/(main)/questions/[id]/components/cp_provider";
 import ConditionalTile from "@/components/conditional_tile";
 import NotebookTile from "@/components/post_card/notebook_tile";
 import { useAuth } from "@/contexts/auth_context";
@@ -28,31 +29,32 @@ const PostCard: FC<Props> = ({ post }) => {
         borderVariant={post.notebook ? "highlighted" : "regular"}
         borderColor={post.notebook ? "purple" : "blue"}
       >
-        {!!post?.question && (
-          <QuestionChartTile
-            question={post?.question}
-            authorUsername={post.author_username}
-            curationStatus={post.status}
-            hideCP={hideCP}
-          />
-        )}
-        {!!post.group_of_questions && (
-          <GroupOfQuestionsTile
-            questions={post.group_of_questions.questions}
-            curationStatus={post.status}
-            post={post}
-            hideCP={hideCP}
-          />
-        )}
-        {!!post.conditional && (
-          <ConditionalTile
-            postTitle={post.title}
-            conditional={post.conditional}
-            curationStatus={post.status}
-            hideCP={hideCP}
-          />
-        )}
-        {!!post.notebook && <NotebookTile notebook={post.notebook} />}
+        <HideCPProvider post={post}>
+          {!!post?.question && (
+            <QuestionChartTile
+              question={post?.question}
+              authorUsername={post.author_username}
+              curationStatus={post.status}
+              hideCP={hideCP}
+            />
+          )}
+          {!!post.group_of_questions && (
+            <GroupOfQuestionsTile
+              questions={post.group_of_questions.questions}
+              curationStatus={post.status}
+              post={post}
+              hideCP={hideCP}
+            />
+          )}
+          {!!post.conditional && (
+            <ConditionalTile
+              postTitle={post.title}
+              conditional={post.conditional}
+              curationStatus={post.status}
+            />
+          )}
+          {!!post.notebook && <NotebookTile notebook={post.notebook} />}
+        </HideCPProvider>
       </BasicPostCard>
     </PostCardErrorBoundary>
   );

--- a/front_end/src/components/post_card/index.tsx
+++ b/front_end/src/components/post_card/index.tsx
@@ -28,14 +28,14 @@ const PostCard: FC<Props> = ({ post }) => {
         borderVariant={post.notebook ? "highlighted" : "regular"}
         borderColor={post.notebook ? "purple" : "blue"}
       >
-        {!!post?.question &&
-          (!hideCP || post.curation_status != PostStatus.APPROVED) && (
-            <QuestionChartTile
-              question={post?.question}
-              authorUsername={post.author_username}
-              curationStatus={post.status}
-            />
-          )}
+        {!!post?.question && (
+          <QuestionChartTile
+            question={post?.question}
+            authorUsername={post.author_username}
+            curationStatus={post.status}
+            hideCP={hideCP}
+          />
+        )}
         {!!post.group_of_questions &&
           (!hideCP || post.curation_status != PostStatus.APPROVED) && (
             <GroupOfQuestionsTile

--- a/front_end/src/components/post_card/question_chart_tile/index.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/index.tsx
@@ -17,12 +17,14 @@ type Props = {
   question: QuestionWithForecasts;
   authorUsername: string;
   curationStatus: PostStatus;
+  hideCP?: boolean;
 };
 
 const QuestionChartTile: FC<Props> = ({
   question,
   authorUsername,
   curationStatus,
+  hideCP,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -58,6 +60,7 @@ const QuestionChartTile: FC<Props> = ({
           question={question}
           curationStatus={curationStatus}
           defaultChartZoom={defaultChartZoom}
+          hideCP={hideCP}
         />
       );
     case QuestionType.MultipleChoice: {
@@ -78,6 +81,7 @@ const QuestionChartTile: FC<Props> = ({
           defaultChartZoom={defaultChartZoom}
           question={question}
           userForecasts={userForecasts}
+          hideCP={hideCP}
         />
       );
     }

--- a/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
@@ -15,12 +15,14 @@ type Props = {
   question: QuestionWithNumericForecasts;
   curationStatus: PostStatus;
   defaultChartZoom?: TimelineChartZoomOption;
+  hideCP?: boolean;
 };
 
 const QuestionNumericTile: FC<Props> = ({
   question,
   curationStatus,
   defaultChartZoom,
+  hideCP,
 }) => {
   const latest = question.aggregations.recency_weighted.latest;
   const prediction = latest?.centers![0];
@@ -51,6 +53,7 @@ const QuestionNumericTile: FC<Props> = ({
           prediction={prediction}
           status={curationStatus}
           showUserForecast
+          hideCP={hideCP}
         />
       </div>
       <div className="my-1 h-24 w-2/3 min-w-24 max-w-[500px] flex-1 overflow-visible">
@@ -72,6 +75,7 @@ const QuestionNumericTile: FC<Props> = ({
             defaultZoom={defaultChartZoom}
             resolution={question.resolution}
             resolveTime={question.actual_resolve_time}
+            hideCP={hideCP}
           />
         ) : (
           <ContinuousAreaChart
@@ -80,6 +84,7 @@ const QuestionNumericTile: FC<Props> = ({
             height={HEIGHT}
             questionType={question.type}
             resolution={question.resolution}
+            hideCP={hideCP}
           />
         )}
       </div>

--- a/front_end/src/components/prediction_chip.tsx
+++ b/front_end/src/components/prediction_chip.tsx
@@ -21,6 +21,7 @@ type Props = {
   chipClassName?: string;
   unresovledChipStyle?: CSSProperties;
   showUserForecast?: boolean;
+  hideCP?: boolean;
 };
 
 const PredictionChip: FC<Props> = ({
@@ -32,6 +33,7 @@ const PredictionChip: FC<Props> = ({
   unresovledChipStyle,
   size,
   showUserForecast,
+  hideCP,
 }) => {
   const t = useTranslations();
   const locale = useLocale();
@@ -121,6 +123,24 @@ const PredictionChip: FC<Props> = ({
         </span>
       );
     default:
+      if (hideCP) {
+        return (
+          <span className={classNames("inline-flex flex-col", className)}>
+            {showUserForecast && !!question.my_forecasts?.history.length && (
+              <p className="m-2 text-base text-orange-800 dark:text-orange-800-dark">
+                <FontAwesomeIcon icon={faUser} className="mr-1" />
+                {getDisplayUserValue(
+                  question.my_forecasts,
+                  lastUserForecast.centers![0],
+                  lastUserForecast.start_time,
+                  question.type,
+                  question.scaling
+                )}
+              </p>
+            )}
+          </span>
+        );
+      }
       return (
         <span className={classNames("inline-flex flex-col", className)}>
           <Chip

--- a/front_end/src/components/ui/progress_bar.tsx
+++ b/front_end/src/components/ui/progress_bar.tsx
@@ -7,6 +7,7 @@ type Props = {
   disabled?: boolean;
   renderLabel?: (value: number | null) => ReactNode;
   progressColor?: string;
+  hideCP?: boolean;
 };
 
 const ProgressBar: FC<Props> = ({
@@ -15,6 +16,7 @@ const ProgressBar: FC<Props> = ({
   renderLabel,
   disabled = false,
   progressColor,
+  hideCP,
 }) => {
   return (
     <div className="BinaryPredictionBar relative h-5">
@@ -30,7 +32,7 @@ const ProgressBar: FC<Props> = ({
           {renderLabel ? renderLabel(value) : <span>{value}</span>}
         </div>
       </div>
-      {value !== null && (
+      {value !== null && !hideCP && (
         <div
           className={classNames(
             "BinaryPredictionBar-outer absolute left-0 top-0 h-5 overflow-hidden text-gray-0 dark:text-gray-0-dark",


### PR DESCRIPTION
- fixed rendering of charts with only user predictions on the feed page question cards
- adjusted chart rendering on the question page when CP is hidden
- updated the forecast maker to render CP correctly across all question types
- fixed a bug where CP wasn't rendering for resolved group questions in the forecast maker
- refactored the 'Reveal Temporarily' functionality to display CP on both the chart and forecast maker
- tested chart rendering after changes, ensuring proper behavior with both hidden and visible CP across the project