### PR TITLE
Issues with "Copy from" buttons on conditionals (P1)

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_continuous.tsx
@@ -142,11 +142,11 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
     }
 
     return {
-      label: `Copy from IF ${inactiveOption.name.toUpperCase()}`,
+      label: t("copyFromBranch", { branch: inactiveOption.name.toUpperCase() }),
       fromQuestionId: inactiveOption.id,
       toQuestionId: activeTableOption,
     };
-  }, [activeTableOption, questionOptions]);
+  }, [activeTableOption, questionOptions, t]);
 
   const copyForecast = useCallback(
     (fromQuestionId: number, toQuestionId: number) => {


### PR DESCRIPTION
- updated copy forecast button label for continuous group forecast maker
- “Copy from Child” issue will require BE update first. Left a comment on GitHub issue.