### PR TITLE
Fix the tournament page question filters

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
@@ -52,11 +52,6 @@ export default async function TournamentSlug({ params }: Props) {
 
   const currentUser = await ProfileApi.getMyProfile();
 
-  const [categories, tags] = await Promise.all([
-    ProjectsApi.getCategories(),
-    ProjectsApi.getTags(),
-  ]);
-
   const t = await getTranslations();
   const locale = await getLocale();
   const isQuestionSeries = tournament.type === TournamentType.QuestionSeries;
@@ -156,7 +151,7 @@ export default async function TournamentSlug({ params }: Props) {
               </Button>
             )}
           </div>
-          <TournamentFilters categories={categories} tags={tags} />
+          <TournamentFilters />
           <TournamentFeed slug={params.slug} />
         </section>
       </div>

--- a/front_end/src/app/(main)/questions/components/feed_filters/main.tsx
+++ b/front_end/src/app/(main)/questions/components/feed_filters/main.tsx
@@ -4,11 +4,10 @@ import { FC, useMemo } from "react";
 
 import {
   getFilterSectionParticipation,
+  getFilterSectionPostStatus,
   getFilterSectionPostType,
   getFilterSectionUsername,
-  POST_STATUS_LABEL_MAP,
 } from "@/app/(main)/questions/helpers/filters";
-import { FilterOptionType } from "@/components/popover_filter/types";
 import PostsFilters from "@/components/posts_filters";
 import { GroupButton } from "@/components/ui/button_group";
 import { POST_STATUS_FILTER } from "@/constants/posts_feed";
@@ -25,21 +24,16 @@ const MainFeedFilters: FC = () => {
   const filters = useMemo(() => {
     const filters = [
       getFilterSectionPostType({ t, params }),
-      {
-        id: POST_STATUS_FILTER,
-        title: t("questionStatus"),
-        type: FilterOptionType.MultiChip,
-        options: [
+      getFilterSectionPostStatus({
+        statuses: [
           PostStatus.OPEN,
           PostStatus.CLOSED,
           PostStatus.RESOLVED,
           PostStatus.UPCOMING,
-        ].map((status) => ({
-          label: POST_STATUS_LABEL_MAP[status],
-          value: status,
-          active: params.getAll(POST_STATUS_FILTER).includes(status),
-        })),
-      },
+        ],
+        t,
+        params,
+      }),
       getFilterSectionUsername({ t, params }),
     ];
     if (user) {

--- a/front_end/src/app/(main)/questions/components/feed_filters/my_predictions.tsx
+++ b/front_end/src/app/(main)/questions/components/feed_filters/my_predictions.tsx
@@ -4,13 +4,10 @@ import { FC, useMemo } from "react";
 
 import {
   getFilterSectionParticipation,
+  getFilterSectionPostStatus,
   getFilterSectionPostType,
-  POST_STATUS_LABEL_MAP,
 } from "@/app/(main)/questions/helpers/filters";
-import {
-  FilterOptionType,
-  FilterReplaceInfo,
-} from "@/components/popover_filter/types";
+import { FilterReplaceInfo } from "@/components/popover_filter/types";
 import PostsFilters from "@/components/posts_filters";
 import { GroupButton } from "@/components/ui/button_group";
 import {
@@ -31,18 +28,11 @@ const MyPredictionsFilters: FC = () => {
   const filters = useMemo(() => {
     const filters = [
       getFilterSectionPostType({ t, params }),
-      {
-        id: POST_STATUS_FILTER,
-        title: t("questionStatus"),
-        type: FilterOptionType.MultiChip,
-        options: [PostStatus.OPEN, PostStatus.CLOSED, PostStatus.RESOLVED].map(
-          (status) => ({
-            label: POST_STATUS_LABEL_MAP[status],
-            value: status,
-            active: params.getAll(POST_STATUS_FILTER).includes(status),
-          })
-        ),
-      },
+      getFilterSectionPostStatus({
+        statuses: [PostStatus.OPEN, PostStatus.CLOSED, PostStatus.RESOLVED],
+        t,
+        params,
+      }),
     ];
     if (user) {
       filters.push(getFilterSectionParticipation({ t, params, user }));

--- a/front_end/src/app/(main)/questions/components/feed_filters/my_questions_and_posts.tsx
+++ b/front_end/src/app/(main)/questions/components/feed_filters/my_questions_and_posts.tsx
@@ -4,13 +4,13 @@ import { FC, useMemo } from "react";
 
 import {
   getFilterSectionParticipation,
+  getFilterSectionPostStatus,
   getFilterSectionPostType,
-  POST_STATUS_LABEL_MAP,
 } from "@/app/(main)/questions/helpers/filters";
 import { FilterOptionType } from "@/components/popover_filter/types";
 import PostsFilters from "@/components/posts_filters";
 import { GroupButton } from "@/components/ui/button_group";
-import { POST_ACCESS_FILTER, POST_STATUS_FILTER } from "@/constants/posts_feed";
+import { POST_ACCESS_FILTER } from "@/constants/posts_feed";
 import { useAuth } from "@/contexts/auth_context";
 import useSearchParams from "@/hooks/use_search_params";
 import { PostStatus } from "@/types/post";
@@ -24,11 +24,8 @@ const MyQuestionsAndPostsFilters: FC = () => {
   const filters = useMemo(() => {
     const filters = [
       getFilterSectionPostType({ t, params }),
-      {
-        id: POST_STATUS_FILTER,
-        title: t("questionStatus"),
-        type: FilterOptionType.MultiChip,
-        options: [
+      getFilterSectionPostStatus({
+        statuses: [
           PostStatus.DRAFT,
           PostStatus.PENDING,
           PostStatus.UPCOMING,
@@ -36,12 +33,10 @@ const MyQuestionsAndPostsFilters: FC = () => {
           PostStatus.CLOSED,
           PostStatus.RESOLVED,
           PostStatus.DELETED,
-        ].map((status) => ({
-          label: POST_STATUS_LABEL_MAP[status],
-          value: status,
-          active: params.getAll(POST_STATUS_FILTER).includes(status),
-        })),
-      },
+        ],
+        t,
+        params,
+      }),
       {
         id: POST_ACCESS_FILTER,
         title: t("special"),

--- a/front_end/src/app/(main)/questions/helpers/filters.ts
+++ b/front_end/src/app/(main)/questions/helpers/filters.ts
@@ -166,15 +166,19 @@ export function getFilterSectionPostType({
 export function getFilterSectionPostStatus({
   t,
   params,
+  statuses,
 }: {
   t: ReturnType<typeof useTranslations>;
   params: URLSearchParams;
+  statuses?: PostStatus[];
 }): FilterSection {
+  const options = statuses ?? Object.values(PostStatus);
+
   return {
     id: POST_STATUS_FILTER,
     title: t("questionStatus"),
     type: FilterOptionType.MultiChip,
-    options: Object.values(PostStatus).map((status) => ({
+    options: options.map((status) => ({
       label: POST_STATUS_LABEL_MAP[status],
       value: status,
       active: params.getAll(POST_STATUS_FILTER).includes(status),
@@ -261,112 +265,6 @@ const mapForecastTypeOptions = (
     value: type,
     active: params.getAll(POST_TYPE_FILTER).includes(type),
   }));
-
-export function getPostsFilters({
-  tags,
-  user,
-  t,
-  params,
-  categories,
-}: {
-  t: ReturnType<typeof useTranslations>;
-  params: URLSearchParams;
-  categories: Category[];
-  tags: Tag[];
-  user: CurrentUser | null;
-}): FilterSection[] {
-  const filters: FilterSection[] = [
-    getFilterSectionPostType({ t, params }),
-    getFilterSectionPostStatus({ t, params }),
-    {
-      id: POST_CATEGORIES_FILTER,
-      title: t("category"),
-      type: FilterOptionType.Combobox,
-      options: categories.map((category) => ({
-        label: category.name,
-        value: category.slug,
-        active: params.getAll(POST_CATEGORIES_FILTER).includes(category.slug),
-      })),
-      chipColor: getFilterChipColor(POST_CATEGORIES_FILTER),
-    },
-    {
-      id: POST_TAGS_FILTER,
-      title: t("tags"),
-      type: FilterOptionType.Combobox,
-      options: tags.map((tag) => ({
-        label: tag.name,
-        value: tag.slug,
-        active: params.getAll(POST_TAGS_FILTER).includes(tag.slug),
-      })),
-      chipColor: getFilterChipColor(POST_TAGS_FILTER),
-      chipFormat: (value) => t("tagFilter", { tag: value.toLowerCase() }),
-      shouldEnforceSearch: true,
-    },
-    getFilterSectionUsername({ t, params }),
-  ];
-
-  if (user) {
-    filters.push({
-      id: "userFilters",
-      title: t("myParticipation"),
-      type: FilterOptionType.ToggleChip,
-      options: [
-        {
-          id: POST_FORECASTER_ID_FILTER,
-          label: t("predicted"),
-          value: user.id.toString(),
-          active: !!params.get(POST_FORECASTER_ID_FILTER),
-        },
-        {
-          id: POST_NOT_FORECASTER_ID_FILTER,
-          label: t("notPredicted"),
-          value: user.id.toString(),
-          active: !!params.get(POST_NOT_FORECASTER_ID_FILTER),
-        },
-        {
-          id: POST_AUTHOR_FILTER,
-          label: t("authored"),
-          value: user.id.toString(),
-          active: !!params.get(POST_AUTHOR_FILTER),
-        },
-        {
-          id: POST_UPVOTED_BY_FILTER,
-          label: t("upvoted"),
-          value: user.id.toString(),
-          active: !!params.get(POST_UPVOTED_BY_FILTER),
-        },
-        {
-          id: POST_COMMENTED_BY_FILTER,
-          label: t("moderating"),
-          value: user.id.toString(),
-          active: !!params.get(POST_COMMENTED_BY_FILTER),
-        },
-      ],
-    });
-  }
-
-  filters.push({
-    id: POST_ACCESS_FILTER,
-    title: t("visibility"),
-    type: FilterOptionType.ToggleChip,
-    options: [
-      {
-        id: POST_ACCESS_FILTER,
-        label: t("public"),
-        value: "public",
-        active: params.get(POST_ACCESS_FILTER) === "public",
-      },
-      {
-        id: POST_ACCESS_FILTER,
-        label: t("private"),
-        value: "private",
-        active: params.get(POST_ACCESS_FILTER) === "private",
-      },
-    ],
-  });
-
-  return filters;
-}
 
 export function getMainOrderOptions(
   t: ReturnType<typeof useTranslations>


### PR DESCRIPTION
- refactored `getFilterSectionPostStatus` to allow providing specific list of statuses to reduce repetitive code
- updated a function for generating filters on tournament page according to provided requirements