### PR TITLE
Question group display issue (also impacting high visibility election hub)

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/choices_tooltip.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/choices_tooltip.tsx
@@ -48,7 +48,8 @@ const ChoicesTooltip: FC<Props> = ({ date, choices, userChoices }) => {
             <td className="px-1.5 py-1 text-right text-sm">{valueLabel}</td>
             {containUserChoices && (
               <td className="px-1.5 py-1 text-right text-sm">
-                {userChoices![idx].valueLabel}
+                {userChoices!.find((item) => item.choiceLabel === choiceLabel)
+                  ?.valueLabel || "?"}
               </td>
             )}
           </tr>

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -732,7 +732,7 @@ export function findPreviousTimestamp(
   timestamp: number
 ): number {
   return timestamps.reduce(
-    (prev, curr) => (curr < timestamp && curr > prev ? curr : prev),
+    (prev, curr) => (curr <= timestamp && curr > prev ? curr : prev),
     0
   );
 }


### PR DESCRIPTION
- add user prediction tooltip for continuous group questions
- fix mismatch in CP and UP tooltip
- adjusted timestamps and forecast values to avoid ? when they shouldn't render