### PR TITLE
Formatting long quotes is janky

### DIFF
--- a/front_end/src/components/comment_feed/comment_editor.tsx
+++ b/front_end/src/components/comment_feed/comment_editor.tsx
@@ -86,6 +86,7 @@ const CommentEditor: FC<CommentEditorProps> = ({
         setErrorMessage(newComment.errors?.message);
         return;
       }
+      setIsEditing(true);
       setHasIncludedForecast(false);
       setMarkdown("");
       setIsMarkdownDirty(false);

--- a/front_end/src/components/markdown_editor/helpers.ts
+++ b/front_end/src/components/markdown_editor/helpers.ts
@@ -1,0 +1,44 @@
+import {
+  revertMathJaxTransform,
+  transformMathJax,
+} from "./embedded_math_jax/helpers";
+
+// escape < and { that is not correctly used
+function escapePlainTextSymbols(str: string) {
+  const tags: any = [];
+  const tagRegex = /<\/?\s*[a-zA-Z][a-zA-Z0-9-]*(?:\s+[^<>]*?)?>/g;
+  let tempStr = str.replace(tagRegex, function (match) {
+    tags.push(match);
+    return "___HTML_TAG___";
+  });
+
+  tempStr = tempStr.replace(/([^\\])</g, "$1\\<").replace(/^</g, "\\<");
+
+  let index = 0;
+  tempStr = tempStr.replace(/___HTML_TAG___/g, function () {
+    return tags[index++];
+  });
+
+  tempStr = tempStr
+    .replace(/([^{]){(?![^}]*})/g, "$1\\{")
+    .replace(/^{(?![^}]*})/g, "\\{");
+
+  return tempStr;
+}
+
+function formatBlockquoteNewlines(markdown: string): string {
+  return markdown.replace(/>\s*\n/g, "> \u00A0\n");
+}
+
+export function processMarkdown(
+  markdown: string,
+  revert: boolean = false
+): string {
+  markdown = formatBlockquoteNewlines(markdown);
+  markdown = revert
+    ? revertMathJaxTransform(markdown)
+    : transformMathJax(markdown);
+  markdown = escapePlainTextSymbols(markdown);
+
+  return markdown;
+}

--- a/front_end/src/components/markdown_editor/index.tsx
+++ b/front_end/src/components/markdown_editor/index.tsx
@@ -45,15 +45,11 @@ import useConfirmPageLeave from "@/hooks/use_confirm_page_leave";
 import { logErrorWithScope } from "@/utils/errors";
 
 import {
-  revertMathJaxTransform,
-  transformMathJax,
-} from "./embedded_math_jax/helpers";
-import {
   embeddedQuestionDescriptor,
   EmbedQuestionAction,
 } from "./embedded_question";
-
 import "./editor.css";
+import { processMarkdown } from "./helpers";
 
 type EditorMode = "write" | "read";
 
@@ -108,10 +104,7 @@ const MarkdownEditor: FC<Props> = ({
 
   // Transform MathJax syntax to JSX embeds to properly utilise the MarkJax renderer
   const formattedMarkdown = useMemo(
-    () =>
-      escapePlainTextSymbols(
-        transformMathJax(formatBlockquoteNewlines(markdown))
-      ),
+    () => processMarkdown(markdown),
     [markdown]
   );
 
@@ -214,12 +207,7 @@ const MarkdownEditor: FC<Props> = ({
       markdown={formattedMarkdown}
       onChange={(value) => {
         // Revert the MathJax transformation before passing the markdown to the parent component
-        onChange &&
-          onChange(
-            escapePlainTextSymbols(
-              revertMathJaxTransform(formatBlockquoteNewlines(value))
-            )
-          );
+        onChange && onChange(processMarkdown(value, true));
       }}
       onError={(err) => {
         logErrorWithScope(err.error, err.source);
@@ -237,33 +225,6 @@ const MarkdownEditor: FC<Props> = ({
     />
   );
 };
-
-// escape < and { that is not correctly used
-function escapePlainTextSymbols(str: string) {
-  const tags: any = [];
-  const tagRegex = /<\/?\s*[a-zA-Z][a-zA-Z0-9-]*(?:\s+[^<>]*?)?>/g;
-  let tempStr = str.replace(tagRegex, function (match) {
-    tags.push(match);
-    return "___HTML_TAG___";
-  });
-
-  tempStr = tempStr.replace(/([^\\])</g, "$1\\<").replace(/^</g, "\\<");
-
-  let index = 0;
-  tempStr = tempStr.replace(/___HTML_TAG___/g, function () {
-    return tags[index++];
-  });
-
-  tempStr = tempStr
-    .replace(/([^{]){(?![^}]*})/g, "$1\\{")
-    .replace(/^{(?![^}]*})/g, "\\{");
-
-  return tempStr;
-}
-
-function formatBlockquoteNewlines(markdown: string): string {
-  return markdown.replace(/>\s*\n/g, "> \u00A0\n");
-}
 
 export default dynamic(() => Promise.resolve(MarkdownEditor), {
   ssr: false,

--- a/front_end/src/components/markdown_editor/index.tsx
+++ b/front_end/src/components/markdown_editor/index.tsx
@@ -108,7 +108,10 @@ const MarkdownEditor: FC<Props> = ({
 
   // Transform MathJax syntax to JSX embeds to properly utilise the MarkJax renderer
   const formattedMarkdown = useMemo(
-    () => escapePlainTextSymbols(transformMathJax(markdown)),
+    () =>
+      escapePlainTextSymbols(
+        transformMathJax(formatBlockquoteNewlines(markdown))
+      ),
     [markdown]
   );
 
@@ -193,6 +196,7 @@ const MarkdownEditor: FC<Props> = ({
   if (errorMarkdown) {
     return <div className="whitespace-pre-line">{errorMarkdown}</div>;
   }
+
   return (
     <MDXEditor
       ref={editorRef}
@@ -211,7 +215,11 @@ const MarkdownEditor: FC<Props> = ({
       onChange={(value) => {
         // Revert the MathJax transformation before passing the markdown to the parent component
         onChange &&
-          onChange(escapePlainTextSymbols(revertMathJaxTransform(value)));
+          onChange(
+            escapePlainTextSymbols(
+              revertMathJaxTransform(formatBlockquoteNewlines(value))
+            )
+          );
       }}
       onError={(err) => {
         logErrorWithScope(err.error, err.source);
@@ -251,6 +259,10 @@ function escapePlainTextSymbols(str: string) {
     .replace(/^{(?![^}]*})/g, "\\{");
 
   return tempStr;
+}
+
+function formatBlockquoteNewlines(markdown: string): string {
+  return markdown.replace(/>\s*\n/g, "> \u00A0\n");
 }
 
 export default dynamic(() => Promise.resolve(MarkdownEditor), {


### PR DESCRIPTION
Related to #1496

- adjusted formatting of quotes to handle empty lines
Bonus:
- fixed a bug with comment editor (if comment was submitted in preview mode - user couldn't write a new comment)