### PR TITLE
Notebook page error out when slug is missing in the URL

### DIFF
--- a/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page.tsx
@@ -81,7 +81,8 @@ export default async function IndividualNotebook({ params }: Props) {
     <Header />
   );
 
-  const slugParam = params.slug[0];
+  // we can pass custom slug for indexes in params
+  const slugParam = params.slug?.[0] ?? postData.slug;
   const indexNotebook = NOTEBOOK_INDEXES[slugParam];
   if (!!indexNotebook) {
     const questionIds = indexNotebook.map((q) => q.questionId);


### PR DESCRIPTION
- fixed a page error when notebook slug is missing
- kept an option to pass custom slug in params for index notebooks (should be the same slug as a hardcoded one in the `indexes.ts` file)