### PR TITLE
maybe fix #1222 - leaderboard links

### DIFF
--- a/front_end/src/app/(main)/(leaderboards)/contributions/components/project_contributions.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/contributions/components/project_contributions.tsx
@@ -59,7 +59,7 @@ const ProjectContributions: FC<Props> = async ({ project, userId }) => {
                 <td className="px-2 py-1 text-sm">
                   <Link
                     className="block no-underline"
-                    href={`/questions/${contribution.question_id}`}
+                    href={`/questions/${contribution.post_id}`}
                   >
                     {contribution.question_title}
                   </Link>


### PR DESCRIPTION
note that this is a 'sight read' based on the issue raised -- I don't know 100% that this is the fix and I **haven't tested it myself** because I can't load a tournament page locally without an openai api key