### PR TITLE
Updating prediction market section of FAQ

### DIFF
--- a/front_end/src/app/(main)/faq/page.tsx
+++ b/front_end/src/app/(main)/faq/page.tsx
@@ -510,7 +510,7 @@ export default function FAQ() {
         </p>
         <p>
           Question Series still show leaderboards, for interest and fun. However
-          they do **not** award medals.
+          they do <b>not</b> award medals.
         </p>
         <p>
           You can find all Question Series in a special section of the{" "}
@@ -521,30 +521,36 @@ export default function FAQ() {
           Is Metaculus a prediction market?
         </h3>
         <p>
-          Sort of. Like a prediction market, Metaculus aims to aggregate many
-          people&apos;s information, expertise, and predictive power into
-          high-quality forecasts. However, prediction markets generally operate
-          using real or virtual currency, which is used to buy and sell shares
-          in &quot;event occurrence.&quot; The idea is that people buy (or sell)
-          shares if they think that the standing prices reflect too low (or
-          high) a probability in that event. Metaculus, in contrast, directly
-          solicits predicted probabilities from its users, then aggregates those
-          probabilities. We believe that this sort of &quot;prediction
-          aggregator&quot; has both advantages and disadvantages relative to a
-          prediction market.
+          Metaculus has some similarities to a prediction market, but ultimately is not one. Metaculus aims to aggregate many people's information, expertise, and predictive power into high-quality forecasts. However, prediction markets generally operate using real or virtual currency, where participants buy (or sell) shares if they think that the standing prices reflect too low (or high) a probability of an event occurring. Metaculus, in contrast, directly solicits predicted probabilities from its users, then aggregates those probabilities. We believe that this sort of "prediction aggregator" has both advantages and disadvantages relative to a prediction market.
         </p>
 
         <h4 className="text-lg font-semibold">
           Advantages of Metaculus over prediction markets
         </h4>
         <p>
-          Metaculus has several advantages over prediction markets. One is that
-          Metaculus forecasts are scored solely based on accuracy, while
-          prediction markets may be used for other reasons, such as hedging.
-          This means that sometimes prediction markets may be distorted from the
-          true probability by bettors who wish to mitigate their downside risk
-          if an event occurs.
+          Metaculus has several advantages over prediction markets, described below, but we want to preface this by saying that despite the potential issues with prediction markets that we describe here, we think prediction markets are valuable, are glad they exist, and would be glad to see more use of them.
         </p>
+
+        <ol className="mb-4 ml-4 list-inside list-decimal space-y-2">
+          <li>
+            <b>Poor incentives for longer term forecasts.</b> It's usually not a good use of your funds to lock them up in a prediction market for the long term, since you can usually get much better returns by investing, which means longer term markets are likely to have low liquidity. For an example see <a href="https://wip.gatspress.com/wp-content/uploads/2024/05/thu9F-cumulative-traded-volume-on-the-2020-us-election-4-1024x897.png">this plot</a> from a <a href="https://worksinprogress.co/issue/why-prediction-markets-arent-popular/">Works in Progress article</a> showing the trading volume on Betfair for the 2020 US presidential election. There was very little volume far in advance of the election, with most of the trading volume occurring only a month out from the election.
+          </li>
+          <li>
+            <b>Problems with low probabilities.</b> Prediction markets have market frictions that make them less useful for low probabilities. The return on using your money to bring a probability from 2% to 1% is negligible, or potentially negative if the prediction market extract a fee from traders. That's why you get weird results like Michelle Obama at 6% chance of becoming the Democratic nominee for the 2024 US presidential election in June of 2024, as was the case <a href="https://polymarket.com/event/democratic-nominee-2024?tid=1724174308005">on Polymarket</a>.
+          </li>
+          <li>
+            <b>The focus isn't always forecasting.</b> Prediction market incentives aren't always aligned with making the most accurate predictions. Consider that one potential use for prediction markets is hedging against risky outcomes. Additionally, people who are irrational but willing to put a ton of money behind their beliefs may skew the outcome. Sure, ideally a liquid market will correct for these skews, but it's possible that they could have an effect on the price. See <a href="https://asteriskmag.com/issues/05/prediction-markets-have-an-elections-problem-jeremiah-johnson">this piece in Asterisk Magazine</a> for more on "dumb money" in prediction markets.
+          </li>
+          <li>
+            <b>What do individuals think will happen?</b> Participants in prediction markets are expressing whether they think the probability is higher or lower than the market price, not making a forecast. If someone thinks the market is too low at 35% and bets accordingly, you don't know whether they think the true probability is 40% or 80%. This doesn't really impact the usefulness of the aggregate, but it does make the data less rich and informative, and harder to see the full distribution of forecasts like you can with the histograms for binary questions on Metaculus.
+          </li>
+          <li>
+            <b>Individual market performance is not always a clear indication of forecasting skill.</b> Excellent individual market performance might just signal proficiency at operating in markets, or ability to take advantage of bad bets made by others. For example, see <a href="https://www.cspicenter.com/p/salem-tournament-5-days-in#:~:text=The%20first%20problem%20we%20saw%20was%20that%20there%20were%20some%20individuals%20who%20made%20a%20killing%20by%20taking%20advantage%20of%20those%20who%20did%20not%20know%20how%20the%20markets%20work%20(see%20discussion%20here).">this post</a> about a tournament organized on Manifold where traders took a large early lead just due to intelligent use of limit orders. Since Metaculus elicits individual probabilities from every forecaster, we can better assess and recruit excellent forecasters.
+          </li>
+          <li>
+            <b>Metaculus performs comparably to markets without the need to manage a portfolio.</b> There are only a handful of apples-to-apples comparisons between platforms, but <a href="https://www.metaculus.com/notebooks/15359/predictive-performance-on-metaculus-vs-manifold-markets/">these</a> <a href="https://firstsigma.substack.com/p/midterm-elections-forecast-comparison-analysis">find</a> an <a href="https://www.astralcodexten.com/p/who-predicted-2023">advantage</a> for Metaculus over prediction markets. Note that sample sizes tend to be small. However, there is also an <a href="https://calibration.city/">indirect comparison</a> (indirect because it does not consider the same questions across platforms) which found that prediction markets are more calibrated.
+          </li>
+        </ol>
 
         <h3 className="scroll-mt-nav text-xl font-semibold" id="justpolling">
           Are Metaculus Questions Polls?


### PR DESCRIPTION
Seems like what's on prod currently didn't capture the latest state of the FAQ, see here: https://old.metaculus.com/help/faq/#predmarket

I think it's most likely just missing the prediction market section, can't think of anything else that was added recently, but haven't looked closely.