### PR TITLE
Add on-platform question edit field for 'Include Community Prediction on Date x'

### DIFF
--- a/posts/serializers.py
+++ b/posts/serializers.py
@@ -17,6 +17,7 @@ from projects.serializers.common import (
 from questions.models import Question, AggregateForecast
 from questions.serializers import (
     QuestionWriteSerializer,
+    QuestionUpdateSerializer,
     serialize_question,
     serialize_conditional,
     serialize_group,
@@ -174,6 +175,7 @@ class PostWriteSerializer(serializers.ModelSerializer):
 
 
 class PostUpdateSerializer(PostWriteSerializer):
+    question = QuestionUpdateSerializer(required=False)
     group_of_questions = GroupOfQuestionsUpdateSerializer(required=False)
 
 


### PR DESCRIPTION
- added input fields for cp reveal time and open time in question editing form
- adjusted conditional validation for new fields based on post status
- being debugging the issue when submitting new values has no effect: seems to be BE issue. Editing these fields on the group form works fine