### PR TITLE
Poor image quality for tournament hero on mobile sc…

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
@@ -88,9 +88,8 @@ export default async function TournamentSlug({ params }: Props) {
               alt=""
               fill
               priority
-              sizes="(max-width: 1200px) 100vw, 780px"
               className="size-full object-cover object-center"
-              quality={100}
+              unoptimized
             />
           </div>
         )}

--- a/front_end/src/components/tournament_card.tsx
+++ b/front_end/src/components/tournament_card.tsx
@@ -72,7 +72,7 @@ const TournamentCard: FC<Props> = ({
             alt=""
             fill
             className="size-full object-cover object-center"
-            sizes="(max-width: 768px) 100vw, 50vw"
+            sizes="(max-width: 768px) 200vw, 100vw"
             quality={100}
           />
         )}


### PR DESCRIPTION
- disabled dynamic image sizing on single tournament page
- improved `srcset` configuration on tournaments feed to improve image resolution on desktop screens