### PR TITLE
Filter the feed by followed status

### DIFF
--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -644,6 +644,7 @@
   "childResolutionCriteria": "Child Resolution Criteria",
   "loadMoreComments": "Load more comments",
   "followers": "Followers",
+  "followed": "Followed",
   "followButton": "Follow",
   "followingButton": "Following",
   "unfollowButton": "Unfollow",

--- a/front_end/src/app/(main)/c/[slug]/page.tsx
+++ b/front_end/src/app/(main)/c/[slug]/page.tsx
@@ -39,7 +39,7 @@ export default async function IndividualCommunity({
         <CommunityInfo community={community} />
 
         <div className="min-h-[calc(100vh-300px)] grow overflow-x-hidden p-2 pt-2.5 no-scrollbar sm:p-0 sm:pt-5">
-          <FeedFilters />
+          <FeedFilters forFeedHome={false} />
           <Suspense
             key={JSON.stringify(searchParams)}
             fallback={

--- a/front_end/src/app/(main)/questions/components/feed_filters/index.tsx
+++ b/front_end/src/app/(main)/questions/components/feed_filters/index.tsx
@@ -9,7 +9,11 @@ import { FeedType } from "@/constants/posts_feed";
 
 import MyPredictionsFilters from "./my_predictions";
 
-const FeedFilters: FC = () => {
+type Props = {
+  forFeedHome?: boolean;
+};
+
+const FeedFilters: FC<Props> = ({ forFeedHome = true }) => {
   const { currentFeed } = useFeed();
 
   switch (currentFeed) {
@@ -20,7 +24,7 @@ const FeedFilters: FC = () => {
     case FeedType.IN_REVIEW:
       return <InReviewFeed />;
     default:
-      return <MainFeedFilters />;
+      return <MainFeedFilters forFeedHome={forFeedHome} />;
   }
 };
 

--- a/front_end/src/app/(main)/questions/components/feed_filters/main.tsx
+++ b/front_end/src/app/(main)/questions/components/feed_filters/main.tsx
@@ -16,7 +16,11 @@ import useSearchParams from "@/hooks/use_search_params";
 import { PostStatus } from "@/types/post";
 import { QuestionOrder } from "@/types/question";
 
-const MainFeedFilters: FC = () => {
+type Props = {
+  forFeedHome?: boolean;
+};
+
+const MainFeedFilters: FC<Props> = ({ forFeedHome = true }) => {
   const { params } = useSearchParams();
   const t = useTranslations();
   const { user } = useAuth();
@@ -52,12 +56,20 @@ const MainFeedFilters: FC = () => {
         value: QuestionOrder.WeeklyMovementDesc,
         label: t("movers"),
       },
+      ...(forFeedHome
+        ? [
+            {
+              value: QuestionOrder.Following,
+              label: t("followed"),
+            },
+          ]
+        : []),
       {
         value: QuestionOrder.PublishTimeDesc,
         label: t("new"),
       },
     ],
-    [t]
+    [t, forFeedHome]
   );
 
   const sortOptions = useMemo(

--- a/front_end/src/app/(main)/questions/components/feed_filters/main.tsx
+++ b/front_end/src/app/(main)/questions/components/feed_filters/main.tsx
@@ -56,7 +56,7 @@ const MainFeedFilters: FC<Props> = ({ forFeedHome = true }) => {
         value: QuestionOrder.WeeklyMovementDesc,
         label: t("movers"),
       },
-      ...(forFeedHome
+      ...(forFeedHome && user
         ? [
             {
               value: QuestionOrder.Following,

--- a/front_end/src/app/(main)/questions/helpers/filters.ts
+++ b/front_end/src/app/(main)/questions/helpers/filters.ts
@@ -26,6 +26,7 @@ import {
   POST_TYPE_FILTER,
   POST_UPVOTED_BY_FILTER,
   POST_USERNAMES_FILTER,
+  POST_FOLLOWING_FILTER,
 } from "@/constants/posts_feed";
 import { PostsParams } from "@/services/posts";
 import { SearchParams } from "@/types/navigation";
@@ -77,6 +78,10 @@ export function generateFiltersFromSearchParams(
 
   if (!withoutPageParam && typeof searchParams[POST_PAGE_FILTER] === "string") {
     filters.page = Number(searchParams[POST_PAGE_FILTER]);
+  }
+
+  if (typeof searchParams[POST_FOLLOWING_FILTER] === "string") {
+    filters.following = Boolean(searchParams[POST_FOLLOWING_FILTER]);
   }
 
   if (typeof searchParams[POST_TEXT_SEARCH_FILTER] === "string") {
@@ -256,6 +261,12 @@ export function getFilterSectionParticipation({
         label: t("notPredicted"),
         value: user.id.toString(),
         active: !!params.get(POST_NOT_FORECASTER_ID_FILTER),
+      },
+      {
+        id: POST_FOLLOWING_FILTER,
+        label: t("followed"),
+        value: QuestionOrder.Following,
+        active: !!params.get(POST_FOLLOWING_FILTER),
       },
     ],
   };

--- a/front_end/src/components/posts_filters.tsx
+++ b/front_end/src/components/posts_filters.tsx
@@ -107,8 +107,11 @@ const PostsFilters: FC<Props> = ({
     setGlobalSearch("");
   };
 
+  const hasFollowingShortcut = mainSortOptions.find(
+    (o) => o.value === QuestionOrder.Following
+  );
   const order = (params.get(POST_ORDER_BY_FILTER) ??
-    params.get(POST_FOLLOWING_FILTER) ??
+    (hasFollowingShortcut ? params.get(POST_FOLLOWING_FILTER) : null) ??
     defaultOrder) as QuestionOrder;
 
   const [popoverFilters, activeFilters] = useMemo(() => {

--- a/front_end/src/components/tournament_filters.tsx
+++ b/front_end/src/components/tournament_filters.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/popover_filter/types";
 import PostsFilters from "@/components/posts_filters";
 import {
+  POST_FOLLOWING_FILTER,
   POST_FORECASTER_ID_FILTER,
   POST_NOT_FORECASTER_ID_FILTER,
   POST_STATUS_FILTER,
@@ -23,7 +24,6 @@ import {
 import { useAuth } from "@/contexts/auth_context";
 import useSearchParams from "@/hooks/use_search_params";
 import { PostStatus } from "@/types/post";
-import { Category, Tag } from "@/types/projects";
 import { QuestionOrder } from "@/types/question";
 import { CurrentUser } from "@/types/users";
 
@@ -142,6 +142,12 @@ function getTournamentPostsFilters({
           label: t("notPredicted"),
           value: user.id.toString(),
           active: !!params.get(POST_NOT_FORECASTER_ID_FILTER),
+        },
+        {
+          id: POST_FOLLOWING_FILTER,
+          label: t("followed"),
+          value: QuestionOrder.Following,
+          active: !!params.get(POST_FOLLOWING_FILTER),
         },
       ],
     });

--- a/front_end/src/constants/posts_feed.ts
+++ b/front_end/src/constants/posts_feed.ts
@@ -15,6 +15,7 @@ export const POST_CATEGORIES_FILTER = "categories";
 export const POST_TAGS_FILTER = "tags";
 export const POST_FORECASTER_ID_FILTER = "forecaster_id";
 export const POST_NOT_FORECASTER_ID_FILTER = "not_forecaster_id";
+export const POST_FOLLOWING_FILTER = "following";
 export const POST_FOR_MAIN_FEED = "for_main_feed";
 export const POST_AUTHOR_FILTER = "author";
 export const POST_USERNAMES_FILTER = "usernames";

--- a/front_end/src/services/posts.ts
+++ b/front_end/src/services/posts.ts
@@ -19,6 +19,7 @@ import { get, post, put } from "@/utils/fetch";
 import { encodeQueryParams } from "@/utils/navigation";
 
 export type PostsParams = PaginationParams & {
+  following?: boolean;
   page?: number;
   topic?: string;
   answered_by_me?: boolean;

--- a/front_end/src/types/question.ts
+++ b/front_end/src/types/question.ts
@@ -28,6 +28,7 @@ export enum QuestionOrder {
   HotAsc = "hotness",
   RankDesc = "-rank",
   CreatedDesc = "-created_at",
+  Following = "true", // used for main feed shortcut and filters popup
 }
 
 export type Scaling = {


### PR DESCRIPTION
Related to #1536 

- add following filter into feed filters
- integrated new filter shortcut into main feed only
- added and tested new filter on different feeds (community, tournament, main...)
- adjusted filters shortcut highlight when there is no following option