### PR TITLE
Fix the translations for languages the same as the content language

### DIFF
--- a/utils/translation.py
+++ b/utils/translation.py
@@ -269,7 +269,6 @@ def translate_fields_for_object_coroutines(obj, field_names, languages):
                 target_field=build_localized_fieldname(field_name, lang),
             )
             for lang in languages
-            if lang != source_lang
         )
 
     return co_routines


### PR DESCRIPTION
Issue fixed:

1. Site language set to English and user creates/writes an English question, with its content at version **V1** (Google Translated detected it also as English content).
2. User changes the language to “Untranslated”
3. User makes more edits to the content, bringing it to **V2**
4. User changes the language back to English (doesn’t edit!) and content is now at **V1**. But for all the other languages, including the “Untranslated”, content is **V2**.
5. The issue is that the platform was detecting the content as being English and was not updating the English column (e.g.: `title_en`) because it was wrongly relying on the Default language mechanism to use the content from the `title_original` given that the language of the content was English. But that only happens if the `title_en` was empty, and here it was not the case, as the question was initially written in English, so it’s `*_en` columns were populated. It’s only the case for content never translated.