### PR TITLE
global contributions endpoint quick optimization

### DIFF
--- a/questions/models.py
+++ b/questions/models.py
@@ -159,20 +159,24 @@ class Question(TimeStampedModel, TranslatedModel):  # type: ignore
 
         return QuestionStatus.OPEN
 
-    def get_global_leaderboard_dates(self) -> tuple[datetime, datetime] | None:
+    def get_global_leaderboard_dates(
+        self, gl_dates: list[tuple[datetime, datetime]] | None = None
+    ) -> tuple[datetime, datetime] | None:
         # returns the global leaderboard dates that this question counts for
-        from scoring.models import global_leaderboard_dates
 
         forecast_horizon_start = self.open_time
         forecast_horizon_end = self.scheduled_close_time
         if forecast_horizon_start is None or forecast_horizon_end is None:
             return (None, None)
-        global_leaderboard_dates = global_leaderboard_dates()
+        if gl_dates is None:
+            from scoring.models import global_leaderboard_dates
+
+            gl_dates = global_leaderboard_dates()
 
         # iterate over the global leaderboard dates in reverse order
         # to find the shortest interval that this question counts for
         shortest_window = (None, None)
-        for gl_start, gl_end in global_leaderboard_dates[::-1]:
+        for gl_start, gl_end in gl_dates[::-1]:
             if forecast_horizon_start < gl_start or gl_end < forecast_horizon_start:
                 continue
             if forecast_horizon_end > gl_end + timedelta(days=3):

--- a/scoring/models.py
+++ b/scoring/models.py
@@ -196,9 +196,13 @@ class Leaderboard(TimeStampedModel):
 
         if self.start_time and self.end_time:
             # global leaderboard
+            gl_dates = global_leaderboard_dates()
             window = (self.start_time, self.end_time)
             questions = [
-                q for q in questions if q.get_global_leaderboard_dates() == window
+                q
+                for q in questions
+                if q.get_global_leaderboard_dates(global_leaderboard_dates=gl_dates)
+                == window
             ]
 
         return list(questions)


### PR DESCRIPTION
This takes a local 12 second operation down to 1.5 seconds.
On production, the process took up to 30 seconds.

More optimization is possible by stored "global_leaderboard_dates" directly on a question object instead, if necessary.