### PR TITLE
No second click required to unresolve a question

### DIFF
--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -247,7 +247,7 @@
   "newUsernamePlaceholder": "new username",
   "confirm": "Confirm",
   "confirmUsernamePlaceholder": "confirm username",
-  "confirmAction": "Please confirm this action",
+  "confirmUnresolveQuestion": "Are you sure you want to unresolve this question?",
   "usernamesNotMatching": "usernames don't match",
   "projectContents": "Project Contents",
   "question": "Question",

--- a/front_end/src/components/confirm_modal.tsx
+++ b/front_end/src/components/confirm_modal.tsx
@@ -21,16 +21,16 @@ const ConfirmModal: FC<Props> = ({ isOpen, onClose, onConfirm }) => {
       isOpen={isOpen}
       onClose={onClose}
     >
-      <h4 className="mb-4 mt-0 text-center">{t("confirmAction")}</h4>
+      <h4 className="mb-4 mt-0 text-center">{t("confirmUnresolveQuestion")}</h4>
       <div className="flex justify-center">
         <Button
-          className="my-auto w-32"
+          className="my-auto w-32 capitalize"
           onClick={() => {
             onConfirm();
             onClose(isOpen);
           }}
         >
-          {t("confirm")}
+          {t("yes")}
         </Button>
       </div>
     </BaseModal>


### PR DESCRIPTION
- adjust text in unresolve confirmation modal