### PR TITLE
Fan graphs are broken for binary groups

### DIFF
--- a/front_end/src/components/charts/primitives/chart_fan_tooltip.tsx
+++ b/front_end/src/components/charts/primitives/chart_fan_tooltip.tsx
@@ -1,9 +1,10 @@
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { ComponentProps, FC } from "react";
 import { VictoryLabel } from "victory";
 
 import { Quartiles, QuestionWithNumericForecasts } from "@/types/question";
 import { getDisplayValue } from "@/utils/charts";
+import { formatResolution } from "@/utils/questions";
 
 const HEIGHT = 70;
 
@@ -23,7 +24,7 @@ const ChartFanTooltip: FC<Props> = ({
   ...props
 }) => {
   const t = useTranslations();
-
+  const locale = useLocale();
   const { x, y, datum } = props;
   const option = datum?.xName;
 
@@ -38,6 +39,7 @@ const ChartFanTooltip: FC<Props> = ({
 
   const quartiles = items[option].quartiles;
   const question = items[option].question;
+  const resolved = !!question.resolution;
 
   const padding = 10;
   const position = y + padding + HEIGHT > chartHeight ? "top" : "bottom";
@@ -48,7 +50,7 @@ const ChartFanTooltip: FC<Props> = ({
         x={x - width / 2}
         y={position === "bottom" ? y + padding : y - HEIGHT}
         width={width}
-        height={HEIGHT}
+        height={resolved ? HEIGHT + 20 : HEIGHT}
       >
         <div className="flex flex-col rounded-sm border border-olive-700 bg-gray-0 p-1 dark:border-olive-700-dark dark:bg-gray-0-dark">
           <TooltipItem
@@ -75,6 +77,16 @@ const ChartFanTooltip: FC<Props> = ({
               question.scaling
             )}
           />
+          {resolved && (
+            <TooltipItem
+              label={t("resolution")}
+              value={formatResolution(
+                question.resolution,
+                question.type,
+                locale
+              )}
+            />
+          )}
         </div>
       </foreignObject>
     </g>
@@ -85,7 +97,7 @@ const TooltipItem: FC<{ label: string; value: string }> = ({
   label,
   value,
 }) => (
-  <div className="flex justify-between text-xs">
+  <div className="flex justify-between text-xs capitalize">
     <div>{label}</div>
     <div className="font-semibold text-olive-700 dark:text-olive-700-dark">
       {value}

--- a/front_end/src/types/post.ts
+++ b/front_end/src/types/post.ts
@@ -7,7 +7,13 @@ import { VoteDirection } from "@/types/votes";
 
 import { Tournament } from "./projects";
 
-export type Resolution = "yes" | "no" | number | string;
+export type Resolution =
+  | "yes"
+  | "no"
+  | "below_lower_bound"
+  | "above_upper_bound"
+  | number
+  | string;
 
 export enum PostForecastType {
   Conditional = "conditional",

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -688,17 +688,11 @@ export function getFanOptionsFromBinaryGroup(
       const resolved = q.resolution !== null;
       return {
         name: extractQuestionGroupName(q.title),
-        quartiles: resolved
-          ? {
-              median: q.resolution === "yes" ? 1 : 0,
-              lower25: aggregation?.interval_lower_bounds?.[0] ?? 0,
-              upper75: aggregation?.interval_upper_bounds?.[0] ?? 0,
-            }
-          : {
-              median: aggregation?.centers?.[0] ?? 0,
-              lower25: aggregation?.interval_lower_bounds?.[0] ?? 0,
-              upper75: aggregation?.interval_upper_bounds?.[0] ?? 0,
-            },
+        quartiles: {
+          median: aggregation?.centers?.[0] ?? 0,
+          lower25: aggregation?.interval_lower_bounds?.[0] ?? 0,
+          upper75: aggregation?.interval_upper_bounds?.[0] ?? 0,
+        },
         resolved,
         question: q,
         resolvedAt: new Date(q.scheduled_resolve_time),


### PR DESCRIPTION
- adjust render of resolution diamond for fan charts to keep prediction square
- add resolution value in the hover popup