### PR TITLE
remove PENDING questions from contributions

### DIFF
--- a/scoring/models.py
+++ b/scoring/models.py
@@ -153,6 +153,7 @@ class Leaderboard(TimeStampedModel):
         invalid_statuses = [
             Post.CurationStatus.DELETED,
             Post.CurationStatus.DRAFT,
+            Post.CurationStatus.PENDING,
             Post.CurationStatus.REJECTED,
         ]
 


### PR DESCRIPTION
closes #906 

The other invalid statuses were already removed sometime after Oct 14
PENDING also needed to be removed
