### PR TITLE
Store subquestion labels separate field

### DIFF
--- a/front_end/src/app/(main)/experiments/elections/components/state_by_forecast/index.tsx
+++ b/front_end/src/app/(main)/experiments/elections/components/state_by_forecast/index.tsx
@@ -13,7 +13,6 @@ import { StateByForecastItem } from "@/types/experiments";
 import { PostWithForecasts } from "@/types/post";
 import { QuestionType, QuestionWithForecasts } from "@/types/question";
 import { getDisplayValue } from "@/utils/charts";
-import { extractQuestionGroupName } from "@/utils/questions";
 
 import MiddleVotesArrow from "./middle_votes_arrow";
 import StateByForecastCharts from "./state_by_forecast_charts";
@@ -144,7 +143,7 @@ const getStateByItems = (
   >(
     (acc, q) => ({
       ...acc,
-      [extractQuestionGroupName(q.title).toLowerCase()]: q,
+      [q.label.toLowerCase()]: q,
     }),
     {}
   );

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
@@ -35,7 +35,6 @@ import {
 } from "@/types/question";
 import { ThemeColor } from "@/types/theme";
 import { extractPrevBinaryForecastValue } from "@/utils/forecasts";
-import { extractQuestionGroupName } from "@/utils/questions";
 
 import ForecastMakerGroupControls from "./forecast_maker_group_menu";
 import { SLUG_POST_SUB_QUESTION_ID } from "../../../search_params";
@@ -319,7 +318,7 @@ function generateChoiceOptions(
   return questions.map((question, index) => {
     return {
       id: question.id,
-      name: extractQuestionGroupName(question.title),
+      name: question.label,
       communityForecast:
         question.aggregations.recency_weighted.latest?.centers![0] ?? null,
       forecast: prevForecastValuesMap[question.id] ?? null,

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
@@ -30,7 +30,6 @@ import {
 } from "@/utils/forecasts";
 import { computeQuartilesFromCDF } from "@/utils/math";
 import {
-  extractQuestionGroupName,
   formatResolution,
   getSubquestionPredictionInputMessage,
 } from "@/utils/questions";
@@ -441,7 +440,7 @@ function generateGroupOptions(
 
       return {
         id: q.id,
-        name: extractQuestionGroupName(q.title),
+        name: q.label,
         question: q,
         userQuartiles: getUserQuartiles(
           prevForecast,

--- a/front_end/src/app/(main)/questions/components/group_form.tsx
+++ b/front_end/src/app/(main)/questions/components/group_form.tsx
@@ -41,7 +41,6 @@ import {
 import { QuestionType } from "@/types/question";
 import { logErrorWithScope } from "@/utils/errors";
 import { getPostLink } from "@/utils/navigation";
-import { extractQuestionGroupName } from "@/utils/questions";
 
 import BacktoCreate from "./back_to_create";
 import CategoryPicker from "./category_picker";
@@ -134,6 +133,7 @@ const GroupForm: React.FC<Props> = ({
         id: x.id,
         type: subtype,
         title: `${data["title"]} (${x.label})`,
+        label: x.label,
         scheduled_close_time: x.scheduled_close_time,
         scheduled_resolve_time: x.scheduled_resolve_time,
         open_time: x.open_time,
@@ -232,7 +232,7 @@ const GroupForm: React.FC<Props> = ({
             scheduled_resolve_time: x.scheduled_resolve_time,
             open_time: x.open_time,
             cp_reveal_time: x.cp_reveal_time,
-            label: extractQuestionGroupName(x.title),
+            label: x.label,
             scaling: x.scaling,
             open_lower_bound: x.open_lower_bound,
             open_upper_bound: x.open_upper_bound,

--- a/front_end/src/types/question.ts
+++ b/front_end/src/types/question.ts
@@ -193,7 +193,7 @@ export type Question = {
   question_weight: number;
   fine_print: string | null;
   resolution_criteria: string | null;
-  label: string | null;
+  label: string;
   nr_forecasters: number;
   author_username: string;
   post_id: number;

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -31,11 +31,7 @@ import {
 } from "@/types/question";
 import { computeQuartilesFromCDF } from "@/utils/math";
 import { abbreviatedNumber } from "@/utils/number_formatters";
-import {
-  extractQuestionGroupName,
-  formatResolution,
-  isUnsuccessfullyResolved,
-} from "@/utils/questions";
+import { formatResolution, isUnsuccessfullyResolved } from "@/utils/questions";
 
 import {
   getForecastDateDisplayValue,
@@ -607,7 +603,7 @@ export function generateChoiceItemsFromBinaryGroup(
   return choiceOrdering.map((order, index) => {
     const question = questions[order];
     const history = question.aggregations.recency_weighted.history;
-    const label = extractQuestionGroupName(question.title);
+    const label = question.label;
     return {
       choice: label,
       values: history.map((forecast) => forecast.centers![0]),
@@ -651,7 +647,7 @@ export function getFanOptionsFromNumericGroup(
 ): FanOption[] {
   return questions
     .map((q) => ({
-      name: extractQuestionGroupName(q.title),
+      name: q.label,
       cdf: q.aggregations.recency_weighted.latest?.forecast_values ?? [],
       resolvedAt: new Date(q.scheduled_resolve_time),
       resolved: q.resolution !== null,
@@ -674,7 +670,7 @@ export function getFanOptionsFromBinaryGroup(
       const aggregation = q.aggregations.recency_weighted.latest;
       const resolved = q.resolution !== null;
       return {
-        name: extractQuestionGroupName(q.title),
+        name: q.label,
         quartiles: {
           median: aggregation?.centers?.[0] ?? 0,
           lower25: aggregation?.interval_lower_bounds?.[0] ?? 0,

--- a/front_end/src/utils/questions.ts
+++ b/front_end/src/utils/questions.ts
@@ -31,11 +31,6 @@ import { abbreviatedNumber } from "@/utils/number_formatters";
 
 import { formatDate } from "./date_formatters";
 
-export function extractQuestionGroupName(title: string) {
-  const match = title.match(/\(([^()]*(?:\([^()]*\)[^()]*)*)\)[^()]*$/);
-  return (match ? match[1] : title) || title;
-}
-
 export function extractPostResolution(post: Post): Resolution | null {
   if (post.question) {
     return post.question.resolution;
@@ -239,7 +234,7 @@ export function getPredictionQuestion(
     .map((q) => ({
       ...q,
       resolvedAt: new Date(q.scheduled_resolve_time),
-      fanName: extractQuestionGroupName(q.title),
+      fanName: q.label,
     }))
     .sort((a, b) => differenceInMilliseconds(a.resolvedAt, b.resolvedAt));
 
@@ -288,7 +283,7 @@ export const generateUserForecasts = (
     const userForecasts = question.my_forecasts;
 
     return {
-      choice: extractQuestionGroupName(question.title),
+      choice: question.label,
       values: userForecasts?.history.map((forecast) =>
         question.type === "binary"
           ? forecast.forecast_values[1]

--- a/notifications/services.py
+++ b/notifications/services.py
@@ -51,10 +51,16 @@ class NotificationQuestionParams:
     id: int
     title: str
     type: str
+    label: str = ""
 
     @classmethod
     def from_question(cls, question: Question):
-        return cls(id=question.id, title=question.title, type=question.type)
+        return cls(
+            id=question.id,
+            title=question.title,
+            type=question.type,
+            label=question.label,
+        )
 
 
 @dataclass
@@ -161,7 +167,8 @@ class CPChangeData:
         return self.format_value(self.cp_median)
 
     def format_question_title(self):
-        return get_question_group_title(self.question.title)
+        # TODO: deprecate get_question_group_title after the first release of this change
+        return self.question.label or get_question_group_title(self.question.title)
 
 
 class NotificationTypeBase:

--- a/posts/serializers.py
+++ b/posts/serializers.py
@@ -285,7 +285,6 @@ class PostFilterSerializer(SerializerKeyLookupMixin, serializers.Serializer):
         return validate_tournaments(lookup_values=values)
 
     def validate_forecast_type(self, value):
-        print("in validate", value)
         # If the value is passed as a single string, split it by commas
         if isinstance(value, list) and len(value) == 1:
             return [v.strip() for v in value[0].split(",")]

--- a/questions/migrations/0008_alter_question_label.py
+++ b/questions/migrations/0008_alter_question_label.py
@@ -1,0 +1,42 @@
+import re
+
+from django.db import migrations, models
+
+
+def get_question_group_title(title: str) -> str:
+    matches = re.findall(r"\((?:[^()]*|\([^()]*\))*\)", title)
+    return matches[-1][1:-1] if matches else title
+
+
+def migrate(apps, schema_editor):
+    """
+    Migrating group questions to have a separate label
+    """
+
+    Question = apps.get_model("questions", "Question")
+    bulk_update = []
+
+    for question in Question.objects.filter(group_id__isnull=False).only("id", "title"):
+        question.label = get_question_group_title(question.title)
+        bulk_update.append(question)
+
+        if len(bulk_update) == 500:
+            Question.objects.bulk_update(bulk_update, fields=["label"])
+            bulk_update = []
+
+    Question.objects.bulk_update(bulk_update, fields=["label"])
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("questions", "0007_question_question_weight"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="question",
+            name="label",
+            field=models.TextField(blank=True, default=""),
+            preserve_default=False,
+        ),
+        migrations.RunPython(migrate, reverse_code=migrations.RunPython.noop),
+    ]

--- a/questions/migrations/0008_alter_question_label.py
+++ b/questions/migrations/0008_alter_question_label.py
@@ -26,6 +26,7 @@ def migrate(apps, schema_editor):
 
     Question.objects.bulk_update(bulk_update, fields=["label"])
 
+
 class Migration(migrations.Migration):
     dependencies = [
         ("questions", "0007_question_question_weight"),

--- a/questions/models.py
+++ b/questions/models.py
@@ -115,7 +115,7 @@ class Question(TimeStampedModel):
     possibilities = models.JSONField(null=True, blank=True)
 
     # Group
-    label = models.TextField(blank=True, null=True)
+    label = models.TextField(blank=True, null=False)
     group: "GroupOfQuestions" = models.ForeignKey(
         "GroupOfQuestions",
         null=True,

--- a/questions/serializers.py
+++ b/questions/serializers.py
@@ -108,6 +108,7 @@ class QuestionWriteSerializer(serializers.ModelSerializer):
             "open_upper_bound",
             "open_lower_bound",
             "options",
+            "label",
             "scheduled_resolve_time",
             "scheduled_close_time",
             "resolution_criteria",


### PR DESCRIPTION
- Moved group question labels to `Question.label` instead of title regexp
- Frontend adjustments
- Added migration to backfill labels for existing questions

closes #1268 