### PR TITLE
Show empty graph, forecaster count, and disclaimer before CP is revealed

### DIFF
--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -67,6 +67,7 @@
   "forecastTimelineHeading": "Forecast Timeline",
   "totalPredictionsLabel": "Total Predictions",
   "totalForecastersLabel": "Total Forecasters",
+  "cpWillRevealOn": "The Community Prediction will be revealed on",
   "communityPredictionLabel": "Community Prediction",
   "metaculusPredictionLabel": "Metaculus Prediction",
   "userPredictionLabel": "User Prediction",

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/index.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/types/question";
 import { getGroupQuestionsTimestamps } from "@/utils/charts";
 import {
+  getGroupCPRevealTime,
   getQuestionLinearChartType,
   sortGroupPredictionOptions,
 } from "@/utils/questions";
@@ -59,7 +60,7 @@ const DetailedGroupCard: FC<Props> = ({
       </div>
     );
   }
-
+  const { closestCPRevealTime, isCPRevealed } = getGroupCPRevealTime(questions);
   let isForecastEmpty = true;
   let oneQuestionClosed = false;
   questions.forEach((question) => {
@@ -73,7 +74,7 @@ const DetailedGroupCard: FC<Props> = ({
       oneQuestionClosed = true;
     }
   });
-  if (isForecastEmpty) {
+  if (isForecastEmpty && isCPRevealed) {
     if (postStatus !== PostStatus.OPEN) {
       return null;
     }
@@ -114,6 +115,8 @@ const DetailedGroupCard: FC<Props> = ({
             isClosed={isClosed}
             preselectedQuestionId={preselectedQuestionId}
             hideCP={hideCP}
+            isCPRevealed={isCPRevealed}
+            cpRevealTime={closestCPRevealTime}
           />
           {hideCP && <RevealCPButton />}
         </>
@@ -124,6 +127,8 @@ const DetailedGroupCard: FC<Props> = ({
         <NumericGroupChart
           questions={questions as QuestionWithNumericForecasts[]}
           withLabel
+          isCPRevealed={isCPRevealed}
+          cpRevealTime={closestCPRevealTime}
         />
       );
     default:

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/numeric_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/numeric_group_chart.tsx
@@ -15,6 +15,8 @@ type Props = {
   withLabel?: boolean;
   hideCP?: boolean;
   withTooltip?: boolean;
+  isCPRevealed?: boolean;
+  cpRevealTime?: string;
 };
 
 const NumericGroupChart: FC<Props> = ({
@@ -24,6 +26,8 @@ const NumericGroupChart: FC<Props> = ({
   withLabel,
   hideCP,
   withTooltip = true,
+  isCPRevealed = true,
+  cpRevealTime,
 }) => {
   const t = useTranslations();
 
@@ -39,6 +43,8 @@ const NumericGroupChart: FC<Props> = ({
       yLabel={withLabel ? t("communityPredictionLabel") : undefined}
       withTooltip={withTooltip}
       hideCP={hideCP}
+      isCPRevealed={isCPRevealed}
+      cpRevealTime={cpRevealTime}
     />
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/index.tsx
@@ -25,6 +25,10 @@ const DetailedQuestionCard: FC<Props> = ({
 }) => {
   const isForecastEmpty =
     question.aggregations.recency_weighted.history.length === 0;
+  const isCPRevealed = question.cp_reveal_time
+    ? new Date(question.cp_reveal_time) <= new Date()
+    : true;
+
   const { hideCP } = useHideCP();
 
   const t = useTranslations();
@@ -40,17 +44,13 @@ const DetailedQuestionCard: FC<Props> = ({
     if (postStatus !== PostStatus.OPEN) {
       return null;
     }
-    return (
-      <>
-        {nrForecasters > 0 ? (
-          <div className="text-l m-4 w-full text-center">{t("CPIsHidden")}</div>
-        ) : (
-          <div className="text-l m-4 w-full text-center">
-            {t("forecastDataIsEmpty")}
-          </div>
-        )}
-      </>
-    );
+    if (nrForecasters === 0) {
+      return (
+        <div className="text-l m-4 w-full text-center">
+          {t("forecastDataIsEmpty")}
+        </div>
+      );
+    }
   }
 
   switch (question.type) {
@@ -59,14 +59,23 @@ const DetailedQuestionCard: FC<Props> = ({
     case QuestionType.Binary:
       return (
         <DetailsQuestionCardErrorBoundary>
-          <NumericChartCard question={question} hideCP={hideCP} />
+          <NumericChartCard
+            question={question}
+            hideCP={hideCP || !isCPRevealed}
+            isCPRevealed={isCPRevealed}
+            nrForecasters={nrForecasters}
+          />
           {hideCP && <RevealCPButton />}
         </DetailsQuestionCardErrorBoundary>
       );
     case QuestionType.MultipleChoice:
       return (
         <DetailsQuestionCardErrorBoundary>
-          <MultipleChoiceChartCard question={question} hideCP={hideCP} />
+          <MultipleChoiceChartCard
+            question={question}
+            hideCP={hideCP}
+            isCPRevealed={isCPRevealed}
+          />
           {hideCP && <RevealCPButton />}
         </DetailsQuestionCardErrorBoundary>
       );

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
@@ -162,7 +162,7 @@ const MultipleChoiceChartCard: FC<Props> = ({
       chartHeight={chartHeight}
       defaultZoom={defaultZoom}
       isCPRevealed={isCPRevealed}
-      CPRevealTime={question.cp_reveal_time}
+      cpRevealTime={question.cp_reveal_time}
     />
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
@@ -31,6 +31,7 @@ type Props = {
   defaultZoom?: TimelineChartZoomOption;
   chartTheme?: VictoryThemeDefinition;
   hideCP?: boolean;
+  isCPRevealed?: boolean;
 };
 
 const MultipleChoiceChartCard: FC<Props> = ({
@@ -40,6 +41,7 @@ const MultipleChoiceChartCard: FC<Props> = ({
   defaultZoom,
   chartTheme,
   hideCP,
+  isCPRevealed,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -149,7 +151,7 @@ const MultipleChoiceChartCard: FC<Props> = ({
       userForecasts={userForecasts}
       forecastersCount={forecastersCount}
       tooltipDate={tooltipDate}
-      onCursorChange={handleCursorChange}
+      onCursorChange={isCPRevealed ? handleCursorChange : undefined}
       onChoiceItemsUpdate={setChoiceItems}
       isClosed={isClosed}
       actualCloseTime={actualCloseTime}
@@ -159,6 +161,8 @@ const MultipleChoiceChartCard: FC<Props> = ({
       embedMode={embedMode}
       chartHeight={chartHeight}
       defaultZoom={defaultZoom}
+      isCPRevealed={isCPRevealed}
+      CPRevealTime={question.cp_reveal_time}
     />
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/numeric_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/numeric_chart_card.tsx
@@ -3,8 +3,8 @@ import classNames from "classnames";
 import { useTranslations } from "next-intl";
 import React, { FC, useCallback, useMemo, useState } from "react";
 
+import CPRevealTime from "@/components/charts/cp_reveal_time";
 import NumericChart from "@/components/charts/numeric_chart";
-import LocalDaytime from "@/components/ui/local_daytime";
 import { useAuth } from "@/contexts/auth_context";
 import { TimelineChartZoomOption } from "@/types/charts";
 import { Question } from "@/types/question";
@@ -128,13 +128,8 @@ const NumericChartCard: FC<Props> = ({
               : undefined
           }
         />
-        {!isCPRevealed && question.cp_reveal_time && (
-          <div className="absolute inset-0 flex items-center justify-center text-center">
-            <p>
-              {t("cpWillRevealOn")}{" "}
-              <LocalDaytime date={question.cp_reveal_time} />
-            </p>
-          </div>
+        {!isCPRevealed && (
+          <CPRevealTime cpRevealTime={question.cp_reveal_time} />
         )}
       </div>
       <div

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
@@ -38,6 +38,8 @@ type Props = {
   chartTheme?: VictoryThemeDefinition;
   embedMode?: boolean;
   withLegend?: boolean;
+  isCPRevealed?: boolean;
+  cpRevealTime?: string;
 };
 
 const MultipleChoiceGroupChart: FC<Props> = ({
@@ -56,6 +58,8 @@ const MultipleChoiceGroupChart: FC<Props> = ({
   chartTheme,
   embedMode,
   withLegend,
+  isCPRevealed = true,
+  cpRevealTime,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -211,7 +215,7 @@ const MultipleChoiceGroupChart: FC<Props> = ({
       timestamps={timestamps}
       userForecasts={userForecasts}
       tooltipDate={tooltipDate}
-      onCursorChange={handleCursorChange}
+      onCursorChange={isCPRevealed ? handleCursorChange : undefined}
       onChoiceItemsUpdate={setChoiceItems}
       isClosed={isClosed}
       actualCloseTime={actualCloseTime}
@@ -224,6 +228,8 @@ const MultipleChoiceGroupChart: FC<Props> = ({
       chartHeight={chartHeight}
       withLegend={withLegend}
       defaultZoom={defaultZoom}
+      isCPRevealed={isCPRevealed}
+      cpRevealTime={cpRevealTime}
     />
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
@@ -5,8 +5,8 @@ import { useTranslations } from "next-intl";
 import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import { VictoryThemeDefinition } from "victory";
 
+import CPRevealTime from "@/components/charts/cp_reveal_time";
 import MultipleChoiceChart from "@/components/charts/multiple_choice_chart";
-import LocalDaytime from "@/components/ui/local_daytime";
 import { useAuth } from "@/contexts/auth_context";
 import useChartTooltip from "@/hooks/use_chart_tooltip";
 import { TickFormat, TimelineChartZoomOption } from "@/types/charts";
@@ -42,7 +42,7 @@ type Props = {
   chartTheme?: VictoryThemeDefinition;
   embedMode?: boolean;
   isCPRevealed?: boolean;
-  CPRevealTime?: string;
+  cpRevealTime?: string;
 };
 
 const MultiChoicesChartView: FC<Props> = ({
@@ -69,7 +69,7 @@ const MultiChoicesChartView: FC<Props> = ({
   chartTheme,
   embedMode = false,
   isCPRevealed = true,
-  CPRevealTime,
+  cpRevealTime,
 }) => {
   const { user } = useAuth();
   const t = useTranslations();
@@ -191,13 +191,7 @@ const MultiChoicesChartView: FC<Props> = ({
                 : TimelineChartZoomOption.TwoMonths
           }
         />
-        {!isCPRevealed && CPRevealTime && (
-          <div className="absolute inset-0 flex items-center justify-center pl-3 text-center">
-            <p>
-              {t("cpWillRevealOn")} <LocalDaytime date={CPRevealTime} />
-            </p>
-          </div>
-        )}
+        {!isCPRevealed && <CPRevealTime cpRevealTime={cpRevealTime} />}
       </div>
 
       {withLegend && (

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
@@ -6,6 +6,7 @@ import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import { VictoryThemeDefinition } from "victory";
 
 import MultipleChoiceChart from "@/components/charts/multiple_choice_chart";
+import LocalDaytime from "@/components/ui/local_daytime";
 import { useAuth } from "@/contexts/auth_context";
 import useChartTooltip from "@/hooks/use_chart_tooltip";
 import { TickFormat, TimelineChartZoomOption } from "@/types/charts";
@@ -25,7 +26,7 @@ type Props = {
   forecastersCount?: number | null;
   onChoiceItemsUpdate: (choiceItems: ChoiceItem[]) => void;
   timestamps: number[];
-  onCursorChange: (value: number, format: TickFormat) => void;
+  onCursorChange?: (value: number, format: TickFormat) => void;
   actualCloseTime?: number | null;
   userForecasts?: UserChoiceItem[];
   isClosed?: boolean;
@@ -40,6 +41,8 @@ type Props = {
   chartHeight?: number;
   chartTheme?: VictoryThemeDefinition;
   embedMode?: boolean;
+  isCPRevealed?: boolean;
+  CPRevealTime?: string;
 };
 
 const MultiChoicesChartView: FC<Props> = ({
@@ -65,6 +68,8 @@ const MultiChoicesChartView: FC<Props> = ({
   chartHeight,
   chartTheme,
   embedMode = false,
+  isCPRevealed = true,
+  CPRevealTime,
 }) => {
   const { user } = useAuth();
   const t = useTranslations();
@@ -159,7 +164,11 @@ const MultiChoicesChartView: FC<Props> = ({
           </>
         )}
       </div>
-      <div ref={refs.setReference} {...getReferenceProps()}>
+      <div
+        ref={refs.setReference}
+        {...getReferenceProps()}
+        className={"relative"}
+      >
         <MultipleChoiceChart
           actualCloseTime={actualCloseTime}
           timestamps={timestamps}
@@ -182,6 +191,13 @@ const MultiChoicesChartView: FC<Props> = ({
                 : TimelineChartZoomOption.TwoMonths
           }
         />
+        {!isCPRevealed && CPRevealTime && (
+          <div className="absolute inset-0 flex items-center justify-center pl-3 text-center">
+            <p>
+              {t("cpWillRevealOn")} <LocalDaytime date={CPRevealTime} />
+            </p>
+          </div>
+        )}
       </div>
 
       {withLegend && (

--- a/front_end/src/components/charts/cp_reveal_time.tsx
+++ b/front_end/src/components/charts/cp_reveal_time.tsx
@@ -29,7 +29,7 @@ const CPRevealTime: FC<Props> = ({
     >
       <p
         className={classNames(
-          "max-w-[300px] pl-5 md:max-w-max md:pl-0",
+          "max-w-[300px] pl-5 max-[425px]:max-w-[200px] md:max-w-max md:pl-0",
           textClassName
         )}
       >

--- a/front_end/src/components/charts/cp_reveal_time.tsx
+++ b/front_end/src/components/charts/cp_reveal_time.tsx
@@ -1,0 +1,42 @@
+import classNames from "classnames";
+import { useTranslations } from "next-intl";
+import React, { FC } from "react";
+
+import LocalDaytime from "../ui/local_daytime";
+
+type Props = {
+  cpRevealTime?: string;
+  className?: string;
+  textClassName?: string;
+};
+
+const CPRevealTime: FC<Props> = ({
+  cpRevealTime,
+  className,
+  textClassName,
+}) => {
+  const t = useTranslations();
+  if (!cpRevealTime) {
+    return null;
+  }
+
+  return (
+    <div
+      className={classNames(
+        "absolute inset-0 flex items-center justify-center text-center",
+        className
+      )}
+    >
+      <p
+        className={classNames(
+          "max-w-[300px] pl-5 md:max-w-max md:pl-0",
+          textClassName
+        )}
+      >
+        {t("cpWillRevealOn")} <LocalDaytime date={cpRevealTime} />
+      </p>
+    </div>
+  );
+};
+
+export default CPRevealTime;

--- a/front_end/src/components/charts/fan_chart.tsx
+++ b/front_end/src/components/charts/fan_chart.tsx
@@ -35,6 +35,8 @@ import {
   unscaleNominalLocation,
 } from "@/utils/charts";
 
+import CPRevealTime from "./cp_reveal_time";
+
 const TOOLTIP_WIDTH = 150;
 
 type Props = {
@@ -45,6 +47,8 @@ type Props = {
   extraTheme?: VictoryThemeDefinition;
   pointSize?: number;
   hideCP?: boolean;
+  isCPRevealed?: boolean;
+  cpRevealTime?: string;
 };
 
 const FanChart: FC<Props> = ({
@@ -55,6 +59,8 @@ const FanChart: FC<Props> = ({
   extraTheme,
   pointSize,
   hideCP,
+  isCPRevealed = true,
+  cpRevealTime,
 }) => {
   const { ref: chartContainerRef, width: chartWidth } =
     useContainerSize<HTMLDivElement>();
@@ -104,7 +110,7 @@ const FanChart: FC<Props> = ({
 
   const shouldDisplayChart = !!chartWidth;
   return (
-    <div ref={chartContainerRef} className="w-full" style={{ height }}>
+    <div ref={chartContainerRef} className="relative w-full" style={{ height }}>
       {shouldDisplayChart && (
         <VictoryChart
           width={chartWidth}
@@ -188,7 +194,7 @@ const FanChart: FC<Props> = ({
             }
           />
           <VictoryAxis tickFormat={(_, index) => labels[index]} />
-          {!hideCP && (
+          {!hideCP && isCPRevealed && (
             <VictoryScatter
               data={points.map((point) => ({
                 ...point,
@@ -226,6 +232,13 @@ const FanChart: FC<Props> = ({
             }
           />
         </VictoryChart>
+      )}
+      {!isCPRevealed && (
+        <CPRevealTime
+          className="text-xs lg:text-sm"
+          textClassName="!max-w-[300px]"
+          cpRevealTime={cpRevealTime}
+        />
       )}
     </div>
   );

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -70,6 +70,8 @@ type Props = {
   resolution?: Resolution | null;
   resolveTime?: string | null;
   hideCP?: boolean;
+  isCPRevealed?: boolean;
+  openTime?: number;
 };
 
 const NumericChart: FC<Props> = ({
@@ -88,6 +90,8 @@ const NumericChart: FC<Props> = ({
   resolution,
   resolveTime,
   hideCP,
+  isCPRevealed,
+  openTime,
 }) => {
   const { ref: chartContainerRef, width: chartWidth } =
     useContainerSize<HTMLDivElement>();
@@ -116,6 +120,8 @@ const NumericChart: FC<Props> = ({
         width: chartWidth,
         zoom,
         extraTheme,
+        isCPRevealed,
+        openTime,
       }),
     [
       questionType,
@@ -127,6 +133,8 @@ const NumericChart: FC<Props> = ({
       chartWidth,
       zoom,
       extraTheme,
+      isCPRevealed,
+      openTime,
     ]
   );
   const { leftPadding, MIN_LEFT_PADDING } = useMemo(() => {
@@ -338,6 +346,8 @@ function buildChartData({
   width,
   zoom,
   extraTheme,
+  isCPRevealed,
+  openTime,
 }: {
   questionType: QuestionType;
   actualCloseTime: number | null;
@@ -348,6 +358,8 @@ function buildChartData({
   width: number;
   zoom: TimelineChartZoomOption;
   extraTheme?: VictoryThemeDefinition;
+  isCPRevealed?: boolean;
+  openTime?: number;
 }): ChartData {
   const line = aggregation.history.map((forecast) => ({
     x: forecast.start_time,
@@ -393,13 +405,17 @@ function buildChartData({
   }
   // TODO: add quartiles if continuous
 
-  const domainTimestamps = [
-    ...aggregation.history.map((f) => f.start_time),
-    ...(myForecasts?.history
-      ? myForecasts.history.map((f) => f.start_time)
-      : []),
-    latestTimestamp,
-  ];
+  const domainTimestamps =
+    !isCPRevealed && openTime
+      ? [openTime / 1000, latestTimestamp]
+      : [
+          ...aggregation.history.map((f) => f.start_time),
+          ...(myForecasts?.history
+            ? myForecasts.history.map((f) => f.start_time)
+            : []),
+          latestTimestamp,
+        ];
+
   const xDomain = generateNumericDomain(domainTimestamps, zoom);
   const fontSize = extraTheme ? getTickLabelFontSize(extraTheme) : undefined;
 

--- a/front_end/src/components/conditional_tile/conditional_chart.tsx
+++ b/front_end/src/components/conditional_tile/conditional_chart.tsx
@@ -16,6 +16,8 @@ import {
 } from "@/utils/forecasts";
 import { cdfToPmf } from "@/utils/math";
 
+import CPRevealTime from "../charts/cp_reveal_time";
+
 type Props = {
   question: QuestionWithForecasts;
   disabled: boolean;
@@ -33,7 +35,19 @@ const ConditionalChart: FC<Props> = ({
   const resolved = question.resolution !== null;
   const aggregate = question.aggregations.recency_weighted;
   const userForecasts = question.my_forecasts;
+  const isCPRevealed = question.cp_reveal_time
+    ? new Date(question.cp_reveal_time) <= new Date()
+    : true;
 
+  if (!isCPRevealed) {
+    return (
+      <CPRevealTime
+        className="!relative text-xs"
+        textClassName="m-0 !max-w-[300px] !pl-0"
+        cpRevealTime={question?.cp_reveal_time}
+      />
+    );
+  }
   switch (question.type) {
     case QuestionType.Binary: {
       const pctCandidate = aggregate.latest?.centers![0];

--- a/front_end/src/components/multiple_choice_tile.tsx
+++ b/front_end/src/components/multiple_choice_tile.tsx
@@ -18,6 +18,8 @@ import { Question, QuestionType, Scaling } from "@/types/question";
 import { ThemeColor } from "@/types/theme";
 import { getChoiceOptionValue } from "@/utils/charts";
 
+import LocalDaytime from "./ui/local_daytime";
+
 type Props = {
   timestamps: number[];
   actualCloseTime?: number | null;
@@ -32,6 +34,7 @@ type Props = {
   questionType?: QuestionType;
   scaling?: Scaling | undefined;
   hideCP?: boolean;
+  isCPRevealed?: boolean;
 };
 
 const MultipleChoiceTile: FC<Props> = ({
@@ -48,6 +51,7 @@ const MultipleChoiceTile: FC<Props> = ({
   questionType,
   scaling,
   hideCP,
+  isCPRevealed,
 }) => {
   const t = useTranslations();
 
@@ -108,18 +112,28 @@ const MultipleChoiceTile: FC<Props> = ({
         )}
       </div>
       {!isResolvedView && (
-        <MultipleChoiceChart
-          timestamps={timestamps}
-          actualCloseTime={actualCloseTime}
-          choiceItems={hideCP ? [] : choices}
-          height={chartHeight}
-          extraTheme={chartTheme}
-          defaultZoom={defaultChartZoom}
-          withZoomPicker={withZoomPicker}
-          userForecasts={userForecasts}
-          questionType={questionType}
-          scaling={scaling}
-        />
+        <div className="relative">
+          <MultipleChoiceChart
+            timestamps={timestamps}
+            actualCloseTime={actualCloseTime}
+            choiceItems={hideCP ? [] : choices}
+            height={chartHeight}
+            extraTheme={chartTheme}
+            defaultZoom={defaultChartZoom}
+            withZoomPicker={withZoomPicker}
+            userForecasts={userForecasts}
+            questionType={questionType}
+            scaling={scaling}
+          />
+          {!isCPRevealed && question?.cp_reveal_time && (
+            <div className="absolute inset-0 flex items-center justify-center pl-4 text-center text-xs lg:text-sm">
+              <p className="max-w-[300px]">
+                {t("cpWillRevealOn")}{" "}
+                <LocalDaytime date={question.cp_reveal_time} />
+              </p>
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/front_end/src/components/multiple_choice_tile.tsx
+++ b/front_end/src/components/multiple_choice_tile.tsx
@@ -18,7 +18,7 @@ import { Question, QuestionType, Scaling } from "@/types/question";
 import { ThemeColor } from "@/types/theme";
 import { getChoiceOptionValue } from "@/utils/charts";
 
-import LocalDaytime from "./ui/local_daytime";
+import CPRevealTime from "./charts/cp_reveal_time";
 
 type Props = {
   timestamps: number[];
@@ -35,6 +35,7 @@ type Props = {
   scaling?: Scaling | undefined;
   hideCP?: boolean;
   isCPRevealed?: boolean;
+  cpRevealTime?: string;
 };
 
 const MultipleChoiceTile: FC<Props> = ({
@@ -52,6 +53,7 @@ const MultipleChoiceTile: FC<Props> = ({
   scaling,
   hideCP,
   isCPRevealed,
+  cpRevealTime,
 }) => {
   const t = useTranslations();
 
@@ -125,13 +127,12 @@ const MultipleChoiceTile: FC<Props> = ({
             questionType={questionType}
             scaling={scaling}
           />
-          {!isCPRevealed && question?.cp_reveal_time && (
-            <div className="absolute inset-0 flex items-center justify-center pl-4 text-center text-xs lg:text-sm">
-              <p className="max-w-[300px]">
-                {t("cpWillRevealOn")}{" "}
-                <LocalDaytime date={question.cp_reveal_time} />
-              </p>
-            </div>
+          {!isCPRevealed && (
+            <CPRevealTime
+              className="text-xs lg:text-sm"
+              textClassName="!max-w-[300px]"
+              cpRevealTime={question?.cp_reveal_time ?? cpRevealTime}
+            />
           )}
         </div>
       )}

--- a/front_end/src/components/post_card/group_of_questions_tile/group_numeric_tile.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/group_numeric_tile.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/utils/charts";
 import {
   generateUserForecasts,
+  getGroupCPRevealTime,
   getPredictionQuestion,
   sortGroupPredictionOptions,
 } from "@/utils/questions";
@@ -46,6 +47,7 @@ const GroupNumericTile: FC<Props> = ({
   const scaling = isBinaryGroup
     ? undefined
     : getContinuousGroupScaling(questions);
+  const { closestCPRevealTime, isCPRevealed } = getGroupCPRevealTime(questions);
 
   if (
     post.group_of_questions?.graph_type === GroupOfQuestionsGraphType.FanGraph
@@ -76,6 +78,8 @@ const GroupNumericTile: FC<Props> = ({
             pointSize={8}
             hideCP={hideCP}
             withTooltip={false}
+            isCPRevealed={isCPRevealed}
+            cpRevealTime={closestCPRevealTime}
           />
         </div>
       </div>
@@ -115,6 +119,8 @@ const GroupNumericTile: FC<Props> = ({
         }
         questionType={questions[0].type}
         hideCP={hideCP}
+        isCPRevealed={isCPRevealed}
+        cpRevealTime={closestCPRevealTime}
       />
     );
   }

--- a/front_end/src/components/post_card/question_chart_tile/index.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/index.tsx
@@ -30,7 +30,11 @@ const QuestionChartTile: FC<Props> = ({
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
-
+  const isForecastEmpty =
+    question.aggregations.recency_weighted.history.length === 0;
+  const isCPRevealed = question.cp_reveal_time
+    ? new Date(question.cp_reveal_time) <= new Date()
+    : true;
   if (curationStatus === PostStatus.PENDING) {
     return (
       <div>
@@ -42,11 +46,13 @@ const QuestionChartTile: FC<Props> = ({
     );
   }
 
-  if (question.aggregations.recency_weighted.history.length === 0) {
-    if (curationStatus === PostStatus.OPEN) {
+  if (isForecastEmpty) {
+    if (curationStatus !== PostStatus.OPEN) {
+      return null;
+    }
+    if (forecasters === 0) {
       return <div>{t("forecastDataIsEmpty")}</div>;
     }
-    return null;
   }
 
   const defaultChartZoom: TimelineChartZoomOption = user
@@ -63,6 +69,7 @@ const QuestionChartTile: FC<Props> = ({
           curationStatus={curationStatus}
           defaultChartZoom={defaultChartZoom}
           hideCP={hideCP}
+          isCPRevealed={isCPRevealed}
           forecasters={forecasters}
         />
       );
@@ -87,6 +94,7 @@ const QuestionChartTile: FC<Props> = ({
           question={question}
           userForecasts={userForecasts}
           hideCP={hideCP}
+          isCPRevealed={isCPRevealed}
           actualCloseTime={actualCloseTime}
         />
       );

--- a/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
@@ -1,9 +1,11 @@
+import { useTranslations } from "next-intl";
 import { FC } from "react";
 
 import ForecastersCounter from "@/app/(main)/questions/components/forecaster_counter";
 import ContinuousAreaChart from "@/components/charts/continuous_area_chart";
 import NumericChart from "@/components/charts/numeric_chart";
 import PredictionChip from "@/components/prediction_chip";
+import LocalDaytime from "@/components/ui/local_daytime";
 import { ContinuousAreaType, TimelineChartZoomOption } from "@/types/charts";
 import { PostStatus, QuestionStatus } from "@/types/post";
 import { QuestionWithNumericForecasts, QuestionType } from "@/types/question";
@@ -18,6 +20,7 @@ type Props = {
   defaultChartZoom?: TimelineChartZoomOption;
   hideCP?: boolean;
   forecasters?: number;
+  isCPRevealed?: boolean;
 };
 
 const QuestionNumericTile: FC<Props> = ({
@@ -26,7 +29,9 @@ const QuestionNumericTile: FC<Props> = ({
   defaultChartZoom,
   hideCP,
   forecasters,
+  isCPRevealed,
 }) => {
+  const t = useTranslations();
   const latest = question.aggregations.recency_weighted.latest;
   const prediction = latest?.centers![0];
 
@@ -61,7 +66,7 @@ const QuestionNumericTile: FC<Props> = ({
 
         <ForecastersCounter forecasters={forecasters} className="p-1" />
       </div>
-      <div className="my-1 h-24 w-2/3 min-w-24 max-w-[500px] flex-1 overflow-visible">
+      <div className="relative my-1 h-24 w-2/3 min-w-24 max-w-[500px] flex-1 overflow-visible">
         {question.type === QuestionType.Binary ? (
           <NumericChart
             aggregation={question.aggregations.recency_weighted}
@@ -81,6 +86,12 @@ const QuestionNumericTile: FC<Props> = ({
             resolution={question.resolution}
             resolveTime={question.actual_resolve_time}
             hideCP={hideCP}
+            isCPRevealed={isCPRevealed}
+            openTime={
+              question.open_time
+                ? new Date(question.open_time).getTime()
+                : undefined
+            }
           />
         ) : (
           <ContinuousAreaChart
@@ -91,6 +102,14 @@ const QuestionNumericTile: FC<Props> = ({
             resolution={question.resolution}
             hideCP={hideCP}
           />
+        )}
+        {!isCPRevealed && question.cp_reveal_time && (
+          <div className="absolute inset-0 flex items-center justify-center pl-3 text-center text-sm">
+            <p>
+              {t("cpWillRevealOn")}{" "}
+              <LocalDaytime date={question.cp_reveal_time} />
+            </p>
+          </div>
         )}
       </div>
     </div>

--- a/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
@@ -3,9 +3,9 @@ import { FC } from "react";
 
 import ForecastersCounter from "@/app/(main)/questions/components/forecaster_counter";
 import ContinuousAreaChart from "@/components/charts/continuous_area_chart";
+import CPRevealTime from "@/components/charts/cp_reveal_time";
 import NumericChart from "@/components/charts/numeric_chart";
 import PredictionChip from "@/components/prediction_chip";
-import LocalDaytime from "@/components/ui/local_daytime";
 import { ContinuousAreaType, TimelineChartZoomOption } from "@/types/charts";
 import { PostStatus, QuestionStatus } from "@/types/post";
 import { QuestionWithNumericForecasts, QuestionType } from "@/types/question";
@@ -103,13 +103,12 @@ const QuestionNumericTile: FC<Props> = ({
             hideCP={hideCP}
           />
         )}
-        {!isCPRevealed && question.cp_reveal_time && (
-          <div className="absolute inset-0 flex items-center justify-center pl-3 text-center text-sm">
-            <p>
-              {t("cpWillRevealOn")}{" "}
-              <LocalDaytime date={question.cp_reveal_time} />
-            </p>
-          </div>
+
+        {!isCPRevealed && (
+          <CPRevealTime
+            className="pl-3 text-xs md:text-sm"
+            cpRevealTime={question.cp_reveal_time}
+          />
         )}
       </div>
     </div>

--- a/front_end/src/utils/questions.ts
+++ b/front_end/src/utils/questions.ts
@@ -22,6 +22,7 @@ import {
   QuestionWithMultipleChoiceForecasts,
   QuestionWithNumericForecasts,
   Scaling,
+  QuestionWithForecasts,
 } from "@/types/question";
 import { scaleInternalLocation, unscaleNominalLocation } from "@/utils/charts";
 import { abbreviatedNumber } from "@/utils/number_formatters";
@@ -411,4 +412,24 @@ export function parseQuestionId(questionUrlOrId: string): {
   }
 
   return result;
+}
+
+export function getGroupCPRevealTime(questions: QuestionWithForecasts[]) {
+  const closestCPRevealTime = Math.min(
+    ...questions
+      .map((q) =>
+        q.cp_reveal_time ? new Date(q.cp_reveal_time).getTime() : undefined
+      )
+      .filter((time) => time !== undefined)
+  );
+  const isCPRevealed = closestCPRevealTime
+    ? new Date(closestCPRevealTime) <= new Date()
+    : true;
+
+  return {
+    closestCPRevealTime: closestCPRevealTime
+      ? new Date(closestCPRevealTime).toString()
+      : undefined,
+    isCPRevealed,
+  };
 }

--- a/front_end/src/utils/questions.ts
+++ b/front_end/src/utils/questions.ts
@@ -415,20 +415,29 @@ export function parseQuestionId(questionUrlOrId: string): {
 }
 
 export function getGroupCPRevealTime(questions: QuestionWithForecasts[]) {
-  const closestCPRevealTime = Math.min(
-    ...questions
-      .map((q) =>
-        q.cp_reveal_time ? new Date(q.cp_reveal_time).getTime() : undefined
-      )
-      .filter((time) => time !== undefined)
-  );
+  const cdRevealTimes: number[] = [];
+  for (const q of questions) {
+    if (q.cp_reveal_time) {
+      cdRevealTimes.push(new Date(q.cp_reveal_time).getTime());
+    }
+  }
+
+  let closestCPRevealTime: Date | null = null;
+  if (cdRevealTimes.length) {
+    const candidate = Math.min(...cdRevealTimes);
+    const candidateDate = new Date(candidate);
+    if (isValid(candidateDate)) {
+      closestCPRevealTime = candidateDate;
+    }
+  }
+
   const isCPRevealed = closestCPRevealTime
-    ? new Date(closestCPRevealTime) <= new Date()
+    ? closestCPRevealTime <= new Date()
     : true;
 
   return {
     closestCPRevealTime: closestCPRevealTime
-      ? new Date(closestCPRevealTime).toString()
+      ? closestCPRevealTime.toString()
       : undefined,
     isCPRevealed,
   };


### PR DESCRIPTION
- implemented reusable component and helper to render cp reveal date
- removed duplicated code with new component
- adjusted render of all graph types on feed page, individual page and embed cards