### PR TITLE
fix max validation and prefill resolution time

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/resolution/resolution_modal.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/resolution/resolution_modal.tsx
@@ -36,11 +36,7 @@ const QuestionResolutionModal: FC<Props> = ({ isOpen, onClose, question }) => {
   const [submitErrors, setSubmitErrors] = useState<ErrorResponse>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const currentDateTime = useMemo(
-    () =>
-      format(
-        new Date(new Date().getTime() + new Date().getTimezoneOffset() * 60000),
-        "yyyy-MM-dd'T'HH:mm:ss'Z'"
-      ),
+    () => format(new Date(), "yyyy-MM-dd'T'HH:mm"),
     []
   );
   const { open_lower_bound, open_upper_bound } = question;


### PR DESCRIPTION
While looking into https://github.com/Metaculus/metaculus/issues/1113 I found the following:

1. Looks like the max datetime validation (from `max={currentDateTime}`) wasn't working previously due to an issue with format of `currentDateTime`. 
2. The resolution time should already be prefilled by this
```python
defaultValues: {
        resolutionType: "",
        actualResolveTime: currentDateTime,
      },
 ```
 but isn't due to the same issue with the format of `currentDateTime`. This commit addresses both 1 and 2.
 

 before:
https://github.com/user-attachments/assets/c7f1f86f-ea49-4ee5-97b6-6d8fc0449de3

 
 after:
https://github.com/user-attachments/assets/7c79e243-b863-4bb2-a71d-c4d4d8ea9662

