### PR TITLE
Make PDF/CDF dropdown a toggle instead

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -67,6 +67,8 @@
   "predictionLabel": "Predikce",
   "pdfLabel": "Hustota pravděpodobnosti",
   "cdfLabel": "Kumulativní pravděpodobnost",
+  "pdf": "PDF",
+  "cdf": "CDF",
   "recencyWeighted": "Váženo o nedávnost",
   "unweighted": "Neváženo",
   "metaculus": "Metaculus",

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -83,6 +83,8 @@
   "predictionLabel": "Prediction",
   "pdfLabel": "Probability Density",
   "cdfLabel": "Cumulative Probability",
+  "pdf": "PDF",
+  "cdf": "CDF",
   "recencyWeighted": "Recency weighted",
   "unweighted": "Unweighted",
   "metaculus": "Metaculus",

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -67,6 +67,8 @@
   "predictionLabel": "Predicción",
   "pdfLabel": "Densidad de Probabilidad",
   "cdfLabel": "Probabilidad Acumulada",
+  "pdf": "PDF",
+  "cdf": "CDF",
   "recencyWeighted": "Peso reciente",
   "unweighted": "Sin peso",
   "metaculus": "Metaculus",

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -77,6 +77,8 @@
   "predictionLabel": "Previsão",
   "pdfLabel": "Densidade de Probabilidade",
   "cdfLabel": "Probabilidade Cumulativa",
+  "pdf": "PDF",
+  "cdf": "CDF",
   "recencyWeighted": "Ponderado por Recência",
   "unweighted": "Não Ponderado",
   "metaculus": "Metaculus",

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -65,6 +65,8 @@
   "predictionLabel": "預測",
   "pdfLabel": "概率密度",
   "cdfLabel": "累積概率",
+  "pdf": "PDF",
+  "cdf": "CDF",
   "recencyWeighted": "最近加權",
   "unweighted": "未加權",
   "metaculus": "Metaculus",

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { faClose } from "@fortawesome/free-solid-svg-icons";
+import { faCircleQuestion } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
 import { isNil } from "lodash";
@@ -12,6 +13,7 @@ import MultiSlider, {
 import Slider from "@/components/sliders/slider";
 import Checkbox from "@/components/ui/checkbox";
 import Switch from "@/components/ui/switch";
+import Tooltip from "@/components/ui/tooltip";
 import { useAuth } from "@/contexts/auth_context";
 import { ContinuousAreaGraphType } from "@/types/charts";
 import { QuestionWithNumericForecasts } from "@/types/question";
@@ -75,9 +77,22 @@ const ContinuousSlider: FC<Props> = ({
           >
             {t("cdf")}
           </p>
+          <Tooltip
+            showDelayMs={200}
+            placement={"bottom"}
+            tooltipContent="PDF (Probability Density Function) shows how likely different outcomes are around specific values, while CDF (Cumulative Distribution Function) shows the cumulative probability of outcomes up to a certain value."
+            className=""
+            tooltipClassName="text-center !max-w-[331px] !border-blue-400 dark:!border-blue-400-dark bg-gray-0 dark:bg-gray-0-dark !text-base !p-4"
+          >
+            <FontAwesomeIcon
+              icon={faCircleQuestion}
+              height={16}
+              className="text-gray-500 hover:text-blue-800 dark:text-gray-500-dark dark:hover:text-blue-800-dark"
+            />
+          </Tooltip>
         </div>
         {previousForecast && (
-          <div className="ml-auto mr-auto mt-1 flex items-center md:mr-0">
+          <div className="ml-auto mr-auto mt-1 flex items-center md:mr-[-4px]">
             <Checkbox
               checked={overlayPreviousForecast}
               onChange={(checked) => setOverlayPreviousForecast(checked)}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { faClose } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import classNames from "classnames";
 import { isNil } from "lodash";
 import { useTranslations } from "next-intl";
 import { FC, useState } from "react";
@@ -10,7 +11,7 @@ import MultiSlider, {
 } from "@/components/sliders/multi_slider";
 import Slider from "@/components/sliders/slider";
 import Checkbox from "@/components/ui/checkbox";
-import InlineSelect from "@/components/ui/inline_select";
+import Switch from "@/components/ui/switch";
 import { useAuth } from "@/contexts/auth_context";
 import { ContinuousAreaGraphType } from "@/types/charts";
 import { QuestionWithNumericForecasts } from "@/types/question";
@@ -49,25 +50,40 @@ const ContinuousSlider: FC<Props> = ({
   const previousForecast = question.my_forecasts?.latest;
 
   return (
-    <div>
-      <div className="mb-2 flex items-center">
-        <InlineSelect<ContinuousAreaGraphType>
-          options={[
-            { label: t("pdfLabel"), value: "pmf" },
-            { label: t("cdfLabel"), value: "cdf" },
-          ]}
-          defaultValue={graphType}
-          className="appearance-none border-none !p-0 text-sm"
-          onChange={(e) =>
-            setGraphType(e.target.value as ContinuousAreaGraphType)
-          }
-        />
+    <div className="mr-0 mt-[-36px] flex flex-col sm:mr-2 md:mt-[-28px]">
+      <div className="flex flex-col items-center gap-2">
+        <div className="flex w-fit flex-row items-center gap-2 self-end">
+          <p
+            className={classNames(
+              "m-0 text-sm",
+              graphType === "cdf" ? "opacity-60" : "opacity-90"
+            )}
+            title="probability density function"
+          >
+            {t("pdf")}
+          </p>
+          <Switch
+            checked={graphType === "cdf"}
+            onChange={(checked) => setGraphType(checked ? "cdf" : "pmf")}
+          />
+          <p
+            className={classNames(
+              "m-0 text-sm",
+              graphType === "cdf" ? "opacity-90" : "opacity-60"
+            )}
+            title="cumulative density function"
+          >
+            {t("cdf")}
+          </p>
+        </div>
         {previousForecast && (
-          <div className="ml-auto flex items-center">
+          <div className="ml-auto mr-auto mt-1 flex items-center md:mr-0">
             <Checkbox
               checked={overlayPreviousForecast}
               onChange={(checked) => setOverlayPreviousForecast(checked)}
-              className={"text-sm"}
+              className={
+                "flex flex-row gap-2 text-sm text-gray-700 dark:text-gray-700-dark md:flex-row-reverse "
+              }
               label={
                 !!previousForecast.end_time
                   ? t("overlayMostRecentForecast")
@@ -77,7 +93,6 @@ const ContinuousSlider: FC<Props> = ({
           </div>
         )}
       </div>
-
       <ContinuousPredictionChart
         dataset={dataset}
         graphType={graphType}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
@@ -2,7 +2,6 @@
 import { faClose } from "@fortawesome/free-solid-svg-icons";
 import { faCircleQuestion } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import cn from "@/utils/cn";
 import { isNil } from "lodash";
 import { useTranslations } from "next-intl";
 import { FC, useState } from "react";
@@ -17,6 +16,7 @@ import Tooltip from "@/components/ui/tooltip";
 import { useAuth } from "@/contexts/auth_context";
 import { ContinuousAreaGraphType } from "@/types/charts";
 import { QuestionWithNumericForecasts } from "@/types/question";
+import cn from "@/utils/cn";
 
 import ContinuousPredictionChart from "./continuous_prediction_chart";
 import { useHideCP } from "../cp_provider";

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
@@ -51,8 +51,18 @@ const ContinuousSlider: FC<Props> = ({
   const [graphType, setGraphType] = useState<ContinuousAreaGraphType>("pmf");
   const previousForecast = question.my_forecasts?.latest;
 
+  const isGroupQuestion = question.label !== "";
+  const isConditionalQuestion =
+    question.title.includes("(No)") || question.title.includes("(Yes)");
+  const shouldHaveMargins = !isGroupQuestion && !isConditionalQuestion;
+
   return (
-    <div className="mr-0 mt-[-36px] flex flex-col sm:mr-2 md:mt-[-28px]">
+    <div
+      className={classNames(
+        "mr-0 flex flex-col sm:mr-2",
+        shouldHaveMargins ? "mt-[-36px] md:mt-[-28px]" : ""
+      )}
+    >
       <div className="flex flex-col items-center gap-2">
         <div className="flex w-fit flex-row items-center gap-2 self-end">
           <p

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
@@ -2,7 +2,7 @@
 import { faClose } from "@fortawesome/free-solid-svg-icons";
 import { faCircleQuestion } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import classNames from "classnames";
+import cn from "@/utils/cn";
 import { isNil } from "lodash";
 import { useTranslations } from "next-intl";
 import { FC, useState } from "react";
@@ -51,22 +51,12 @@ const ContinuousSlider: FC<Props> = ({
   const [graphType, setGraphType] = useState<ContinuousAreaGraphType>("pmf");
   const previousForecast = question.my_forecasts?.latest;
 
-  const isGroupQuestion = question.label !== "";
-  const isConditionalQuestion =
-    question.title.includes("(No)") || question.title.includes("(Yes)");
-  const shouldHaveMargins = !isGroupQuestion && !isConditionalQuestion;
-
   return (
-    <div
-      className={classNames(
-        "mr-0 flex flex-col sm:mr-2",
-        shouldHaveMargins ? "mt-[-36px] md:mt-[-28px]" : ""
-      )}
-    >
+    <div className="mr-0 flex flex-col sm:mr-2">
       <div className="flex flex-col items-center gap-2">
         <div className="flex w-fit flex-row items-center gap-2 self-end">
           <p
-            className={classNames(
+            className={cn(
               "m-0 text-sm",
               graphType === "cdf" ? "opacity-60" : "opacity-90"
             )}
@@ -79,7 +69,7 @@ const ContinuousSlider: FC<Props> = ({
             onChange={(checked) => setGraphType(checked ? "cdf" : "pmf")}
           />
           <p
-            className={classNames(
+            className={cn(
               "m-0 text-sm",
               graphType === "cdf" ? "opacity-90" : "opacity-60"
             )}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
@@ -154,20 +154,22 @@ const ForecastMakerContinuous: FC<Props> = ({
   );
   return (
     <>
-      <ContinuousSlider
-        forecast={forecast}
-        weights={weights}
-        dataset={dataset}
-        onChange={(forecast, weight) => {
-          setForecast(forecast);
-          setWeights(weight);
-          setIsDirty(true);
-        }}
-        overlayPreviousForecast={overlayPreviousForecast}
-        setOverlayPreviousForecast={setOverlayPreviousForecast}
-        question={question}
-        disabled={!canPredict}
-      />
+      <div className="mt-[-36px] md:mt-[-28px]">
+        <ContinuousSlider
+          forecast={forecast}
+          weights={weights}
+          dataset={dataset}
+          onChange={(forecast, weight) => {
+            setForecast(forecast);
+            setWeights(weight);
+            setIsDirty(true);
+          }}
+          overlayPreviousForecast={overlayPreviousForecast}
+          setOverlayPreviousForecast={setOverlayPreviousForecast}
+          question={question}
+          disabled={!canPredict}
+        />
+      </div>
 
       {canPredict && (
         <>

--- a/front_end/src/components/ui/switch.tsx
+++ b/front_end/src/components/ui/switch.tsx
@@ -1,6 +1,7 @@
 import { Switch as HeadlessSwitch, SwitchProps } from "@headlessui/react";
-import cn from "@/utils/cn";
 import React, { FC } from "react";
+
+import cn from "@/utils/cn";
 
 const Switch: FC<SwitchProps> = ({ className, ...props }) => {
   return (

--- a/front_end/src/components/ui/switch.tsx
+++ b/front_end/src/components/ui/switch.tsx
@@ -1,12 +1,12 @@
 import { Switch as HeadlessSwitch, SwitchProps } from "@headlessui/react";
-import classNames from "classnames";
+import cn from "@/utils/cn";
 import React, { FC } from "react";
 
 const Switch: FC<SwitchProps> = ({ className, ...props }) => {
   return (
     <HeadlessSwitch
       {...props}
-      className={classNames(
+      className={cn(
         "group inline-flex h-6 w-11 items-center rounded-full bg-gray-400 transition data-[checked]:bg-blue-700 dark:bg-gray-400-dark dark:data-[checked]:bg-blue-700-dark",
         className
       )}

--- a/front_end/src/components/ui/switch.tsx
+++ b/front_end/src/components/ui/switch.tsx
@@ -1,18 +1,17 @@
 import { Switch as HeadlessSwitch, SwitchProps } from "@headlessui/react";
+import classNames from "classnames";
 import React, { FC } from "react";
-
-import cn from "@/utils/cn";
 
 const Switch: FC<SwitchProps> = ({ className, ...props }) => {
   return (
     <HeadlessSwitch
       {...props}
-      className={cn(
-        "group inline-flex h-6 w-11 items-center rounded-full bg-gray-300 transition data-[checked]:bg-blue-600",
+      className={classNames(
+        "group inline-flex h-6 w-11 items-center rounded-full bg-gray-400 transition data-[checked]:bg-blue-700 dark:bg-gray-400-dark dark:data-[checked]:bg-blue-700-dark",
         className
       )}
     >
-      <span className="size-4 translate-x-1 rounded-full bg-white transition group-data-[checked]:translate-x-6" />
+      <span className="size-4 translate-x-1 rounded-full bg-blue-100 transition group-data-[checked]:translate-x-6 dark:bg-blue-100-dark" />
     </HeadlessSwitch>
   );
 };


### PR DESCRIPTION
For https://github.com/Metaculus/metaculus/issues/479

Looks like after this issue was created the dropdown was updated to include both items. I used the label "Cumulative Distribution Function" as requested in the issue description - let me know if "Cumulative Probability" is preferred.

I also added an opacity effect on the labels to match the current setting because I think it looks nice.

before:
![toggle_before](https://github.com/user-attachments/assets/b5ce84c3-31b9-463b-a5b2-afa5f28118c4)


after:
https://github.com/user-attachments/assets/94c3332f-74b0-4287-bf80-2db2e75c02fa
