### PR TITLE
Multiple choice questions are showing the CP extending beyond the resolution in the feed

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
@@ -25,6 +25,7 @@ import {
 import {
   findPreviousTimestamp,
   generateChoiceItemsFromBinaryGroup,
+  getContinuousGroupScaling,
   getDisplayValue,
 } from "@/utils/charts";
 import { generateUserForecasts } from "@/utils/questions";
@@ -197,32 +198,7 @@ const ContinuousGroupTimeline: FC<Props> = ({
     }
   }, []);
 
-  const zeroPoints: number[] = [];
-  questions.forEach((question) => {
-    if (question.scaling.zero_point !== null) {
-      zeroPoints.push(question.scaling.zero_point);
-    }
-  });
-  const scaling: Scaling = {
-    range_max: Math.max(
-      ...questions.map((question) => question.scaling.range_max!)
-    ),
-    range_min: Math.min(
-      ...questions.map((question) => question.scaling.range_min!)
-    ),
-    zero_point: zeroPoints.length > 0 ? Math.min(...zeroPoints) : null,
-  };
-  // we can have mixes of log and linear scaled options
-  // which leads to a derived zero point inside the range which is invalid
-  // so just igore the log scaling in this case
-  if (
-    scaling.zero_point !== null &&
-    scaling.range_min! <= scaling.zero_point &&
-    scaling.zero_point <= scaling.range_max!
-  ) {
-    scaling.zero_point = null;
-  }
-
+  const scaling = getContinuousGroupScaling(questions);
   return (
     <MultiChoicesChartView
       tooltipChoices={!!hideCP ? [] : tooltipChoices}

--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -442,8 +442,12 @@ function buildChartData({
           };
         }
 
-        if (resolution === "yes" || resolution === "no") {
-          // binary group case
+        if (
+          ["yes", "no", "below_lower_bound", "above_upper_bound"].includes(
+            resolution as string
+          )
+        ) {
+          // binary group and out of borders cases
           item.resolutionPoint = {
             x: Math.min(
               Math.max(
@@ -454,11 +458,30 @@ function buildChartData({
               ),
               latestTimestamp
             ),
-            y: resolution === "no" ? rangeMin ?? 0 : rangeMax ?? 1,
+            y:
+              resolution === "no" || resolution === "below_lower_bound" ? 0 : 1,
           };
         }
-        // TODO: add resolution point for continuous group case
+
+        if (isFinite(Number(resolution))) {
+          // continuous group case
+          item.resolutionPoint = {
+            x: Math.min(
+              Math.max(
+                closeTime
+                  ? closeTime / 1000
+                  : actualTimestamps[actualTimestamps.length - 1],
+                actualTimestamps[actualTimestamps.length - 1]
+              ),
+              latestTimestamp
+            ),
+            y: scaling
+              ? unscaleNominalLocation(Number(resolution), scaling)
+              : Number(resolution) ?? 0,
+          };
+        }
       }
+
       return item;
     }
   );

--- a/front_end/src/components/forecast_card.tsx
+++ b/front_end/src/components/forecast_card.tsx
@@ -107,8 +107,8 @@ const ForecastCard: FC<Props> = ({
                 questions={sortedQuestions}
                 timestamps={timestamps}
                 actualCloseTime={
-                  post.scheduled_close_time
-                    ? new Date(post.scheduled_close_time).getTime()
+                  post.actual_close_time
+                    ? new Date(post.actual_close_time).getTime()
                     : null
                 }
                 chartHeight={chartHeight}
@@ -148,6 +148,11 @@ const ForecastCard: FC<Props> = ({
               <BinaryGroupChart
                 questions={sortedQuestions}
                 timestamps={timestamps}
+                actualCloseTime={
+                  post.actual_close_time
+                    ? new Date(post.actual_close_time).getTime()
+                    : null
+                }
                 defaultZoom={defaultChartZoom}
                 chartHeight={chartHeight}
                 chartTheme={embedTheme?.chart}

--- a/front_end/src/components/multiple_choice_tile.tsx
+++ b/front_end/src/components/multiple_choice_tile.tsx
@@ -30,6 +30,7 @@ type Props = {
   userForecasts?: UserChoiceItem[];
   question?: Question;
   questionType?: QuestionType;
+  scaling?: Scaling | undefined;
   hideCP?: boolean;
 };
 
@@ -45,6 +46,7 @@ const MultipleChoiceTile: FC<Props> = ({
   userForecasts,
   question,
   questionType,
+  scaling,
   hideCP,
 }) => {
   const t = useTranslations();
@@ -115,6 +117,8 @@ const MultipleChoiceTile: FC<Props> = ({
           defaultZoom={defaultChartZoom}
           withZoomPicker={withZoomPicker}
           userForecasts={userForecasts}
+          questionType={questionType}
+          scaling={scaling}
         />
       )}
     </div>

--- a/front_end/src/components/post_card/group_of_questions_tile/group_numeric_tile.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/group_numeric_tile.tsx
@@ -13,6 +13,7 @@ import { PostStatus, PostWithForecasts } from "@/types/post";
 import { QuestionWithNumericForecasts } from "@/types/question";
 import {
   generateChoiceItemsFromBinaryGroup,
+  getContinuousGroupScaling,
   getGroupQuestionsTimestamps,
 } from "@/utils/charts";
 import {
@@ -38,6 +39,7 @@ const GroupNumericTile: FC<Props> = ({
 }) => {
   const { user } = useAuth();
   const locale = useLocale();
+  const scaling = getContinuousGroupScaling(questions);
 
   if (
     post.group_of_questions?.graph_type === GroupOfQuestionsGraphType.FanGraph
@@ -93,6 +95,7 @@ const GroupNumericTile: FC<Props> = ({
         defaultChartZoom={
           user ? TimelineChartZoomOption.All : TimelineChartZoomOption.TwoMonths
         }
+        scaling={scaling}
         userForecasts={
           user
             ? generateUserForecasts(

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -808,3 +808,34 @@ export function getTickLabelFontSize(actualTheme: VictoryThemeDefinition) {
     : actualTheme.axis?.style?.tickLabels?.fontSize;
   return fontSize as number;
 }
+
+export function getContinuousGroupScaling(
+  questions: QuestionWithNumericForecasts[]
+) {
+  const zeroPoints: number[] = [];
+  questions.forEach((question) => {
+    if (question.scaling.zero_point !== null) {
+      zeroPoints.push(question.scaling.zero_point);
+    }
+  });
+  const scaling: Scaling = {
+    range_max: Math.max(
+      ...questions.map((question) => question.scaling.range_max!)
+    ),
+    range_min: Math.min(
+      ...questions.map((question) => question.scaling.range_min!)
+    ),
+    zero_point: zeroPoints.length > 0 ? Math.min(...zeroPoints) : null,
+  };
+  // we can have mixes of log and linear scaled options
+  // which leads to a derived zero point inside the range which is invalid
+  // so just igore the log scaling in this case
+  if (
+    scaling.zero_point !== null &&
+    scaling.range_min! <= scaling.zero_point &&
+    scaling.zero_point <= scaling.range_max!
+  ) {
+    scaling.zero_point = null;
+  }
+  return scaling;
+}


### PR DESCRIPTION
- add resolution points
- adjust timestamps in embed cards
- fixed scaling and yAxis ticks on feed page