### PR TITLE
Fixed broken email images

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -15,7 +15,6 @@ jobs:
       HEROKU_APP: dev-metaculus-web
       NEXT_PUBLIC_APP_URL: "https://dev.metaculus.com"
       NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
-      NEXT_PUBLIC_CDN_DOMAIN_NAME: ${{ vars.NEXT_PUBLIC_CDN_DOMAIN_NAME }}
       NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 

--- a/.github/workflows/deploy_play.yml
+++ b/.github/workflows/deploy_play.yml
@@ -12,7 +12,6 @@ jobs:
       HEROKU_APP: play-metaculus-web
       NEXT_PUBLIC_APP_URL: "https://play.metaculus.com"
       NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
-      NEXT_PUBLIC_CDN_DOMAIN_NAME: ${{ vars.NEXT_PUBLIC_CDN_DOMAIN_NAME }}
       NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -12,7 +12,6 @@ jobs:
       HEROKU_APP: metaculus-web
       NEXT_PUBLIC_APP_URL: "https://www.metaculus.com"
       NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
-      NEXT_PUBLIC_CDN_DOMAIN_NAME: ${{ vars.NEXT_PUBLIC_CDN_DOMAIN_NAME }}
       NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 

--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
@@ -93,7 +93,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     openGraph: {
       type: "article",
       images: {
-        url: `${process.env.NEXT_PUBLIC_CDN_DOMAIN_NAME ?? ""}/api/posts/preview-image/${params.id}/`,
+        url: `/api/posts/preview-image/${params.id}/`,
         width: 1200,
         height: 630,
         alt: "community predictions",
@@ -103,7 +103,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       site: "@metaculus",
       card: "summary_large_image",
       images: {
-        url: `${process.env.NEXT_PUBLIC_CDN_DOMAIN_NAME ?? ""}/api/posts/preview-image/${params.id}/`,
+        url: `/api/posts/preview-image/${params.id}/`,
         width: 1200,
         height: 630,
         alt: "community predictions",

--- a/front_end/src/components/post_actions/share_post_menu.tsx
+++ b/front_end/src/components/post_actions/share_post_menu.tsx
@@ -58,7 +58,7 @@ export const SharePostMenu: FC<Props> = ({ questionTitle, questionId }) => {
               {
                 id: "image",
                 name: t("image"),
-                link: `${process.env.NEXT_PUBLIC_CDN_DOMAIN_NAME ?? ""}/api/posts/preview-image/${questionId}`,
+                link: `/api/posts/preview-image/${questionId}`,
                 openNewTab: true,
               },
             ]

--- a/metaculus_web/settings.py
+++ b/metaculus_web/settings.py
@@ -282,7 +282,6 @@ SCREENSHOT_SERVICE_API_KEY = os.environ.get("SCREENSHOT_SERVICE_API_KEY", "")
 SCREENSHOT_SERVICE_API_URL = os.environ.get(
     "SCREENSHOT_SERVICE_API_URL", "https://screenshot.metaculus.com/api/screenshot"
 )
-CDN_DOMAIN_NAME = os.environ.get("CDN_DOMAIN_NAME", "")
 
 # django-dramatiq
 # https://github.com/Bogdanp/django_dramatiq

--- a/utils/frontend.py
+++ b/utils/frontend.py
@@ -28,8 +28,7 @@ def build_question_graph_image_url(question_id: int):
 
 
 def build_question_graph_image_cdn_url(question_id: int):
-    cdn_domain_name = settings.CDN_DOMAIN_NAME.strip().rstrip("/")
-    return f"{cdn_domain_name}/api/posts/preview-image/{question_id}/"
+    return build_frontend_url(f"/api/posts/preview-image/{question_id}/")
 
 
 def build_question_embed_url(question_id: int):


### PR DESCRIPTION
Fixed broken email images by deprecating unused cloudfront cdn. It was replaced with Cloudflare endpoint caching rules