### PR TITLE
Default to English if the detected language is not one that's supported

### DIFF
--- a/utils/translation.py
+++ b/utils/translation.py
@@ -168,6 +168,14 @@ async def adetect_language_for_object(obj, fields):
         return (obj, None)
 
     lang = await agoogle_translate_detect_language(text)
+    supported_languages = [
+        lang[0]
+        for lang in settings.LANGUAGES
+        if lang[0] != settings.ORIGINAL_LANGUAGE_CODE
+    ]
+    if lang not in supported_languages:
+        lang = "en"
+
     return (obj, lang)
 
 


### PR DESCRIPTION
We have seen Google translate failing miserably at detecting the language of short texts which would include also formatting tags. We decided to take this compromise and better fail at translating unsupported languages, than mistranslating one of the supported languages.