### PR TITLE
Fixed private comments confusion

### DIFF
--- a/comments/services/common.py
+++ b/comments/services/common.py
@@ -69,8 +69,9 @@ def create_comment(
     # Update comments read cache counter
     PostUserSnapshot.update_viewed_at(on_post, user)
 
-    # Send related notifications
-    if on_post:
+    # Send related notifications and update counters
+    # Only if comment is public
+    if on_post and not obj.is_private:
         on_post.update_comment_count()
         run_on_post_comment_create.send(obj.id)
 

--- a/comments/views.py
+++ b/comments/views.py
@@ -147,7 +147,9 @@ def comment_create_api_view(request: Request):
 
     trigger_update_comment_translations(new_comment, force=False)
 
-    return Response(serialize_comment(new_comment), status=status.HTTP_201_CREATED)
+    return Response(
+        serialize_comment_many([new_comment])[0], status=status.HTTP_201_CREATED
+    )
 
 
 @api_view(["POST"])

--- a/front_end/src/components/comment_feed/comment_editor.tsx
+++ b/front_end/src/components/comment_feed/comment_editor.tsx
@@ -2,9 +2,9 @@
 
 import { sendGAEvent } from "@next/third-parties/google";
 import { useTranslations } from "next-intl";
-import { FC, useState, useEffect } from "react";
+import { FC, useEffect, useState } from "react";
 
-import { createComment, getComments } from "@/app/(main)/questions/actions";
+import { createComment } from "@/app/(main)/questions/actions";
 import MarkdownEditor from "@/components/markdown_editor";
 import Button from "@/components/ui/button";
 import Checkbox from "@/components/ui/checkbox";
@@ -86,24 +86,12 @@ const CommentEditor: FC<CommentEditorProps> = ({
         setErrorMessage(newComment.errors?.message);
         return;
       }
-      // TODO: remove when BE data will include mentioned users in comment creation response
-      const newCommentResponse = await getComments({
-        focus_comment_id: String(newComment.id),
-        limit: 1,
-        sort: "-created_at",
-      });
-      if ("errors" in newCommentResponse) {
-        console.error(newCommentResponse.errors?.message);
-        setErrorMessage(newCommentResponse.errors?.message);
-        return;
-      }
-      const newCommentData = newCommentResponse.results[0];
       setHasIncludedForecast(false);
       setMarkdown("");
       setIsMarkdownDirty(false);
       updateRerenderKey((prev) => prev + 1); // completely reset mdx editor
-      // TODO: revisit after BE changes
-      onSubmit && onSubmit(parseComment(newCommentData));
+
+      onSubmit && onSubmit(parseComment(newComment));
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
I fixed the issue where a foreign comment appeared instead of the one the user had just created during private comment creation. The problem was due to a small bug in the comment rendering process: after a comment was created, the frontend was not rendering the newly created one. Instead, it fetched the last comment from the post comments feed, which missed the `is_private=true` flag. As a result, the last public comment was rendered instead of the private comment the user had just created.

No private comments were exposed.

related #1517 
closes #1387