### PR TITLE
"Load more" status is not maintained

### DIFF
--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/project_leaderboard_table/index.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/project_leaderboard_table/index.tsx
@@ -100,7 +100,7 @@ const ProjectLeaderboardTable: FC<Props> = ({
             variant="tertiary"
             onClick={handleLoadMoreClick}
           >
-            Load More
+            {t("loadMoreButton")}
           </Button>
         </div>
       )}

--- a/front_end/src/components/posts_feed/constants.ts
+++ b/front_end/src/components/posts_feed/constants.ts
@@ -1,0 +1,1 @@
+export const SCROLL_CACHE_KEY = `feed-scroll-restoration`;

--- a/front_end/src/components/posts_feed/constants.ts
+++ b/front_end/src/components/posts_feed/constants.ts
@@ -1,1 +1,1 @@
-export const SCROLL_CACHE_KEY = `feed-scroll-restoration`;
+export const SCROLL_CACHE_KEY = "feed-scroll-restoration";

--- a/front_end/src/components/posts_feed/feed_scroll_restoration.tsx
+++ b/front_end/src/components/posts_feed/feed_scroll_restoration.tsx
@@ -5,6 +5,8 @@ import { POSTS_PER_PAGE } from "@/constants/posts_feed";
 import useSearchParams from "@/hooks/use_search_params";
 import { PostWithForecasts } from "@/types/post";
 
+import { SCROLL_CACHE_KEY } from "./constants";
+
 type Props = {
   initialQuestions: PostWithForecasts[];
   serverPage: number | null;
@@ -36,12 +38,11 @@ const PostsFeedScrollRestoration: FC<Props> = ({
   }, []);
 
   useEffect(() => {
-    const cacheKey = `feed-scroll-restoration`;
     const saveScrollPosition = () => {
       const currentScroll = window.scrollY;
       if (currentScroll >= 0) {
         sessionStorage.setItem(
-          cacheKey,
+          SCROLL_CACHE_KEY,
           JSON.stringify({
             scrollPathName: fullPathname,
             scrollPosition: currentScroll.toString(),
@@ -50,7 +51,7 @@ const PostsFeedScrollRestoration: FC<Props> = ({
       }
     };
 
-    const savedScrollData = sessionStorage.getItem(cacheKey);
+    const savedScrollData = sessionStorage.getItem(SCROLL_CACHE_KEY);
     const parsedScrollData = savedScrollData ? JSON.parse(savedScrollData) : {};
     const { scrollPathName, scrollPosition } = parsedScrollData;
 
@@ -66,7 +67,7 @@ const PostsFeedScrollRestoration: FC<Props> = ({
         behavior: "smooth",
       });
 
-      sessionStorage.removeItem(cacheKey);
+      sessionStorage.removeItem(SCROLL_CACHE_KEY);
       window.addEventListener("scrollend", saveScrollPosition);
     } else {
       window.addEventListener("scrollend", saveScrollPosition);

--- a/front_end/src/components/posts_feed/paginated_feed.tsx
+++ b/front_end/src/components/posts_feed/paginated_feed.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { sendGAEvent } from "@next/third-parties/google";
 import { isNil } from "lodash";
+import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { FC, Fragment, useEffect, useState } from "react";
 
@@ -16,6 +17,7 @@ import { PostsParams } from "@/services/posts";
 import { PostWithForecasts, PostWithNotebook } from "@/types/post";
 import { logError } from "@/utils/errors";
 
+import { SCROLL_CACHE_KEY } from "./constants";
 import EmptyCommunityFeed from "./empty_community_feed";
 import PostsFeedScrollRestoration from "./feed_scroll_restoration";
 import InReviewBox from "./in_review_box";
@@ -37,7 +39,9 @@ const PaginatedPostsFeed: FC<Props> = ({
   isCommunity,
 }) => {
   const t = useTranslations();
+  const pathname = usePathname();
   const { params, setParam, shallowNavigateToSearchParams } = useSearchParams();
+
   const pageNumberParam = params.get(POST_PAGE_FILTER);
   const pageNumber = !isNil(pageNumberParam)
     ? Number(params.get(POST_PAGE_FILTER))
@@ -105,6 +109,17 @@ const PaginatedPostsFeed: FC<Props> = ({
         const error = err as Error & { digest?: string };
         setError(error);
       } finally {
+        const fullPathname = `${pathname}${params.toString() ? `?${params.toString()}` : ""}`;
+        const currentScroll = window.scrollY;
+        if (currentScroll >= 0) {
+          sessionStorage.setItem(
+            SCROLL_CACHE_KEY,
+            JSON.stringify({
+              scrollPathName: fullPathname,
+              scrollPosition: currentScroll.toString(),
+            })
+          );
+        }
         setIsLoading(false);
       }
     }

--- a/front_end/src/hooks/use_search_input_state.ts
+++ b/front_end/src/hooks/use_search_input_state.ts
@@ -28,10 +28,14 @@ const useSearchInputState = (paramName: string, config?: Config) => {
     return search ? decodeURIComponent(search) : "";
   });
   const debouncedSearch = useDebounce(search, debounceTime);
-  const prevDebouncedSearch = usePrevious(search);
+  const prevDebouncedSearch = usePrevious(debouncedSearch);
 
   useEffect(() => {
-    if (isNil(prevDebouncedSearch) || !modifySearchParams) {
+    if (
+      isNil(prevDebouncedSearch) ||
+      !modifySearchParams ||
+      prevDebouncedSearch === debouncedSearch
+    ) {
       return;
     }
 


### PR DESCRIPTION
Related to #1149

- fixed a regression caused by global search input changes when page param was removed after questions page navigation
- handle save of scroll position on load more event without scroll
  - (when the user clicked load more and then opened any new post without previously scrolling the page he had an old page URL saved in session storage, so then on back navigation scroll was not triggered)