### PR TITLE
Suggest usernames when typing @ in comment (improvements)

### DIFF
--- a/front_end/src/app/(main)/questions/actions.ts
+++ b/front_end/src/app/(main)/questions/actions.ts
@@ -285,7 +285,17 @@ export async function reportComment(
 
 export async function searchUsers(query: string) {
   try {
-    return await ProfileApi.searchUsers(query);
+    const usersResponse = await ProfileApi.searchUsers(query);
+    usersResponse.results.sort((a, b) => {
+      const usernameA = a.username.toLowerCase();
+      const usernameB = b.username.toLowerCase();
+      const search = query.toLowerCase();
+
+      const startsWithA = usernameA.startsWith(search) ? 0 : 1;
+      const startsWithB = usernameB.startsWith(search) ? 0 : 1;
+      return startsWithA - startsWithB;
+    });
+    return usersResponse;
   } catch (err) {
     const error = err as FetchError;
 

--- a/front_end/src/app/(main)/questions/actions.ts
+++ b/front_end/src/app/(main)/questions/actions.ts
@@ -285,17 +285,7 @@ export async function reportComment(
 
 export async function searchUsers(query: string) {
   try {
-    const usersResponse = await ProfileApi.searchUsers(query);
-    usersResponse.results.sort((a, b) => {
-      const usernameA = a.username.toLowerCase();
-      const usernameB = b.username.toLowerCase();
-      const search = query.toLowerCase();
-
-      const startsWithA = usernameA.startsWith(search) ? 0 : 1;
-      const startsWithB = usernameB.startsWith(search) ? 0 : 1;
-      return startsWithA - startsWithB;
-    });
-    return usersResponse;
+    return await ProfileApi.searchUsers(query);
   } catch (err) {
     const error = err as FetchError;
 

--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -188,9 +188,7 @@ const Comment: FC<CommentProps> = ({
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleted, setIsDeleted] = useState(comment.is_soft_deleted);
   const [isReplying, setIsReplying] = useState(false);
-  const [commentMarkdown, setCommentMarkdown] = useState(
-    parseUserMentions(comment.text, comment.mentioned_users)
-  );
+  const [commentMarkdown, setCommentMarkdown] = useState(comment.text);
   const [tempCommentMarkdown, setTempCommentMarkdown] = useState("");
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
 
@@ -461,7 +459,10 @@ const Comment: FC<CommentProps> = ({
           )}{" "}
           {!isEditing && (
             <MarkdownEditor
-              markdown={commentMarkdown}
+              markdown={parseUserMentions(
+                commentMarkdown,
+                comment.mentioned_users
+              )}
               mode={"read"}
               withUgcLinks
             />
@@ -496,12 +497,7 @@ const Comment: FC<CommentProps> = ({
                     const newCommentData = newCommentDataResponse.results.find(
                       (q) => q.id === comment.id
                     );
-                    setCommentMarkdown(
-                      parseUserMentions(
-                        commentMarkdown,
-                        newCommentData?.mentioned_users
-                      )
-                    );
+                    setCommentMarkdown(commentMarkdown);
                   }
                   setIsEditing(false);
                 }
@@ -583,7 +579,7 @@ const Comment: FC<CommentProps> = ({
         <CommentEditor
           parentId={comment.id}
           postId={comment.on_post}
-          text={formatMention(comment)}
+          replyUsername={comment.author.username}
           onSubmit={(newComment: CommentType) => {
             addNewChildrenComment(comment, newComment);
             setIsReplying(false);
@@ -618,10 +614,6 @@ function addNewChildrenComment(comment: CommentType, newComment: CommentType) {
   comment.children.map((nestedComment) => {
     addNewChildrenComment(nestedComment, newComment);
   });
-}
-
-function formatMention(comment: CommentType) {
-  return `[@${comment.author.username}](/accounts/profile/${comment.author.id})`;
 }
 
 export default Comment;

--- a/front_end/src/components/comment_feed/comment_editor.tsx
+++ b/front_end/src/components/comment_feed/comment_editor.tsx
@@ -21,6 +21,7 @@ interface CommentEditorProps {
   shouldIncludeForecast?: boolean;
   onSubmit?: (newComment: CommentType) => void;
   isReplying?: boolean;
+  replyUsername?: string;
   isPrivateFeed?: boolean;
 }
 
@@ -31,6 +32,7 @@ const CommentEditor: FC<CommentEditorProps> = ({
   onSubmit,
   shouldIncludeForecast,
   isReplying = false,
+  replyUsername,
   isPrivateFeed = false,
 }) => {
   const t = useTranslations();
@@ -158,6 +160,7 @@ const CommentEditor: FC<CommentEditorProps> = ({
             shouldConfirmLeave={isMarkdownDirty}
             withUgcLinks
             withUserMentions
+            initialMention={replyUsername}
           />
         </div>
       )}

--- a/front_end/src/components/comment_feed/index.tsx
+++ b/front_end/src/components/comment_feed/index.tsx
@@ -3,6 +3,7 @@
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
+import { isNil } from "lodash";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { FC, useCallback, useEffect, useMemo, useState } from "react";
@@ -152,8 +153,14 @@ const CommentFeed: FC<Props> = ({
   const includeUserForecast = shouldIncludeForecast(postData);
 
   const commentAuthorMentionItems: MentionItem[] = useMemo(
-    () => extractUniqueAuthors(comments),
-    [comments]
+    () =>
+      extractUniqueAuthors({
+        authorId: postData?.author_id,
+        authorUsername: postData?.author_username,
+        coauthors: postData?.coauthors,
+        comments,
+      }),
+    [comments, postData]
   );
 
   const { setBannerisVisible } = useContentTranslatedBannerProvider();
@@ -466,8 +473,28 @@ const CommentFeed: FC<Props> = ({
   );
 };
 
-function extractUniqueAuthors(comments: CommentType[]): MentionItem[] {
+function extractUniqueAuthors({
+  authorId,
+  authorUsername,
+  coauthors,
+  comments,
+}: {
+  comments: CommentType[];
+  authorId?: number;
+  authorUsername?: string;
+  coauthors?: { id: number; username: string }[];
+}): MentionItem[] {
   const authorMap = new Map<number, string>();
+
+  if (!isNil(authorId) && !isNil(authorUsername)) {
+    authorMap.set(authorId, authorUsername);
+  }
+
+  if (!isNil(coauthors)) {
+    for (const coauthor of coauthors) {
+      authorMap.set(coauthor.id, coauthor.username);
+    }
+  }
 
   const traverseComments = (commentList: CommentType[]) => {
     for (const comment of commentList) {

--- a/front_end/src/components/markdown_editor/index.tsx
+++ b/front_end/src/components/markdown_editor/index.tsx
@@ -70,6 +70,7 @@ type Props = {
   shouldConfirmLeave?: boolean;
   withUgcLinks?: boolean;
   className?: string;
+  initialMention?: string;
 };
 
 const PlainTextCodeEditorDescriptor: CodeBlockEditorDescriptor = {
@@ -95,6 +96,7 @@ const MarkdownEditor: FC<Props> = ({
   className,
   shouldConfirmLeave = false,
   withUgcLinks,
+  initialMention,
 }) => {
   const { theme } = useAppTheme();
   const [errorMarkdown, setErrorMarkdown] = useState<string | null>(null);
@@ -120,7 +122,13 @@ const MarkdownEditor: FC<Props> = ({
     linkPlugin({
       withUgcLinks,
     }),
-    ...(withUserMentions ? [mentionsPlugin()] : []),
+    ...(withUserMentions
+      ? [
+          mentionsPlugin({
+            initialMention,
+          }),
+        ]
+      : []),
     quotePlugin(),
     markdownShortcutPlugin(),
     codeBlockPlugin({

--- a/front_end/src/components/markdown_editor/index.tsx
+++ b/front_end/src/components/markdown_editor/index.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/components/markdown_editor/embedded_math_jax";
 import { linkPlugin } from "@/components/markdown_editor/plugins/link";
 import { mentionsPlugin } from "@/components/markdown_editor/plugins/mentions";
+import { useAuth } from "@/contexts/auth_context";
 import useAppTheme from "@/hooks/use_app_theme";
 import useConfirmPageLeave from "@/hooks/use_confirm_page_leave";
 import { logErrorWithScope } from "@/utils/errors";
@@ -98,6 +99,7 @@ const MarkdownEditor: FC<Props> = ({
   withUgcLinks,
   initialMention,
 }) => {
+  const { user } = useAuth();
   const { theme } = useAppTheme();
   const [errorMarkdown, setErrorMarkdown] = useState<string | null>(null);
   const editorRef = useRef<MDXEditorMethods>(null);
@@ -126,6 +128,7 @@ const MarkdownEditor: FC<Props> = ({
       ? [
           mentionsPlugin({
             initialMention,
+            isStuff: user?.is_staff || user?.is_superuser,
           }),
         ]
       : []),

--- a/front_end/src/components/markdown_editor/plugins/mentions/LexicalBeautifulMentionVisitor.ts
+++ b/front_end/src/components/markdown_editor/plugins/mentions/LexicalBeautifulMentionVisitor.ts
@@ -5,9 +5,6 @@ import {
 } from "lexical-beautiful-mentions";
 import * as Mdast from "mdast";
 
-import { MentionData } from "./types";
-import { generateMentionLink } from "./utils";
-
 export const LexicalBeautifulMentionVisitor: LexicalExportVisitor<
   BeautifulMentionNode,
   Mdast.Link
@@ -15,16 +12,9 @@ export const LexicalBeautifulMentionVisitor: LexicalExportVisitor<
   testLexicalNode: $isBeautifulMentionNode,
   visitLexicalNode: ({ lexicalNode, actions }) => {
     const value = lexicalNode.getValue();
-    const data: MentionData | undefined = lexicalNode.getData();
 
-    actions.addAndStepInto(
-      "link",
-      {
-        url: generateMentionLink(value, data),
-        title: null,
-        children: [{ type: "text", value: `@${value}` }],
-      },
-      false
-    );
+    actions.addAndStepInto("text", {
+      value: `@${value}`,
+    });
   },
 };

--- a/front_end/src/components/markdown_editor/plugins/mentions/components/mention.tsx
+++ b/front_end/src/components/markdown_editor/plugins/mentions/components/mention.tsx
@@ -1,11 +1,9 @@
 import { BeautifulMentionComponentProps } from "lexical-beautiful-mentions";
 import { forwardRef } from "react";
 
-import { MentionData } from "../types";
-
 const CustomMentionComponent = forwardRef<
   HTMLAnchorElement,
-  BeautifulMentionComponentProps<MentionData>
+  BeautifulMentionComponentProps
 >(({ trigger, value, data: myData, children, ...other }, ref) => {
   return (
     <span {...other} ref={ref}>

--- a/front_end/src/components/markdown_editor/plugins/mentions/components/mention.tsx
+++ b/front_end/src/components/markdown_editor/plugins/mentions/components/mention.tsx
@@ -1,35 +1,16 @@
 import { BeautifulMentionComponentProps } from "lexical-beautiful-mentions";
-import { forwardRef, useEffect } from "react";
-
-import { logErrorWithScope } from "@/utils/errors";
+import { forwardRef } from "react";
 
 import { MentionData } from "../types";
-import { generateMentionLink } from "../utils";
 
 const CustomMentionComponent = forwardRef<
   HTMLAnchorElement,
   BeautifulMentionComponentProps<MentionData>
 >(({ trigger, value, data: myData, children, ...other }, ref) => {
-  const mentionLink = generateMentionLink(value, myData);
-
-  useEffect(() => {
-    if (!mentionLink) {
-      logErrorWithScope(
-        new Error("Mention link is not generated"),
-        { value, myData },
-        "Couldn't generate mention link"
-      );
-    }
-  }, [mentionLink, myData, value]);
-
-  if (!mentionLink) {
-    return null;
-  }
-
   return (
-    <a {...other} ref={ref} href={mentionLink} target="_blank">
+    <span {...other} ref={ref}>
       {trigger + value}
-    </a>
+    </span>
   );
 });
 CustomMentionComponent.displayName = "CustomMentionComponent";

--- a/front_end/src/components/markdown_editor/plugins/mentions/components/plugin.tsx
+++ b/front_end/src/components/markdown_editor/plugins/mentions/components/plugin.tsx
@@ -1,12 +1,29 @@
-import { BeautifulMentionsPlugin } from "lexical-beautiful-mentions";
-import { FC } from "react";
+import {
+  BeautifulMentionsPlugin,
+  useBeautifulMentions,
+} from "lexical-beautiful-mentions";
+import { FC, useEffect, useRef } from "react";
 
 import useUserMentionsContext from "./default_mentions_context";
 import { Menu, MenuItem } from "./menu";
 import { queryMentions } from "../utils";
 
-const MentionsPlugin: FC = () => {
+type Props = {
+  initialMention?: string;
+};
+
+const MentionsPlugin: FC<Props> = ({ initialMention }) => {
   const { defaultUserMentions } = useUserMentionsContext();
+  const { insertMention } = useBeautifulMentions();
+
+  const insertedReplyMention = useRef(false);
+
+  useEffect(() => {
+    if (initialMention && !insertedReplyMention.current) {
+      insertMention({ trigger: "@", value: initialMention });
+      insertedReplyMention.current = true;
+    }
+  }, [insertMention, initialMention]);
 
   return (
     <BeautifulMentionsPlugin

--- a/front_end/src/components/markdown_editor/plugins/mentions/components/plugin.tsx
+++ b/front_end/src/components/markdown_editor/plugins/mentions/components/plugin.tsx
@@ -10,9 +10,10 @@ import { queryMentions } from "../utils";
 
 type Props = {
   initialMention?: string;
+  isStuff?: boolean;
 };
 
-const MentionsPlugin: FC<Props> = ({ initialMention }) => {
+const MentionsPlugin: FC<Props> = ({ initialMention, isStuff }) => {
   const { defaultUserMentions } = useUserMentionsContext();
   const { insertMention } = useBeautifulMentions();
 
@@ -29,11 +30,12 @@ const MentionsPlugin: FC<Props> = ({ initialMention }) => {
     <BeautifulMentionsPlugin
       triggers={["@"]}
       onSearch={(trigger, queryString) =>
-        queryMentions(trigger, queryString, defaultUserMentions)
+        queryMentions(trigger, queryString, defaultUserMentions, isStuff)
       }
       menuComponent={Menu}
       menuItemComponent={MenuItem}
       menuItemLimit={false}
+      autoSpace={false}
     />
   );
 };

--- a/front_end/src/components/markdown_editor/plugins/mentions/index.tsx
+++ b/front_end/src/components/markdown_editor/plugins/mentions/index.tsx
@@ -13,15 +13,19 @@ import CustomMentionComponent from "./components/mention";
 import MentionsPlugin from "./components/plugin";
 import { LexicalBeautifulMentionVisitor } from "./LexicalBeautifulMentionVisitor";
 
-export const mentionsPlugin = realmPlugin({
-  init(realm) {
+export const mentionsPlugin = realmPlugin<{
+  initialMention?: string;
+}>({
+  init(realm, params) {
     realm.pubIn({
       [addLexicalNode$]: [
         ...createBeautifulMentionNode(CustomMentionComponent),
         PlaceholderNode,
       ],
       [addExportVisitor$]: LexicalBeautifulMentionVisitor,
-      [addComposerChild$]: () => <MentionsPlugin />,
+      [addComposerChild$]: () => (
+        <MentionsPlugin initialMention={params?.initialMention} />
+      ),
     });
   },
 });

--- a/front_end/src/components/markdown_editor/plugins/mentions/index.tsx
+++ b/front_end/src/components/markdown_editor/plugins/mentions/index.tsx
@@ -15,6 +15,7 @@ import { LexicalBeautifulMentionVisitor } from "./LexicalBeautifulMentionVisitor
 
 export const mentionsPlugin = realmPlugin<{
   initialMention?: string;
+  isStuff?: boolean;
 }>({
   init(realm, params) {
     realm.pubIn({
@@ -24,7 +25,10 @@ export const mentionsPlugin = realmPlugin<{
       ],
       [addExportVisitor$]: LexicalBeautifulMentionVisitor,
       [addComposerChild$]: () => (
-        <MentionsPlugin initialMention={params?.initialMention} />
+        <MentionsPlugin
+          initialMention={params?.initialMention}
+          isStuff={params?.isStuff}
+        />
       ),
     });
   },

--- a/front_end/src/components/markdown_editor/plugins/mentions/types.ts
+++ b/front_end/src/components/markdown_editor/plugins/mentions/types.ts
@@ -1,6 +1,8 @@
 export type MentionData = {
   userId?: number;
 };
+
+// TODO: deprecate userId as we don't convert mention item to link anymore (when in edit mode0
 export type MentionItem = {
   value: string;
 } & MentionData;

--- a/front_end/src/components/markdown_editor/plugins/mentions/types.ts
+++ b/front_end/src/components/markdown_editor/plugins/mentions/types.ts
@@ -1,8 +1,3 @@
-export type MentionData = {
-  userId?: number;
-};
-
-// TODO: deprecate userId as we don't convert mention item to link anymore (when in edit mode0
 export type MentionItem = {
   value: string;
-} & MentionData;
+};

--- a/front_end/src/components/markdown_editor/plugins/mentions/utils.ts
+++ b/front_end/src/components/markdown_editor/plugins/mentions/utils.ts
@@ -35,10 +35,33 @@ export async function queryMentions(
   return [
     ...users.results.map((user) => ({ value: user.username, userId: user.id })),
     ...usersGroupMentions,
-  ];
+  ].sort((a, b) => {
+    const usernameA = a.value.toLowerCase();
+    const usernameB = b.value.toLowerCase();
+    const search = query.toLowerCase();
+
+    const startsWithA = usernameA.startsWith(search) ? 0 : 1;
+    const startsWithB = usernameB.startsWith(search) ? 0 : 1;
+    return startsWithA - startsWithB;
+  });
 }
 
 const clientSearch = (query: string, mentions: MentionItem[]) =>
-  mentions.filter((mention) =>
-    mention.value.toLowerCase().includes(query?.toLowerCase() ?? "")
+  sortUsernames(
+    query,
+    mentions.filter((mention) =>
+      mention.value.toLowerCase().includes(query?.toLowerCase() ?? "")
+    )
   );
+
+const sortUsernames = (query: string, mentions: MentionItem[]) => {
+  return [...mentions].sort((a, b) => {
+    const usernameA = a.value.toLowerCase();
+    const usernameB = b.value.toLowerCase();
+    const search = query.toLowerCase();
+
+    const startsWithA = usernameA.startsWith(search) ? 0 : 1;
+    const startsWithB = usernameB.startsWith(search) ? 0 : 1;
+    return startsWithA - startsWithB;
+  });
+};

--- a/front_end/src/components/markdown_editor/plugins/mentions/utils.ts
+++ b/front_end/src/components/markdown_editor/plugins/mentions/utils.ts
@@ -32,18 +32,10 @@ export async function queryMentions(
     return clientSearch(query, fallbackMentions);
   }
 
-  return [
+  return sortUsernames(query, [
     ...users.results.map((user) => ({ value: user.username, userId: user.id })),
     ...usersGroupMentions,
-  ].sort((a, b) => {
-    const usernameA = a.value.toLowerCase();
-    const usernameB = b.value.toLowerCase();
-    const search = query.toLowerCase();
-
-    const startsWithA = usernameA.startsWith(search) ? 0 : 1;
-    const startsWithB = usernameB.startsWith(search) ? 0 : 1;
-    return startsWithA - startsWithB;
-  });
+  ]);
 }
 
 const clientSearch = (query: string, mentions: MentionItem[]) =>

--- a/front_end/src/components/markdown_editor/plugins/mentions/utils.ts
+++ b/front_end/src/components/markdown_editor/plugins/mentions/utils.ts
@@ -2,18 +2,6 @@ import { searchUsers } from "@/app/(main)/questions/actions";
 
 import { MentionData, MentionItem } from "./types";
 
-export function generateMentionLink(value: string, data?: MentionData) {
-  if (!data || !Object.keys(data).length) {
-    if (["moderators", "predictors", "admins", "members"].includes(value)) {
-      return `/faq/#${value}-tag`;
-    }
-
-    return null;
-  }
-
-  return `/accounts/profile/${data.userId}`;
-}
-
 export async function queryMentions(
   _trigger: string,
   query: string | null | undefined,

--- a/front_end/src/components/markdown_editor/plugins/mentions/utils.ts
+++ b/front_end/src/components/markdown_editor/plugins/mentions/utils.ts
@@ -1,18 +1,21 @@
 import { searchUsers } from "@/app/(main)/questions/actions";
 
-import { MentionData, MentionItem } from "./types";
+import { MentionItem } from "./types";
 
 export async function queryMentions(
   _trigger: string,
   query: string | null | undefined,
-  defaultUserMentions?: MentionItem[]
+  defaultUserMentions?: MentionItem[],
+  isStuff?: boolean
 ): Promise<MentionItem[]> {
   const usersGroupMentions = [
     { value: "moderators" },
-    { value: "predictors" },
     { value: "admins" },
     { value: "members" },
   ];
+  if (isStuff) {
+    usersGroupMentions.push({ value: "predictors" });
+  }
   const fallbackUserMentions = defaultUserMentions ? defaultUserMentions : [];
   const fallbackMentions = [...fallbackUserMentions, ...usersGroupMentions];
 


### PR DESCRIPTION
This PR addresses #538, #1493 and focuses on resolving feedback provided in the comments:

- Populated the default mentions list with the post author and co-authors.
- Fixed broken mentions interactions caused by conflicts with the link popup:
  - Mentions now use plain text in edit mode, similar to GitHub mentions. Markdown links are rendered only in read mode.
  - Mentions will be stored as plain text in the backend, improving scalability (e.g., accommodating changes to profile page URLs)
- Implemented sorting of suggested users to prioritize matches with the user query (e.g., "ryanb" listed before "bryanb")
- Disabled auto-spacing around the mention component to avoid double spacing
- Adjusted predictor suggestions to display only for staff and superusers

Note: some parts were skipped for now, as implementing those would be time-consuming:
- Focused UI for mention cards: `lexical-beautiful-mentions` API doesn't match with the way MDX Editor provides custom theming. Therefore, in order to be able to style this variant we would need to patch the package and implement a custom solution
- Selecting a mention with space: this one would also require a workaround to implement as `lexical-beautiful-mentions` doesn't support custom keyboard triggers for mention selection (supports enter and tab by default)