### PR TITLE
Can't update forecast on group question

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
@@ -132,7 +132,11 @@ const ForecastMakerGroupBinary: FC<Props> = ({
 
   const [submitErrors, setSubmitErrors] = useState<ErrorResponse[]>([]);
   const questionsToSubmit = useMemo(
-    () => questionOptions.filter((option) => option.forecast !== null),
+    () =>
+      questionOptions.filter(
+        (option) =>
+          option.forecast !== null && option.status === QuestionStatus.OPEN
+      ),
     [questionOptions]
   );
 
@@ -196,6 +200,9 @@ const ForecastMakerGroupBinary: FC<Props> = ({
         errors.push(response_errors);
       }
     }
+    if (response && "error" in response && !!response.error) {
+      errors.push(response.error);
+    }
     if (errors.length) {
       setSubmitErrors(errors);
     }
@@ -248,7 +255,7 @@ const ForecastMakerGroupBinary: FC<Props> = ({
               isRowDirty={questionOption.isDirty}
               menu={questionOption.menu}
               disabled={
-                !canPredict || questionOption.status != QuestionStatus.OPEN
+                !canPredict || questionOption.status !== QuestionStatus.OPEN
               }
               optionResolution={{
                 resolution: questionOption.resolution,

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
@@ -117,7 +117,12 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitErrors, setSubmitErrors] = useState<ErrorResponse[]>([]);
   const questionsToSubmit = useMemo(
-    () => groupOptions.filter((option) => option.userForecast !== null),
+    () =>
+      groupOptions.filter(
+        (option) =>
+          option.userForecast !== null &&
+          option.question.status === QuestionStatus.OPEN
+      ),
     [groupOptions]
   );
   const isPickerDirty = useMemo(
@@ -253,6 +258,9 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
         errors.push(response_errors);
       }
     }
+    if (response && "error" in response && !!response.error) {
+      errors.push(response.error);
+    }
     if (errors.length) {
       setSubmitErrors(errors);
     }
@@ -308,7 +316,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
                 handleChange(option.id, forecast, weight)
               }
               disabled={
-                !canPredict || option.question.status != QuestionStatus.OPEN
+                !canPredict || option.question.status !== QuestionStatus.OPEN
               }
             />
           </div>


### PR DESCRIPTION
- updated submission logic on forecast maker for group posts to skip closed questions from payload
- improved the logic for handling error to properly display BE-driven errors when there is a single error for the entire request