### PR TITLE
Key factors feedback

### DIFF
--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -34,6 +34,7 @@
   "report": "Report",
   "delete": "Delete",
   "copyLink": "Copy Link",
+  "copyId": "Copy ID",
   "continueButton": "Continue",
   "submit": "Submit",
   "submitTagsFeedback": "Submit Tags Feedback",

--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
@@ -118,6 +118,11 @@ export default async function IndividualQuestion({
 }: Props) {
   const postData = await cachedGetPost(params.id);
   const defaultProject = postData.projects.default_project;
+  const keyFactors = (postData.key_factors ?? []).sort((a, b) =>
+    b.votes_score === a.votes_score
+      ? Math.random() - 0.5
+      : b.votes_score - a.votes_score
+  );
 
   if (postData.notebook) {
     return redirect(
@@ -220,8 +225,8 @@ export default async function IndividualQuestion({
                   />
                 )}
                 <div className="flex flex-col gap-2.5">
-                  {!!postData.key_factors?.length && (
-                    <KeyFactorsSection keyFactors={postData.key_factors} />
+                  {!!keyFactors.length && (
+                    <KeyFactorsSection keyFactors={keyFactors} />
                   )}
                   <BackgroundInfo post={postData} />
                   <HistogramDrawer post={postData} />

--- a/front_end/src/app/(main)/questions/[id]/components/key_factors.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { FC, useState } from "react";
+import { FC, useEffect, useState } from "react";
 
 import KeyFactorVoter from "@/components/comment_feed/key_factor_voter";
 import Button from "@/components/ui/button";
 import SectionToggle from "@/components/ui/section_toggle";
+import useHash from "@/hooks/use_hash";
 import { KeyFactor } from "@/types/comment";
 
 type KeyFactorsSectionProps = {
@@ -15,6 +16,12 @@ type KeyFactorsSectionProps = {
 const KeyFactorsSection: FC<KeyFactorsSectionProps> = ({ keyFactors }) => {
   const t = useTranslations();
   const [displayLimit, setDisplayLimit] = useState(4);
+  const hash = useHash();
+
+  useEffect(() => {
+    // Expands the key factor list when you follow the #key-factors link.
+    if (hash === "key-factors") setDisplayLimit(keyFactors.length);
+  }, [hash, keyFactors.length]);
 
   return (
     <SectionToggle title={t("keyFactors")} defaultOpen id="key-factors">

--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -301,8 +301,14 @@ const Comment: FC<CommentProps> = ({
       name: t("copyLink"),
       onClick: () => {
         const urlWithoutHash = window.location.href.split("#")[0];
-        copyToClipboard(`${urlWithoutHash}#comment-${comment.id}`);
+        void copyToClipboard(`${urlWithoutHash}#comment-${comment.id}`);
       },
+    },
+    {
+      hidden: !user?.is_staff,
+      id: "copyId",
+      name: t("copyId"),
+      onClick: () => copyToClipboard(comment.id.toString()),
     },
     {
       hidden: !user?.id,

--- a/front_end/src/components/comment_feed/comment_key_factor.tsx
+++ b/front_end/src/components/comment_feed/comment_key_factor.tsx
@@ -12,13 +12,13 @@ const CommentKeyFactor: FC<Props> = ({ keyFactor: { text } }) => {
   const t = useTranslations();
 
   return (
-    <div className="left-5 top-5 order-none my-2 box-border flex flex-col items-center gap-1.5 rounded border border-blue-500 bg-blue-300 p-3 text-xs dark:border-blue-500-dark dark:bg-blue-300-dark md:flex-row md:gap-3">
-      <div className="w-full text-nowrap uppercase text-gray-500 dark:text-gray-600-dark md:w-fit">
+    <div className="left-5 top-5 order-none my-2 box-border flex flex-col items-center gap-1.5 rounded border border-blue-500 bg-blue-300 p-3 dark:border-blue-500-dark dark:bg-blue-300-dark md:flex-row md:gap-3">
+      <div className="w-full text-nowrap text-xs uppercase text-gray-500 dark:text-gray-600-dark md:w-fit">
         {t("keyFactor")}
       </div>
       <Link
         href="#key-factors"
-        className="w-full text-blue-800 no-underline hover:underline dark:text-blue-800-dark md:w-fit"
+        className="w-full text-sm text-blue-800 no-underline hover:underline dark:text-blue-800-dark md:w-fit"
       >
         {text}
       </Link>

--- a/front_end/src/components/comment_feed/comment_key_factor.tsx
+++ b/front_end/src/components/comment_feed/comment_key_factor.tsx
@@ -16,12 +16,12 @@ const CommentKeyFactor: FC<Props> = ({ keyFactor: { text } }) => {
       <div className="w-full text-nowrap text-xs uppercase text-gray-500 dark:text-gray-600-dark md:w-fit">
         {t("keyFactor")}
       </div>
-      <Link
+      <a
         href="#key-factors"
         className="w-full text-sm text-blue-800 no-underline hover:underline dark:text-blue-800-dark md:w-fit"
       >
         {text}
-      </Link>
+      </a>
     </div>
   );
 };


### PR DESCRIPTION
- The key factor font size on comments looks smaller than in figma
- Expand the key factor list (= show more) when you follow the #key-factors link.
- Find posts by pasting the post_id in the search box in admin.
- Add a "copy id" option to the comment menu (for mods & admins only).
