### PR TITLE
Add on-platform question edit field for 'Include Community Prediction on Date x'

### DIFF
--- a/front_end/src/app/(main)/questions/components/question_form.tsx
+++ b/front_end/src/app/(main)/questions/components/question_form.tsx
@@ -399,7 +399,6 @@ const QuestionForm: FC<Props> = ({
         <div className="flex w-full flex-col gap-4 md:flex-row">
           <InputContainer labelText={t("closingDate")} className="w-full gap-2">
             <Input
-              readOnly={hasForecasts && mode !== "create"}
               type="datetime-local"
               className="w-full rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
               {...control.register("scheduled_close_time", {
@@ -427,7 +426,6 @@ const QuestionForm: FC<Props> = ({
             className="w-full gap-2"
           >
             <Input
-              readOnly={hasForecasts && mode !== "create"}
               type="datetime-local"
               className="w-full rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
               {...control.register("scheduled_resolve_time", {
@@ -455,7 +453,6 @@ const QuestionForm: FC<Props> = ({
           <div className="flex w-full flex-col gap-4 md:flex-row">
             <InputContainer labelText={t("openTime")} className="w-full gap-2">
               <Input
-                readOnly={hasForecasts}
                 type="datetime-local"
                 className="w-full rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
                 {...control.register("open_time", {
@@ -483,7 +480,6 @@ const QuestionForm: FC<Props> = ({
               className="w-full gap-2"
             >
               <Input
-                readOnly={hasForecasts}
                 type="datetime-local"
                 className="w-full rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
                 {...control.register("cp_reveal_time", {


### PR DESCRIPTION
This PR is a follow-up on @lsabor's [comment](https://github.com/Metaculus/metaculus/pull/1329#issuecomment-2465487210), which removes read-only behaviour for Closing Date, Resolving Date, Open Time, and CP Reveal Time inputs when there is an existing CP.