### PR TITLE
Multiple choice questions are showing the CP extending beyond the resolution in the feed

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_multiple_choice.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_multiple_choice.tsx
@@ -322,7 +322,8 @@ function generateChoiceOptions(
     const bCenter = latest?.forecast_values[b] ?? 0;
     return bCenter - aCenter;
   });
-  return choiceOrdering.map((order, index) => {
+
+  const choiceItems = choiceOrdering.map((order, index) => {
     return {
       name: question.options![order],
       color: MULTIPLE_CHOICE_COLOR_SCALE[index] ?? METAC_COLORS.gray["400"],
@@ -332,6 +333,14 @@ function generateChoiceOptions(
         : null,
     };
   });
+  const resolutionIndex = choiceOrdering.findIndex(
+    (order) => question.options![order] === question.resolution
+  );
+  if (resolutionIndex !== -1) {
+    const [resolutionItem] = choiceItems.splice(resolutionIndex, 1);
+    choiceItems.unshift(resolutionItem);
+  }
+  return choiceItems;
 }
 
 function getDefaultForecast(

--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -437,15 +437,7 @@ function buildChartData({
         if (resolution === choice) {
           // multiple choice case
           item.resolutionPoint = {
-            x: Math.min(
-              Math.max(
-                closeTime
-                  ? closeTime / 1000
-                  : actualTimestamps[actualTimestamps.length - 1],
-                actualTimestamps[actualTimestamps.length - 1]
-              ),
-              latestTimestamp
-            ),
+            x: closeTime ? closeTime / 1000 : latestTimestamp,
             y: rangeMax ?? 1,
           };
         }
@@ -465,6 +457,7 @@ function buildChartData({
             y: resolution === "no" ? rangeMin ?? 0 : rangeMax ?? 1,
           };
         }
+        // TODO: add resolution point for continuous group case
       }
       return item;
     }

--- a/front_end/src/components/multiple_choice_tile.tsx
+++ b/front_end/src/components/multiple_choice_tile.tsx
@@ -20,6 +20,7 @@ import { getChoiceOptionValue } from "@/utils/charts";
 
 type Props = {
   timestamps: number[];
+  actualCloseTime?: number | null;
   choices: ChoiceItem[];
   visibleChoicesCount: number;
   defaultChartZoom?: TimelineChartZoomOption;
@@ -34,6 +35,7 @@ type Props = {
 
 const MultipleChoiceTile: FC<Props> = ({
   timestamps,
+  actualCloseTime,
   choices,
   visibleChoicesCount,
   defaultChartZoom,
@@ -106,6 +108,7 @@ const MultipleChoiceTile: FC<Props> = ({
       {!isResolvedView && (
         <MultipleChoiceChart
           timestamps={timestamps}
+          actualCloseTime={actualCloseTime}
           choiceItems={hideCP ? [] : choices}
           height={chartHeight}
           extraTheme={chartTheme}

--- a/front_end/src/components/post_card/group_of_questions_tile/group_numeric_tile.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/group_numeric_tile.tsx
@@ -81,10 +81,14 @@ const GroupNumericTile: FC<Props> = ({
       activeCount: visibleChoicesCount,
       locale,
     });
+    const actualCloseTime = post.actual_close_time
+      ? new Date(post.actual_close_time).getTime()
+      : null;
     return (
       <MultipleChoiceTile
         choices={choices}
         timestamps={timestamps}
+        actualCloseTime={actualCloseTime}
         visibleChoicesCount={visibleChoicesCount}
         defaultChartZoom={
           user ? TimelineChartZoomOption.All : TimelineChartZoomOption.TwoMonths

--- a/front_end/src/components/post_card/question_chart_tile/index.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/index.tsx
@@ -70,7 +70,9 @@ const QuestionChartTile: FC<Props> = ({
         activeCount: visibleChoicesCount,
       });
       const userForecasts = generateUserForecastsForMultipleQuestion(question);
-
+      const actualCloseTime = question.actual_close_time
+        ? new Date(question.actual_close_time).getTime()
+        : null;
       return (
         <MultipleChoiceTile
           timestamps={question.aggregations.recency_weighted.history.map(
@@ -82,6 +84,7 @@ const QuestionChartTile: FC<Props> = ({
           question={question}
           userForecasts={userForecasts}
           hideCP={hideCP}
+          actualCloseTime={actualCloseTime}
         />
       );
     }

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -567,7 +567,7 @@ export function generateChoiceItemsFromMultipleChoiceForecast(
   });
 
   const history = question.aggregations.recency_weighted.history;
-  return choiceOrdering.map((order, index) => {
+  const choiceItems = choiceOrdering.map((order, index) => {
     const label = question.options![order];
     return {
       choice: label,
@@ -579,7 +579,6 @@ export function generateChoiceItemsFromMultipleChoiceForecast(
         (forecast) => forecast.interval_upper_bounds![order]
       ),
       color: MULTIPLE_CHOICE_COLOR_SCALE[index] ?? METAC_COLORS.gray["400"],
-      active: !!activeCount ? index <= activeCount - 1 : true,
       highlighted: false,
       resolution: question.resolution,
       displayedResolution: question.resolution
@@ -591,6 +590,17 @@ export function generateChoiceItemsFromMultipleChoiceForecast(
       rangeMax: 1,
     };
   });
+  const resolutionIndex = choiceOrdering.findIndex(
+    (order) => question.options![order] === question.resolution
+  );
+  if (resolutionIndex !== -1) {
+    const [resolutionItem] = choiceItems.splice(resolutionIndex, 1);
+    choiceItems.unshift(resolutionItem);
+  }
+  return choiceItems.map((item, index) => ({
+    ...item,
+    active: !!activeCount ? index < activeCount - 1 : true,
+  }));
 }
 
 export function generateChoiceItemsFromBinaryGroup(


### PR DESCRIPTION
* fixed charts for MC questions to render resolution point at correct timestamp
* adjusted render of resolved option for MC questions (move it on the first place in list)
* fixed bug with group question chart when it was rendered beyond the resolution date