### PR TITLE
Group question timeline showing user's forecast incorrectly

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
@@ -153,7 +153,13 @@ const ContinuousGroupTimeline: FC<Props> = ({
         ? []
         : userForecasts?.map(
             (
-              { choice, values, color, timestamps: optionTimestamps },
+              {
+                choice,
+                values,
+                color,
+                timestamps: optionTimestamps,
+                unscaledValues,
+              },
               index
             ) => {
               return {
@@ -161,7 +167,7 @@ const ContinuousGroupTimeline: FC<Props> = ({
                 color,
                 valueLabel: getQuestionTooltipLabel({
                   timestamps: optionTimestamps ?? timestamps,
-                  values: values ?? [],
+                  values: unscaledValues ? unscaledValues : values ?? [],
                   cursorTimestamp,
                   question: questions[index],
                   isUserPrediction: true,

--- a/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
@@ -167,7 +167,7 @@ const ContinuousGroupTimeline: FC<Props> = ({
                 color,
                 valueLabel: getQuestionTooltipLabel({
                   timestamps: optionTimestamps ?? timestamps,
-                  values: unscaledValues ? unscaledValues : values ?? [],
+                  values: unscaledValues ?? values ?? [],
                   cursorTimestamp,
                   question: questions[index],
                   isUserPrediction: true,

--- a/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/continuous_group_timeline.tsx
@@ -106,7 +106,10 @@ const ContinuousGroupTimeline: FC<Props> = ({
   const [choiceItems, setChoiceItems] = useState<ChoiceItem[]>(
     generateList(questions, preselectedQuestionId)
   );
-  const userForecasts = user ? generateUserForecasts(questions) : undefined;
+  const scaling = getContinuousGroupScaling(questions);
+  const userForecasts = user
+    ? generateUserForecasts(questions, scaling)
+    : undefined;
   const timestampsCount = timestamps.length;
   const prevTimestampsCount = usePrevious(timestampsCount);
   // sync BE driven data with local state
@@ -198,7 +201,6 @@ const ContinuousGroupTimeline: FC<Props> = ({
     }
   }, []);
 
-  const scaling = getContinuousGroupScaling(questions);
   return (
     <MultiChoicesChartView
       tooltipChoices={!!hideCP ? [] : tooltipChoices}

--- a/front_end/src/components/post_card/group_of_questions_tile/group_numeric_tile.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/group_numeric_tile.tsx
@@ -102,7 +102,8 @@ const GroupNumericTile: FC<Props> = ({
         userForecasts={
           user
             ? generateUserForecasts(
-                sortedQuestions as QuestionWithNumericForecasts[]
+                sortedQuestions as QuestionWithNumericForecasts[],
+                scaling
               )
             : undefined
         }

--- a/front_end/src/types/choices.ts
+++ b/front_end/src/types/choices.ts
@@ -25,6 +25,7 @@ export type UserChoiceItem = {
   timestamps?: number[];
   values?: number[];
   color: ThemeColor;
+  unscaledValues?: number[];
 };
 
 export type ChoiceTooltipItem = {

--- a/front_end/src/types/choices.ts
+++ b/front_end/src/types/choices.ts
@@ -25,7 +25,7 @@ export type UserChoiceItem = {
   timestamps?: number[];
   values?: number[];
   color: ThemeColor;
-  unscaledValues?: number[];
+  unscaledValues?: number[]; // This array is needed to display the correct value for the continuous group in the chart tooltip
 };
 
 export type ChoiceTooltipItem = {

--- a/front_end/src/utils/questions.ts
+++ b/front_end/src/utils/questions.ts
@@ -21,7 +21,9 @@ import {
   QuestionType,
   QuestionWithMultipleChoiceForecasts,
   QuestionWithNumericForecasts,
+  Scaling,
 } from "@/types/question";
+import { scaleInternalLocation, unscaleNominalLocation } from "@/utils/charts";
 import { abbreviatedNumber } from "@/utils/number_formatters";
 
 import { formatDate } from "./date_formatters";
@@ -274,16 +276,23 @@ export const generateUserForecastsForMultipleQuestion = (
 };
 
 export const generateUserForecasts = (
-  questions: QuestionWithNumericForecasts[]
+  questions: QuestionWithNumericForecasts[],
+  scaling?: Scaling
 ): UserChoiceItem[] => {
   return questions.map((question, index) => {
     const userForecasts = question.my_forecasts;
+
     return {
       choice: extractQuestionGroupName(question.title),
       values: userForecasts?.history.map((forecast) =>
         question.type === "binary"
           ? forecast.forecast_values[1]
-          : forecast.centers![0]
+          : scaling
+            ? unscaleNominalLocation(
+                scaleInternalLocation(forecast.centers![0], question.scaling),
+                scaling
+              )
+            : forecast.centers![0]
       ),
       timestamps: userForecasts?.history.map((forecast) => forecast.start_time),
       color: MULTIPLE_CHOICE_COLOR_SCALE[index] ?? METAC_COLORS.gray["400"],

--- a/front_end/src/utils/questions.ts
+++ b/front_end/src/utils/questions.ts
@@ -296,6 +296,11 @@ export const generateUserForecasts = (
       ),
       timestamps: userForecasts?.history.map((forecast) => forecast.start_time),
       color: MULTIPLE_CHOICE_COLOR_SCALE[index] ?? METAC_COLORS.gray["400"],
+      unscaledValues: userForecasts?.history.map((forecast) =>
+        question.type === "binary"
+          ? forecast.forecast_values[1]
+          : forecast.centers![0]
+      ),
     };
   });
 };


### PR DESCRIPTION
- fixed scaling of user prediction for continuous group question
- the issue was because of scaling mismatch between CP line and user prediction - to fix that I scaled user prediction with subquetion scaling and then unscaled it with general question scaling
- adjusted `UserChoiceItem` keep unscaled value to show correct data in chart tooltip