### PR TITLE
fix regex backwards matching

### DIFF
--- a/front_end/src/utils/comments.ts
+++ b/front_end/src/utils/comments.ts
@@ -23,11 +23,24 @@ export function parseUserMentions(
   markdown: string,
   mentionedUsers?: AuthorType[]
 ): string {
-  const userTagPattern = /(?<!\[[^\]]*)@(\(([^)]+)\)|(\w+))/g;
+  const userTagPattern = /@(\(([^)]+)\)|(\w+))/g;
+
+  function isInsideSquareBrackets(index: number) {
+    let insideBrackets = false;
+    for (let i = 0; i < index; i++) {
+      if (markdown[i] === "[") insideBrackets = true;
+      if (markdown[i] === "]") insideBrackets = false;
+    }
+    return insideBrackets;
+  }
 
   markdown = markdown.replace(
     userTagPattern,
-    (match, _group1, group2, group3) => {
+    (match, _group1, group2, group3, offset) => {
+      if (isInsideSquareBrackets(offset)) {
+        return match;
+      }
+
       const cleanedUsername = (group2 || group3).replace(/[@()]/g, "");
       switch (cleanedUsername) {
         case "moderators":


### PR DESCRIPTION
The previous pattern relied on negative lookbehind. This isn't supported by some browsers - especially older ones.

This removes the lookbehind and only does forward matching. The cost is that we have to iteratively match to takes that need to be placed into brackets.