### PR TITLE
Regression: zoom picker is missing

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
@@ -12,11 +12,10 @@ import React, {
 import { VictoryThemeDefinition } from "victory";
 
 import MultiChoicesChartView from "@/app/(main)/questions/[id]/components/multi_choices_chart_view";
-import MultipleChoiceChart from "@/components/charts/multiple_choice_chart";
 import { useAuth } from "@/contexts/auth_context";
-import useChartTooltip from "@/hooks/use_chart_tooltip";
 import usePrevious from "@/hooks/use_previous";
 import useTimestampCursor from "@/hooks/use_timestamp_cursor";
+import { TimelineChartZoomOption } from "@/types/charts";
 import { ChoiceItem, ChoiceTooltipItem } from "@/types/choices";
 import {
   Question,
@@ -73,6 +72,7 @@ type Props = {
   withLegand?: boolean;
   chartHeight?: number;
   chartTheme?: VictoryThemeDefinition;
+  defaultZoom?: TimelineChartZoomOption;
   embedMode?: boolean;
 };
 
@@ -84,6 +84,7 @@ const ContinuousGroupTimeline: FC<Props> = ({
   actualCloseTime,
   withLegand = true,
   chartTheme,
+  defaultZoom,
   chartHeight,
   embedMode = false,
 }) => {
@@ -203,6 +204,7 @@ const ContinuousGroupTimeline: FC<Props> = ({
       embedMode={embedMode}
       chartHeight={chartHeight}
       withLegend={withLegand}
+      defaultZoom={defaultZoom}
     />
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
@@ -7,6 +7,7 @@ import MultiChoicesChartView from "@/app/(main)/questions/[id]/components/multi_
 import { useAuth } from "@/contexts/auth_context";
 import usePrevious from "@/hooks/use_previous";
 import useTimestampCursor from "@/hooks/use_timestamp_cursor";
+import { TimelineChartZoomOption } from "@/types/charts";
 import { ChoiceItem, ChoiceTooltipItem } from "@/types/choices";
 import { QuestionWithMultipleChoiceForecasts } from "@/types/question";
 import { generateChoiceItemsFromMultipleChoiceForecast } from "@/utils/charts";
@@ -24,6 +25,7 @@ type Props = {
   question: QuestionWithMultipleChoiceForecasts;
   embedMode?: boolean;
   chartHeight?: number;
+  defaultZoom?: TimelineChartZoomOption;
   chartTheme?: VictoryThemeDefinition;
 };
 
@@ -31,6 +33,7 @@ const MultipleChoiceChartCard: FC<Props> = ({
   question,
   embedMode = false,
   chartHeight,
+  defaultZoom,
   chartTheme,
 }) => {
   const t = useTranslations();
@@ -165,6 +168,7 @@ const MultipleChoiceChartCard: FC<Props> = ({
       chartTheme={chartTheme}
       embedMode={embedMode}
       chartHeight={chartHeight}
+      defaultZoom={defaultZoom}
     />
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/multi_choices_chart_view.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multi_choices_chart_view.tsx
@@ -6,6 +6,7 @@ import { VictoryThemeDefinition } from "victory";
 import ChoicesLegend from "@/app/(main)/questions/[id]/components/choices_legend";
 import ChoicesTooltip from "@/app/(main)/questions/[id]/components/choices_tooltip";
 import MultipleChoiceChart from "@/components/charts/multiple_choice_chart";
+import { useAuth } from "@/contexts/auth_context";
 import useChartTooltip from "@/hooks/use_chart_tooltip";
 import { TickFormat, TimelineChartZoomOption } from "@/types/charts";
 import { ChoiceItem, ChoiceTooltipItem, UserChoiceItem } from "@/types/choices";
@@ -57,12 +58,15 @@ const MultiChoicesChartView: FC<Props> = ({
   yLabel,
   questionType,
   scaling,
+  defaultZoom,
 
   withLegend = true,
   chartHeight,
   chartTheme,
   embedMode = false,
 }) => {
+  const { user } = useAuth();
+
   const [isChartReady, setIsChartReady] = useState(false);
   const handleChartReady = useCallback(() => {
     setIsChartReady(true);
@@ -116,6 +120,14 @@ const MultiChoicesChartView: FC<Props> = ({
           isClosed={isClosed}
           extraTheme={chartTheme}
           height={normalizedChartHeight}
+          withZoomPicker
+          defaultZoom={
+            defaultZoom
+              ? defaultZoom
+              : user
+                ? TimelineChartZoomOption.All
+                : TimelineChartZoomOption.TwoMonths
+          }
         />
       </div>
 

--- a/front_end/src/components/forecast_card.tsx
+++ b/front_end/src/components/forecast_card.tsx
@@ -113,6 +113,7 @@ const ForecastCard: FC<Props> = ({
                 }
                 chartHeight={chartHeight}
                 chartTheme={embedTheme?.chart}
+                defaultZoom={defaultChartZoom}
                 embedMode
               />
             );
@@ -216,6 +217,7 @@ const ForecastCard: FC<Props> = ({
               embedMode
               chartHeight={chartHeight}
               chartTheme={embedTheme?.chart}
+              defaultZoom={defaultChartZoom}
             />
           );
         default:


### PR DESCRIPTION
Fixed a regression with missing zoom picker on multi-option charts