### PR TITLE
"Load more" status is not maintained

### DIFF
--- a/front_end/src/app/(main)/news/helpers/filters.ts
+++ b/front_end/src/app/(main)/news/helpers/filters.ts
@@ -1,5 +1,6 @@
 import {
   POST_NEWS_TYPE_FILTER,
+  POST_PAGE_FILTER,
   POST_TEXT_SEARCH_FILTER,
 } from "@/constants/posts_feed";
 import { PostsParams } from "@/services/posts";
@@ -36,6 +37,10 @@ export function generateFiltersFromSearchParams(
 
   if (typeof searchParams[POST_NEWS_TYPE_FILTER] === "string") {
     filters.news_type = searchParams[POST_NEWS_TYPE_FILTER];
+  }
+
+  if (typeof searchParams[POST_PAGE_FILTER] === "string") {
+    filters.page = Number(searchParams[POST_PAGE_FILTER]);
   }
 
   return filters;

--- a/front_end/src/components/posts_feed/feed_scroll_restoration.tsx
+++ b/front_end/src/components/posts_feed/feed_scroll_restoration.tsx
@@ -1,27 +1,45 @@
 import { usePathname } from "next/navigation";
 import { FC, useEffect } from "react";
 
+import { POSTS_PER_PAGE } from "@/constants/posts_feed";
 import useSearchParams from "@/hooks/use_search_params";
 import { PostWithForecasts } from "@/types/post";
 
 type Props = {
   initialQuestions: PostWithForecasts[];
+  serverPage: number | null;
   pageNumber: number;
 };
 const PostsFeedScrollRestoration: FC<Props> = ({
   initialQuestions,
   pageNumber,
+  serverPage,
 }) => {
   const pathname = usePathname();
-  const { params } = useSearchParams();
+  const { params, navigateToSearchParams } = useSearchParams();
   const fullPathname = `${pathname}${params.toString() ? `?${params.toString()}` : ""}`;
+
+  // disable native scroll restoration as we're doing it programmatically
+  useEffect(() => {
+    history.scrollRestoration = "manual";
+  }, []);
+
+  // propagate shallow page param to server on the first render
+  // we skip server navigation on the feed, as pagination is executed client-side
+  // but we need to ensure the server is in sync with the client when doing back navigation
+  useEffect(() => {
+    if (pageNumber > 1 && serverPage !== pageNumber) {
+      navigateToSearchParams();
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     const cacheKey = `feed-scroll-restoration`;
-    let timeoutId = undefined;
     const saveScrollPosition = () => {
       const currentScroll = window.scrollY;
-      if (currentScroll > 0) {
+      if (currentScroll >= 0) {
         sessionStorage.setItem(
           cacheKey,
           JSON.stringify({
@@ -35,28 +53,27 @@ const PostsFeedScrollRestoration: FC<Props> = ({
     const savedScrollData = sessionStorage.getItem(cacheKey);
     const parsedScrollData = savedScrollData ? JSON.parse(savedScrollData) : {};
     const { scrollPathName, scrollPosition } = parsedScrollData;
+
+    const minRequiredQuestions = (pageNumber - 1) * POSTS_PER_PAGE;
     if (
       scrollPosition &&
-      initialQuestions.length > 0 &&
+      initialQuestions.length > minRequiredQuestions &&
       !!pageNumber &&
       scrollPathName === fullPathname
     ) {
-      timeoutId = setTimeout(() => {
-        window.scrollTo({
-          top: parseInt(scrollPosition),
-          behavior: "smooth",
-        });
+      window.scrollTo({
+        top: parseInt(scrollPosition),
+        behavior: "smooth",
+      });
 
-        sessionStorage.removeItem(cacheKey);
-        window.addEventListener("scrollend", saveScrollPosition);
-      }, 1000);
+      sessionStorage.removeItem(cacheKey);
+      window.addEventListener("scrollend", saveScrollPosition);
     } else {
       window.addEventListener("scrollend", saveScrollPosition);
     }
 
     return () => {
       window.removeEventListener("scrollend", saveScrollPosition);
-      timeoutId && clearTimeout(timeoutId);
     };
   }, [fullPathname, initialQuestions.length, pageNumber]);
 

--- a/front_end/src/components/posts_feed/paginated_feed.tsx
+++ b/front_end/src/components/posts_feed/paginated_feed.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { sendGAEvent } from "@next/third-parties/google";
+import { isNil } from "lodash";
 import { useTranslations } from "next-intl";
 import { FC, Fragment, useEffect, useState } from "react";
 
@@ -37,7 +38,10 @@ const PaginatedPostsFeed: FC<Props> = ({
 }) => {
   const t = useTranslations();
   const { params, setParam, shallowNavigateToSearchParams } = useSearchParams();
-  const pageNumber = Number(params.get(POST_PAGE_FILTER));
+  const pageNumberParam = params.get(POST_PAGE_FILTER);
+  const pageNumber = !isNil(pageNumberParam)
+    ? Number(params.get(POST_PAGE_FILTER))
+    : 1;
   const [paginatedPosts, setPaginatedPosts] =
     useState<PostWithForecasts[]>(initialQuestions);
   const [offset, setOffset] = useState(
@@ -135,6 +139,7 @@ const PaginatedPostsFeed: FC<Props> = ({
           <Fragment key={p.id}>{renderPost(p)}</Fragment>
         ))}
         <PostsFeedScrollRestoration
+          serverPage={filters.page ?? null}
           pageNumber={pageNumber}
           initialQuestions={initialQuestions}
         />

--- a/front_end/src/hooks/use_search_input_state.ts
+++ b/front_end/src/hooks/use_search_input_state.ts
@@ -1,7 +1,9 @@
+import { isNil } from "lodash";
 import { useEffect, useState } from "react";
 
 import { POST_ORDER_BY_FILTER, POST_PAGE_FILTER } from "@/constants/posts_feed";
 import useDebounce from "@/hooks/use_debounce";
+import usePrevious from "@/hooks/use_previous";
 import useSearchParams from "@/hooks/use_search_params";
 import { QuestionOrder } from "@/types/question";
 
@@ -21,8 +23,13 @@ const useSearchInputState = (paramName: string, config?: Config) => {
     return search ? decodeURIComponent(search) : "";
   });
   const debouncedSearch = useDebounce(search, debounceTime);
+  const prevDebouncedSearch = usePrevious(search);
 
   useEffect(() => {
+    if (isNil(prevDebouncedSearch)) {
+      return;
+    }
+
     const withNavigation = mode === "server";
 
     if (debouncedSearch) {
@@ -50,7 +57,7 @@ const useSearchInputState = (paramName: string, config?: Config) => {
       shallowNavigateToSearchParams();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedSearch, mode, paramName]);
+  }, [debouncedSearch, prevDebouncedSearch, mode, paramName]);
 
   return [search, setSearch] as const;
 };


### PR DESCRIPTION
This PR is related to #1149 and includes some fixes for feed restoration regressions

- fixed redundant effect calls in `useSearchInputState` hook which resulted in unexpected page param cleanup
- found and fixed an issue when shallow page param wasn’t properly added on server, which resulted in invalid request on initial page load
- improved scrolling experience by reducing scroll delay (now it depends on BE response time)
- disabled native scroll restoration when custom solution is applied to improve the UX