### PR TITLE
Show their predictions to users who hide the CP

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/multiple_choice_chart_card.tsx
@@ -98,9 +98,11 @@ const MultipleChoiceChartCard: FC<Props> = ({
         .map(({ choice, values, color }) => ({
           choiceLabel: choice,
           color,
-          valueLabel: getForecastPctDisplayValue(values[cursorIndex]),
+          valueLabel: hideCP
+            ? "-"
+            : getForecastPctDisplayValue(values[cursorIndex]),
         })),
-    [choiceItems, cursorIndex]
+    [choiceItems, cursorIndex, hideCP]
   );
 
   const tooltipUserChoices = useMemo<ChoiceTooltipItem[]>(() => {
@@ -144,7 +146,7 @@ const MultipleChoiceChartCard: FC<Props> = ({
 
   return (
     <MultiChoicesChartView
-      tooltipChoices={hideCP ? [] : tooltipChoices}
+      tooltipChoices={tooltipChoices}
       tooltipUserChoices={tooltipUserChoices}
       choiceItems={hideCP ? [] : choiceItems}
       timestamps={timestamps}

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
@@ -137,17 +137,19 @@ const MultipleChoiceGroupChart: FC<Props> = ({
             return {
               choiceLabel: choice,
               color,
-              valueLabel: getQuestionTooltipLabel({
-                timestamps: optionTimestamps ?? timestamps,
-                values,
-                cursorTimestamp,
-                closeTime,
-                question: questions[index],
-              }),
+              valueLabel: hideCP
+                ? "-"
+                : getQuestionTooltipLabel({
+                    timestamps: optionTimestamps ?? timestamps,
+                    values,
+                    cursorTimestamp,
+                    closeTime,
+                    question: questions[index],
+                  }),
             };
           }
         ),
-    [choiceItems, cursorTimestamp, questions, timestamps]
+    [choiceItems, cursorTimestamp, hideCP, questions, timestamps]
   );
   const tooltipUserChoices = useMemo<ChoiceTooltipItem[]>(() => {
     if (!userForecasts) {
@@ -208,7 +210,7 @@ const MultipleChoiceGroupChart: FC<Props> = ({
 
   return (
     <MultiChoicesChartView
-      tooltipChoices={!!hideCP ? [] : tooltipChoices}
+      tooltipChoices={tooltipChoices}
       tooltipUserChoices={tooltipUserChoices}
       forecastersCount={forecastersCount}
       choiceItems={!!hideCP ? [] : choiceItems}


### PR DESCRIPTION
- adjusted graph hover tooltip to be displayed on MC and group question when hide cp toggle is active

Related to #937. This PR fixes the following bullet point from discussion in comments:

> Mouseovering the graph should show the user's forecasts (I mean the actual numbers)