### PR TITLE
Comment @ mentions don't work before some punctuation

### DIFF
--- a/front_end/src/utils/comments.ts
+++ b/front_end/src/utils/comments.ts
@@ -23,7 +23,7 @@ export function parseUserMentions(
   markdown: string,
   mentionedUsers?: AuthorType[]
 ): string {
-  const userTagPattern = /@\(([^)]+)\)|@([^\s]+)/g;
+  const userTagPattern = /@\(([^)]+)\)|@(\w+)/g;
 
   markdown = markdown.replace(userTagPattern, (match) => {
     const cleanedUsername = match.replace(/[@()\\]/g, "");


### PR DESCRIPTION
* updated `userTagPattern` regular expression to properly handle punctuation when mentioning a user