### PR TITLE
Group question chart is showing the wrong forecast

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
@@ -259,7 +259,7 @@ function getQuestionTooltipLabel({
     ? cursorTimestamp >= Math.min(...timestamps)
     : cursorTimestamp >= Math.min(...timestamps) &&
       cursorTimestamp <= Math.max(...timestamps, closeTime ?? 0);
-  if (!hasValue) {
+  if (!hasValue || !question) {
     return "?";
   }
 

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
@@ -148,7 +148,7 @@ const MultipleChoiceGroupChart: FC<Props> = ({
                     values,
                     cursorTimestamp,
                     closeTime,
-                    question: questions.find((q) => q.id === id) as Question,
+                    question: questions.find((q) => q.id === id),
                   }),
             };
           }
@@ -251,7 +251,7 @@ function getQuestionTooltipLabel({
   timestamps: number[];
   values: number[];
   cursorTimestamp: number;
-  question: Question;
+  question?: Question;
   isUserPrediction?: boolean;
   closeTime?: number | undefined;
 }) {

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
@@ -130,10 +130,14 @@ const MultipleChoiceGroupChart: FC<Props> = ({
       choiceItems
         .filter(({ active }) => active)
         .map(
-          (
-            { choice, values, color, timestamps: optionTimestamps, closeTime },
-            index
-          ) => {
+          ({
+            id,
+            choice,
+            values,
+            color,
+            timestamps: optionTimestamps,
+            closeTime,
+          }) => {
             return {
               choiceLabel: choice,
               color,
@@ -144,7 +148,7 @@ const MultipleChoiceGroupChart: FC<Props> = ({
                     values,
                     cursorTimestamp,
                     closeTime,
-                    question: questions[index],
+                    question: questions.find((q) => q.id === id) as Question,
                   }),
             };
           }

--- a/front_end/src/types/choices.ts
+++ b/front_end/src/types/choices.ts
@@ -4,6 +4,7 @@ import { ThemeColor } from "@/types/theme";
 import { Scaling } from "./question";
 
 export type ChoiceItem = {
+  id?: number;
   choice: string;
   timestamps?: number[];
   closeTime?: number;

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -582,6 +582,7 @@ export function generateChoiceItemsFromGroupQuestions(
     const history = question.aggregations.recency_weighted.history;
     const label = question.label;
     return {
+      id: question.id,
       choice: label,
       values: history.map((forecast) => forecast.centers![0]),
       minValues: history.map(


### PR DESCRIPTION
Related to #1598

- fix `tooltipChoices` calculation to avoid mismatch after a change of active choices
- tested tooltip behavior after changes in the main graph and timeline graph 
  - (group questions with fan graph and conditionals questions)
- MC question doesn't have such an issue because of the way tooltip choices are calculated