### PR TITLE
Allow reaffirming predictions

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -3,6 +3,7 @@
   "newsletterFormDescription": "Přihlašte se k odběru novinek z platformy Metaculus, zajímavých forecastingových reportů a pozvánek na akce.",
   "predict": "Predikovat",
   "saveChange": "Uložit změny",
+  "reaffirm": "Potvrzení",
   "rescalePrediction": "Automatický součet na 100 %",
   "signUpToPredict": "Predikujte s námi",
   "logIn": "Přihlaste se",

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -3,6 +3,7 @@
   "newsletterFormDescription": "Sign up for Metaculus news, special forecasting reports, and event invitations.",
   "predict": "Predict",
   "saveChange": "Save Change",
+  "reaffirm": "Reaffirm",
   "rescalePrediction": "Auto-sum to 100%",
   "signUpToPredict": "Sign Up to Predict",
   "logIn": "Log in",

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -3,6 +3,7 @@
   "newsletterFormDescription": "Suscríbete para recibir noticias de Metaculus, informes especiales de pronósticos e invitaciones a eventos.",
   "predict": "Predecir",
   "saveChange": "Guardar Cambios",
+  "reaffirm": "Reafirmar",
   "rescalePrediction": "Auto-sumar al 100%",
   "signUpToPredict": "Regístrate para Predecir",
   "logIn": "Iniciar sesión",

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -3,6 +3,7 @@
   "newsletterFormDescription": "訂閱 Metaculus 新聞，特別的預測報告和活動邀請。",
   "predict": "預測",
   "saveChange": "保存更改",
+  "reaffirm": "再确认",
   "rescalePrediction": "自動加總至 100%",
   "signUpToPredict": "註冊預測",
   "logIn": "登入",

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
@@ -8,7 +8,6 @@ import { createForecasts } from "@/app/(main)/questions/actions";
 import Button from "@/components/ui/button";
 import { FormErrorMessage } from "@/components/ui/form_field";
 import { useAuth } from "@/contexts/auth_context";
-import { useModal } from "@/contexts/modal_context";
 import { ErrorResponse } from "@/types/fetch";
 import { Post, PostConditional } from "@/types/post";
 import {
@@ -23,6 +22,7 @@ import BinarySlider, { BINARY_FORECAST_PRECISION } from "../binary_slider";
 import ConditionalForecastTable, {
   ConditionalTableOption,
 } from "../conditional_forecast_table";
+import PredictButton from "../predict_button";
 import ScoreDisplay from "../resolution/score_display";
 
 type Props = {
@@ -49,10 +49,10 @@ const ForecastMakerConditionalBinary: FC<Props> = ({
   const t = useTranslations();
   const { user } = useAuth();
   const { hideCP } = useHideCP();
-  const { setCurrentModal } = useModal();
 
   const prevYesForecastValue = extractPrevBinaryForecastValue(prevYesForecast);
   const prevNoForecastValue = extractPrevBinaryForecastValue(prevNoForecast);
+  const hasUserForecast = !!prevYesForecastValue || !!prevNoForecastValue;
 
   const { condition, condition_child, question_yes, question_no } = conditional;
   const questionYesId = question_yes.id;
@@ -96,13 +96,9 @@ const ForecastMakerConditionalBinary: FC<Props> = ({
     [questionOptions]
   );
   const questionsToSubmit = useMemo(
-    () =>
-      questionOptions.filter(
-        (option) => option.isDirty && option.value !== null
-      ),
+    () => questionOptions.filter((option) => option.value !== null),
     [questionOptions]
   );
-  const submitIsAllowed = !isSubmitting && !!questionsToSubmit.length;
 
   const copyForecastButton = useMemo(() => {
     if (!activeTableOption) return null;
@@ -283,51 +279,46 @@ const ForecastMakerConditionalBinary: FC<Props> = ({
             {t(predictionMessage)}
           </div>
         )}
-        {canPredict &&
-          (user ? (
-            <>
-              <Button
-                variant="secondary"
-                type="reset"
-                onClick={
-                  copyForecastButton
-                    ? () =>
-                        copyForecast(
-                          copyForecastButton.fromQuestionId,
-                          copyForecastButton.toQuestionId
-                        )
-                    : undefined
-                }
-                disabled={!copyForecastButton}
-              >
-                {copyForecastButton?.label ?? "Copy from Child"}
-              </Button>
-              <Button
-                variant="secondary"
-                type="reset"
-                onClick={resetForecasts}
-                disabled={!isPickerDirty}
-              >
-                {t("discardChangesButton")}
-              </Button>
-              <Button
-                variant="primary"
-                type="submit"
-                onClick={handlePredictSubmit}
-                disabled={!submitIsAllowed}
-              >
-                {t("saveChange")}
-              </Button>
-            </>
-          ) : (
-            <Button
-              variant="primary"
-              type="button"
-              onClick={() => setCurrentModal({ type: "signup" })}
-            >
-              {t("signUpToPredict")}
-            </Button>
-          ))}
+        {canPredict && (
+          <>
+            {!!user && (
+              <>
+                <Button
+                  variant="secondary"
+                  type="reset"
+                  onClick={
+                    copyForecastButton
+                      ? () =>
+                          copyForecast(
+                            copyForecastButton.fromQuestionId,
+                            copyForecastButton.toQuestionId
+                          )
+                      : undefined
+                  }
+                  disabled={!copyForecastButton}
+                >
+                  {copyForecastButton?.label ?? "Copy from Child"}
+                </Button>
+                <Button
+                  variant="secondary"
+                  type="reset"
+                  onClick={resetForecasts}
+                  disabled={!isPickerDirty}
+                >
+                  {t("discardChangesButton")}
+                </Button>
+              </>
+            )}
+
+            <PredictButton
+              onSubmit={handlePredictSubmit}
+              isDirty={isPickerDirty}
+              hasUserForecast={hasUserForecast}
+              isPending={isSubmitting}
+              isDisabled={!questionsToSubmit.length}
+            />
+          </>
+        )}
       </div>
       {submitErrors.map((errResponse, index) => (
         <FormErrorMessage

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_continuous.tsx
@@ -8,7 +8,6 @@ import { MultiSliderValue } from "@/components/sliders/multi_slider";
 import Button from "@/components/ui/button";
 import { FormErrorMessage } from "@/components/ui/form_field";
 import { useAuth } from "@/contexts/auth_context";
-import { useModal } from "@/contexts/modal_context";
 import { ErrorResponse } from "@/types/fetch";
 import { Post, PostConditional } from "@/types/post";
 import {
@@ -30,6 +29,7 @@ import ConditionalForecastTable, {
 } from "../conditional_forecast_table";
 import ContinuousSlider from "../continuous_slider";
 import NumericForecastTable from "../numeric_table";
+import PredictButton from "../predict_button";
 import ScoreDisplay from "../resolution/score_display";
 
 type Props = {
@@ -56,7 +56,6 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
   const t = useTranslations();
   const { user } = useAuth();
   const { hideCP } = useHideCP();
-  const { setCurrentModal } = useModal();
 
   const { condition, condition_child, question_yes, question_no } = conditional;
   const questionYesId = question_yes.id;
@@ -64,6 +63,8 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
 
   const prevYesForecastValue = extractPrevNumericForecastValue(prevYesForecast);
   const prevNoForecastValue = extractPrevNumericForecastValue(prevNoForecast);
+  const hasUserForecast =
+    !!prevYesForecastValue.forecast || !!prevNoForecastValue.forecast;
 
   const [questionOptions, setQuestionOptions] = useState<
     Array<
@@ -122,13 +123,9 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
     [questionOptions]
   );
   const questionsToSubmit = useMemo(
-    () =>
-      questionOptions.filter(
-        (option) => option.isDirty && option.value !== null
-      ),
+    () => questionOptions.filter((option) => option.value !== null),
     [questionOptions]
   );
-  const submitIsAllowed = !isSubmitting && !!questionsToSubmit.length;
 
   const copyForecastButton = useMemo(() => {
     if (!activeTableOption) return null;
@@ -384,7 +381,7 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
       )}
       {canPredict && (
         <div className="my-5 flex flex-wrap items-center justify-center gap-3 px-4">
-          {user ? (
+          {!!user && (
             <>
               <Button
                 variant="secondary"
@@ -419,24 +416,15 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
               >
                 {t("discardChangesButton")}
               </Button>
-              <Button
-                variant="primary"
-                type="submit"
-                onClick={handlePredictSubmit}
-                disabled={!submitIsAllowed}
-              >
-                {t("saveChange")}
-              </Button>
             </>
-          ) : (
-            <Button
-              variant="primary"
-              type="button"
-              onClick={() => setCurrentModal({ type: "signup" })}
-            >
-              {t("signUpToPredict")}
-            </Button>
           )}
+          <PredictButton
+            onSubmit={handlePredictSubmit}
+            isDirty={isPickerDirty}
+            hasUserForecast={hasUserForecast}
+            isPending={isSubmitting}
+            isDisabled={!questionsToSubmit.length}
+          />
         </div>
       )}
       {submitErrors.map((errResponse, index) => (

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
@@ -20,7 +20,6 @@ import { FormErrorMessage } from "@/components/ui/form_field";
 import LoadingIndicator from "@/components/ui/loading_indicator";
 import { METAC_COLORS, MULTIPLE_CHOICE_COLOR_SCALE } from "@/constants/colors";
 import { useAuth } from "@/contexts/auth_context";
-import { useModal } from "@/contexts/modal_context";
 import { useServerAction } from "@/hooks/use_server_action";
 import { ErrorResponse } from "@/types/fetch";
 import {
@@ -47,6 +46,7 @@ import {
   BINARY_MIN_VALUE,
 } from "../binary_slider";
 import ForecastChoiceOption from "../forecast_choice_option";
+import PredictButton from "../predict_button";
 import ScoreDisplay from "../resolution/score_display";
 
 type QuestionOption = {
@@ -81,7 +81,6 @@ const ForecastMakerGroupBinary: FC<Props> = ({
   const { hideCP } = useHideCP();
   const params = useSearchParams();
   const subQuestionId = Number(params.get(SLUG_POST_SUB_QUESTION_ID));
-  const { setCurrentModal } = useModal();
 
   const { id: postId, user_permission: permission } = post;
 
@@ -97,6 +96,10 @@ const ForecastMakerGroupBinary: FC<Props> = ({
         {}
       ),
     [questions]
+  );
+  const hasUserForecast = useMemo(
+    () => Object.values(prevForecastValuesMap).some((v) => v !== null),
+    [prevForecastValuesMap]
   );
   const [questionOptions, setQuestionOptions] = useState<QuestionOption[]>(
     generateChoiceOptions(questions, prevForecastValuesMap, undefined, post)
@@ -129,10 +132,7 @@ const ForecastMakerGroupBinary: FC<Props> = ({
 
   const [submitErrors, setSubmitErrors] = useState<ErrorResponse[]>([]);
   const questionsToSubmit = useMemo(
-    () =>
-      questionOptions.filter(
-        (option) => option.isDirty && option.forecast !== null
-      ),
+    () => questionOptions.filter((option) => option.forecast !== null),
     [questionOptions]
   );
 
@@ -201,7 +201,6 @@ const ForecastMakerGroupBinary: FC<Props> = ({
     }
   }, [postId, questionsToSubmit]);
   const [submit, isPending] = useServerAction(handlePredictSubmit);
-  const submitIsAllowed = !isPending && !!questionsToSubmit.length;
   return (
     <>
       <table className="mt-3 border-separate rounded border border-gray-300 bg-gray-0 dark:border-gray-300-dark dark:bg-gray-0-dark">
@@ -275,34 +274,24 @@ const ForecastMakerGroupBinary: FC<Props> = ({
       {canPredict && (
         <>
           <div className="mt-5 flex flex-wrap items-center justify-center gap-3 px-4">
-            {user ? (
-              <>
-                <Button
-                  variant="secondary"
-                  type="reset"
-                  onClick={resetForecasts}
-                  disabled={!isPickerDirty}
-                >
-                  {t("discardChangesButton")}
-                </Button>
-                <Button
-                  variant="primary"
-                  type="submit"
-                  onClick={submit}
-                  disabled={!submitIsAllowed}
-                >
-                  {t("saveChange")}
-                </Button>
-              </>
-            ) : (
+            {!!user && (
               <Button
-                variant="primary"
-                type="button"
-                onClick={() => setCurrentModal({ type: "signup" })}
+                variant="secondary"
+                type="reset"
+                onClick={resetForecasts}
+                disabled={!isPickerDirty}
               >
-                {t("signUpToPredict")}
+                {t("discardChangesButton")}
               </Button>
             )}
+
+            <PredictButton
+              onSubmit={submit}
+              isDirty={isPickerDirty}
+              hasUserForecast={hasUserForecast}
+              isPending={isPending}
+              isDisabled={!questionsToSubmit.length}
+            />
           </div>
           {submitErrors.map((errResponse, index) => (
             <FormErrorMessage

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
@@ -3,6 +3,7 @@ import { faEllipsis } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
 import { differenceInMilliseconds } from "date-fns";
+import { isNil } from "lodash";
 import { useSearchParams } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import React, { FC, useCallback, useEffect, useMemo, useState } from "react";
@@ -12,7 +13,6 @@ import { MultiSliderValue } from "@/components/sliders/multi_slider";
 import Button from "@/components/ui/button";
 import { FormErrorMessage } from "@/components/ui/form_field";
 import { useAuth } from "@/contexts/auth_context";
-import { useModal } from "@/contexts/modal_context";
 import { ErrorResponse } from "@/types/fetch";
 import {
   Post,
@@ -43,6 +43,7 @@ import GroupForecastTable, {
   ConditionalTableOption,
 } from "../group_forecast_table";
 import NumericForecastTable from "../numeric_table";
+import PredictButton from "../predict_button";
 import ScoreDisplay from "../resolution/score_display";
 
 type Props = {
@@ -65,7 +66,6 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
   const { user } = useAuth();
   const { hideCP } = useHideCP();
   const params = useSearchParams();
-  const { setCurrentModal } = useModal();
   const subQuestionId = Number(params.get(SLUG_POST_SUB_QUESTION_ID));
 
   const { id: postId, user_permission: permission } = post;
@@ -85,6 +85,14 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
       ),
     [questions]
   );
+  const hasUserForecast = useMemo(() => {
+    const forecastsByQuestions = Object.values(prevForecastValuesMap);
+
+    return (
+      !!forecastsByQuestions.length &&
+      forecastsByQuestions.some((v) => !isNil(v.forecast))
+    );
+  }, [prevForecastValuesMap]);
 
   const [groupOptions, setGroupOptions] = useState<ConditionalTableOption[]>(
     generateGroupOptions(questions, prevForecastValuesMap, undefined, post)
@@ -109,13 +117,9 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitErrors, setSubmitErrors] = useState<ErrorResponse[]>([]);
   const questionsToSubmit = useMemo(
-    () =>
-      groupOptions.filter(
-        (option) => option.isDirty && option.userForecast !== null
-      ),
+    () => groupOptions.filter((option) => option.userForecast !== null),
     [groupOptions]
   );
-  const submitIsAllowed = !isSubmitting && !!questionsToSubmit.length;
   const isPickerDirty = useMemo(
     () => groupOptions.some((option) => option.isDirty),
     [groupOptions]
@@ -159,7 +163,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
       prev.map((prevChoice) => {
         if (prevChoice.id === optionId) {
           const newUserForecast = [
-            ...prevChoice.userForecast,
+            ...getNormalizedUserForecast(prevChoice.userForecast),
             { left: 0.4, center: 0.5, right: 0.6 },
           ];
           const newWeights = [...prevChoice.userWeights, 1];
@@ -223,7 +227,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
           questionId: question.id,
           forecastData: {
             continuousCdf: getNumericForecastDataset(
-              userForecast,
+              getNormalizedUserForecast(userForecast),
               userWeights,
               question.open_lower_bound!,
               question.open_upper_bound!
@@ -232,7 +236,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
             probabilityYes: null,
           },
           sliderValues: {
-            forecast: userForecast,
+            forecast: getNormalizedUserForecast(userForecast),
             weights: userWeights,
           },
         };
@@ -257,7 +261,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
   const userCdf: number[] | undefined =
     activeGroupOption &&
     getNumericForecastDataset(
-      activeGroupOption?.userForecast,
+      getNormalizedUserForecast(activeGroupOption.userForecast),
       activeGroupOption?.userWeights,
       activeGroupOption?.question.open_lower_bound!,
       activeGroupOption?.question.open_upper_bound!
@@ -276,8 +280,12 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
         showCP={!user || !hideCP}
       />
       {groupOptions.map((option) => {
+        const normalizedUserForecast = getNormalizedUserForecast(
+          option.userForecast
+        );
+
         const dataset = getNumericForecastDataset(
-          option.userForecast,
+          normalizedUserForecast,
           option.userWeights,
           option.question.open_lower_bound!,
           option.question.open_upper_bound!
@@ -293,7 +301,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
           >
             <ContinuousSlider
               question={option.question}
-              forecast={option.userForecast}
+              forecast={normalizedUserForecast}
               weights={option.userWeights}
               dataset={dataset}
               onChange={(forecast, weight) =>
@@ -314,42 +322,36 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
       {!!activeGroupOption &&
         activeGroupOption.question.status == QuestionStatus.OPEN && (
           <div className="my-5 flex flex-wrap items-center justify-center gap-3 px-4">
-            {canPredict &&
-              (user ? (
-                <>
-                  <Button
-                    variant="secondary"
-                    type="reset"
-                    onClick={() => handleAddComponent(activeGroupOption.id)}
-                  >
-                    {t("addComponentButton")}
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    type="reset"
-                    onClick={handleResetForecasts}
-                    disabled={!isPickerDirty}
-                  >
-                    {t("discardChangesButton")}
-                  </Button>
-                  <Button
-                    variant="primary"
-                    type="submit"
-                    onClick={handlePredictSubmit}
-                    disabled={!submitIsAllowed}
-                  >
-                    {t("saveChange")}
-                  </Button>
-                </>
-              ) : (
-                <Button
-                  variant="primary"
-                  type="button"
-                  onClick={() => setCurrentModal({ type: "signup" })}
-                >
-                  {t("signUpToPredict")}
-                </Button>
-              ))}
+            {canPredict && (
+              <>
+                {!!user && (
+                  <>
+                    <Button
+                      variant="secondary"
+                      type="reset"
+                      onClick={() => handleAddComponent(activeGroupOption.id)}
+                    >
+                      {t("addComponentButton")}
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      type="reset"
+                      onClick={handleResetForecasts}
+                      disabled={!isPickerDirty}
+                    >
+                      {t("discardChangesButton")}
+                    </Button>
+                  </>
+                )}
+                <PredictButton
+                  onSubmit={handlePredictSubmit}
+                  isDirty={isPickerDirty}
+                  hasUserForecast={hasUserForecast}
+                  isPending={isSubmitting}
+                  isDisabled={!questionsToSubmit.length}
+                />
+              </>
+            )}
           </div>
         )}
       {submitErrors.map((errResponse, index) => (
@@ -497,6 +499,10 @@ function getUserQuartiles(
 }
 
 function getSliderValue(forecast?: MultiSliderValue[]) {
+  return forecast ?? null;
+}
+
+function getNormalizedUserForecast(forecast: MultiSliderValue[] | null) {
   return (
     forecast ?? [
       {

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
@@ -4,11 +4,9 @@ import { useTranslations } from "next-intl";
 import React, { FC, useEffect, useState } from "react";
 
 import { createForecasts } from "@/app/(main)/questions/actions";
-import Button from "@/components/ui/button";
 import { FormErrorMessage } from "@/components/ui/form_field";
 import LoadingIndicator from "@/components/ui/loading_indicator";
 import { useAuth } from "@/contexts/auth_context";
-import { useModal } from "@/contexts/modal_context";
 import { useServerAction } from "@/hooks/use_server_action";
 import { ErrorResponse } from "@/types/fetch";
 import { PostWithForecasts, ProjectPermissions } from "@/types/post";
@@ -21,6 +19,7 @@ import { extractPrevBinaryForecastValue } from "@/utils/forecasts";
 import { sendGAPredictEvent } from "./ga_events";
 import { useHideCP } from "../../cp_provider";
 import BinarySlider, { BINARY_FORECAST_PRECISION } from "../binary_slider";
+import PredictButton from "../predict_button";
 import QuestionResolutionButton from "../resolution";
 import QuestionUnresolveButton from "../resolution/unresolve_button";
 
@@ -45,12 +44,12 @@ const ForecastMakerBinary: FC<Props> = ({
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
-  const { setCurrentModal } = useModal();
   const { hideCP } = useHideCP();
   const communityForecast =
     question.aggregations.recency_weighted.latest?.centers![0];
 
   const prevForecastValue = extractPrevBinaryForecastValue(prevForecast);
+  const hasUserForecast = !!prevForecastValue;
   const [forecast, setForecast] = useState<number | null>(prevForecastValue);
 
   const [isForecastDirty, setIsForecastDirty] = useState(false);
@@ -63,11 +62,6 @@ const ForecastMakerBinary: FC<Props> = ({
 
   const handlePredictSubmit = async () => {
     setSubmitError(undefined);
-
-    if (!user) {
-      setCurrentModal({ type: "signup" });
-      return;
-    }
 
     if (forecast === null) return;
 
@@ -111,13 +105,13 @@ const ForecastMakerBinary: FC<Props> = ({
       <div className="flex flex-col items-center justify-center">
         {canPredict && (
           <>
-            <Button
-              variant="primary"
-              disabled={!!user && (!isForecastDirty || isPending)}
-              onClick={submit}
-            >
-              {user ? t("predict") : t("signUpToPredict")}
-            </Button>
+            <PredictButton
+              hasUserForecast={hasUserForecast}
+              isDirty={isForecastDirty}
+              isPending={isPending}
+              onSubmit={submit}
+              predictLabel={t("predict")}
+            />
             <FormErrorMessage
               className="mt-2 flex justify-center"
               errors={submitError}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_multiple_choice.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_multiple_choice.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { faUserGroup } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { round } from "lodash";
+import { isNil, round } from "lodash";
 import { useTranslations } from "next-intl";
 import React, { FC, useCallback, useMemo, useState } from "react";
 
@@ -11,7 +11,6 @@ import { FormErrorMessage } from "@/components/ui/form_field";
 import LoadingIndicator from "@/components/ui/loading_indicator";
 import { METAC_COLORS, MULTIPLE_CHOICE_COLOR_SCALE } from "@/constants/colors";
 import { useAuth } from "@/contexts/auth_context";
-import { useModal } from "@/contexts/modal_context";
 import { useServerAction } from "@/hooks/use_server_action";
 import { ErrorResponse } from "@/types/fetch";
 import { PostWithForecasts, ProjectPermissions } from "@/types/post";
@@ -32,6 +31,7 @@ import {
   BINARY_MIN_VALUE,
 } from "../binary_slider";
 import ForecastChoiceOption from "../forecast_choice_option";
+import PredictButton from "../predict_button";
 import QuestionResolutionButton from "../resolution";
 import QuestionUnresolveButton from "../resolution/unresolve_button";
 
@@ -62,13 +62,25 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
   const t = useTranslations();
   const { user } = useAuth();
   const { hideCP } = useHideCP();
-  const { setCurrentModal } = useModal();
+
+  const choiceOrdering = useMemo(() => {
+    const latest = question.aggregations.recency_weighted.latest;
+    const choiceOrdering: number[] = question.options!.map((_, i) => i);
+    choiceOrdering.sort((a, b) => {
+      const aCenter = latest?.forecast_values[a] ?? 0;
+      const bCenter = latest?.forecast_values[b] ?? 0;
+      return bCenter - aCenter;
+    });
+
+    return choiceOrdering;
+  }, [question.aggregations.recency_weighted.latest, question.options]);
 
   const [isDirty, setIsDirty] = useState(false);
   const [choicesForecasts, setChoicesForecasts] = useState<ChoiceOption[]>(
     generateChoiceOptions(
       question,
       question.aggregations.recency_weighted,
+      choiceOrdering,
       question.my_forecasts ?? { history: [] }
     )
   );
@@ -93,12 +105,20 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
   const resetForecasts = useCallback(() => {
     setIsDirty(false);
     setChoicesForecasts((prev) =>
-      prev.map((prevChoice, i) => ({
-        ...prevChoice,
-        forecast: question.my_forecasts?.latest?.forecast_values[i] ?? null,
-      }))
+      choiceOrdering.map((order, index) => {
+        const choiceOption = prev[index];
+        const userForecast =
+          question.my_forecasts?.latest?.forecast_values[order] ?? null;
+
+        return {
+          ...choiceOption,
+          forecast: !isNil(userForecast)
+            ? Math.round(userForecast * 1000) / 10
+            : null,
+        };
+      })
     );
-  }, [question.my_forecasts?.latest?.forecast_values]);
+  }, [choiceOrdering, question.my_forecasts?.latest?.forecast_values]);
   const handleForecastChange = useCallback(
     (choice: string, value: number) => {
       setIsDirty(true);
@@ -163,11 +183,6 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
   const handlePredictSubmit = async () => {
     setSubmitError(undefined);
 
-    if (!user) {
-      setCurrentModal({ type: "signup" });
-      return;
-    }
-
     if (!isForecastValid) return;
 
     const forecastValue: Record<string, number> = {};
@@ -194,7 +209,6 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
     }
   };
   const [submit, isPending] = useServerAction(handlePredictSubmit);
-  const submitIsAllowed = !isPending && isDirty && isForecastValid;
   return (
     <>
       <table className="border-separate rounded border border-gray-300 bg-gray-0 dark:border-gray-300-dark dark:bg-gray-0-dark">
@@ -283,14 +297,13 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
             >
               {t("discardChangesButton")}
             </Button>
-            <Button
-              variant="primary"
-              type="submit"
-              disabled={!submitIsAllowed}
-              onClick={submit}
-            >
-              {user ? t("saveChange") : t("signUpToPredict")}
-            </Button>
+            <PredictButton
+              onSubmit={submit}
+              isDirty={isDirty}
+              hasUserForecast={forecastHasValues}
+              isPending={isPending}
+              isDisabled={!isForecastValid}
+            />
           </div>
         )}
       </div>
@@ -316,15 +329,10 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
 function generateChoiceOptions(
   question: Question,
   aggregate: AggregateForecastHistory,
+  choiceOrdering: number[],
   my_forecasts: UserForecastHistory
 ): ChoiceOption[] {
   const latest = aggregate.latest;
-  const choiceOrdering: number[] = question.options!.map((_, i) => i);
-  choiceOrdering.sort((a, b) => {
-    const aCenter = latest?.forecast_values[a] ?? 0;
-    const bCenter = latest?.forecast_values[b] ?? 0;
-    return bCenter - aCenter;
-  });
 
   const choiceItems = choiceOrdering.map((order, index) => {
     return {
@@ -344,14 +352,6 @@ function generateChoiceOptions(
     choiceItems.unshift(resolutionItem);
   }
   return choiceItems;
-}
-
-function getDefaultForecast(
-  option: string,
-  defaultForecasts: Record<string, number> | null
-) {
-  const defaultForecast = defaultForecasts?.[option];
-  return defaultForecast ? round(defaultForecast * 100, 1) : null;
 }
 
 function sumForecasts(choiceOptions: ChoiceOption[]) {

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/group_forecast_table.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/group_forecast_table.tsx
@@ -26,7 +26,7 @@ export type ConditionalTableOption = {
   id: number;
   name: string;
   question: QuestionWithNumericForecasts;
-  userForecast: MultiSliderValue[];
+  userForecast: MultiSliderValue[] | null;
   userWeights: number[];
   userQuartiles: Quartiles | null;
   communityQuartiles: Quartiles;

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/predict_button.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/predict_button.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { useTranslations } from "next-intl";
+import React, { FC, useMemo } from "react";
+
+import Button from "@/components/ui/button";
+import { useAuth } from "@/contexts/auth_context";
+import { useModal } from "@/contexts/modal_context";
+
+type Props = {
+  predictLabel?: string;
+  onSubmit: () => void;
+  isDirty: boolean;
+  hasUserForecast: boolean;
+  isPending: boolean;
+  isDisabled?: boolean;
+};
+
+const PredictButton: FC<Props> = ({
+  predictLabel,
+  hasUserForecast,
+  isPending,
+  isDirty,
+  onSubmit,
+  isDisabled,
+}) => {
+  const { user } = useAuth();
+  const { setCurrentModal } = useModal();
+  const t = useTranslations();
+
+  const disabled = useMemo(() => {
+    if (!user) {
+      return false;
+    }
+
+    if (isDisabled) {
+      return true;
+    }
+
+    if (isPending) {
+      return true;
+    }
+
+    if (hasUserForecast) {
+      return false;
+    }
+
+    return !isDirty;
+  }, [hasUserForecast, isDirty, isDisabled, isPending, user]);
+  const buttonLabel = useMemo(() => {
+    if (!user) {
+      return t("signUpToPredict");
+    }
+
+    if (hasUserForecast && !isDirty) {
+      return t("reaffirm");
+    }
+
+    return predictLabel ?? t("saveChange");
+  }, [hasUserForecast, isDirty, predictLabel, t, user]);
+
+  const handleClick = () => {
+    if (!user) {
+      setCurrentModal({ type: "signup" });
+      return;
+    }
+
+    onSubmit();
+  };
+
+  return (
+    <Button
+      variant="primary"
+      type="submit"
+      disabled={disabled}
+      onClick={handleClick}
+    >
+      {buttonLabel}
+    </Button>
+  );
+};
+
+export default PredictButton;


### PR DESCRIPTION
* finalized `PredictButton` component for handling all the edge cases on disabled state and display label
* integrated `PredictButton` into forecast makers for regular questions (continuous, binary, multiple choices)
* integrated `PredictButton` into conditional forecast makers
* integrated `PredictButton` into group forecast makers
* bonus: noticed and fixed wrong value scaling and options order on forecast maker for multiple-choice questions after using the “Reset” button