### PR TITLE
Feed rendering errors

### DIFF
--- a/front_end/src/components/markdown_editor/index.tsx
+++ b/front_end/src/components/markdown_editor/index.tsx
@@ -210,13 +210,18 @@ function escapePlainTextSymbols(str: string) {
     return "___HTML_TAG___";
   });
 
-  tempStr = tempStr.replace(/(?<!\\)</g, "\\<");
+  tempStr = tempStr.replace(/([^\\])</g, "$1\\<").replace(/^</g, "\\<");
 
   let index = 0;
   tempStr = tempStr.replace(/___HTML_TAG___/g, function () {
     return tags[index++];
   });
-  return tempStr.replace(/(?<!\\){(?![^}]*})/g, `\\{`);
+
+  tempStr = tempStr
+    .replace(/([^{]){(?![^}]*})/g, "$1\\{")
+    .replace(/^{(?![^}]*})/g, "\\{");
+
+  return tempStr;
 }
 
 export default dynamic(() => Promise.resolve(MarkdownEditor), {

--- a/front_end/src/components/post_card/error_boundary.tsx
+++ b/front_end/src/components/post_card/error_boundary.tsx
@@ -6,7 +6,7 @@ const Fallback: FC<FallbackProps> = ({ error }) => {
   return (
     <div className="text-center text-red-500 dark:text-red-500-dark">
       <p>An error has occurred when rendering the feed card.</p>
-      <pre> {error.message}</pre>
+      <pre className="whitespace-pre-wrap"> {error.message}</pre>
     </div>
   );
 };


### PR DESCRIPTION
- fixed `escapePlainTextSymbols` logic crashed markdown editor in IOS 16.3 or below