### PR TITLE
Histogram axes don't always respect dark/light mode setting / Binary histogram charts too small in mobile

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/numeric_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/numeric_chart_card.tsx
@@ -1,5 +1,6 @@
 "use client";
 import classNames from "classnames";
+import { isNil } from "lodash";
 import { useTranslations } from "next-intl";
 import React, { FC, useCallback, useMemo, useState } from "react";
 
@@ -11,7 +12,6 @@ import { AggregateForecastHistory, Question } from "@/types/question";
 import { getUserPredictionDisplayValue, getDisplayValue } from "@/utils/charts";
 
 import CursorDetailItem from "./numeric_cursor_item";
-import { isNil } from "lodash";
 
 type Props = {
   question: Question;

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
@@ -69,11 +69,11 @@ const ForecastMakerConditionalBinary: FC<Props> = ({
 
   const prevYesAggregationValue =
     latestAggregationYes && !latestAggregationYes.end_time
-      ? latestAggregationYes.centers![0]
+      ? latestAggregationYes.centers?.[0]
       : null;
   const prevNoAggregationValue =
     latestAggregationNo && !latestAggregationNo.end_time
-      ? latestAggregationNo.centers![0]
+      ? latestAggregationNo.centers?.[0]
       : null;
 
   const [questionOptions, setQuestionOptions] = useState<

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
@@ -63,15 +63,17 @@ const ForecastMakerConditionalBinary: FC<Props> = ({
       : null;
   const hasUserForecast = !!prevYesForecastValue || !!prevNoForecastValue;
 
-  const latestAggregationYes = question_yes.my_forecasts?.latest;
-  const latestAggregationNo = question_no.my_forecasts?.latest;
+  const latestAggregationYes =
+    question_yes.aggregations?.recency_weighted.latest;
+  const latestAggregationNo = question_no.aggregations?.recency_weighted.latest;
+
   const prevYesAggregationValue =
     latestAggregationYes && !latestAggregationYes.end_time
-      ? extractPrevBinaryForecastValue(latestAggregationYes.forecast_values[1])
+      ? latestAggregationYes.centers![0]
       : null;
   const prevNoAggregationValue =
     latestAggregationNo && !latestAggregationNo.end_time
-      ? extractPrevBinaryForecastValue(latestAggregationNo.forecast_values[1])
+      ? latestAggregationNo.centers![0]
       : null;
 
   const [questionOptions, setQuestionOptions] = useState<

--- a/front_end/src/app/(main)/questions/[id]/components/histogram_drawer.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/histogram_drawer.tsx
@@ -1,14 +1,18 @@
 "use client";
-
+import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import React from "react";
 
-import Histogram from "@/components/charts/histogram";
 import SectionToggle from "@/components/ui/section_toggle";
+import useContainerSize from "@/hooks/use_container_size";
 import { PostWithForecasts } from "@/types/post";
 
 import { useHideCP } from "./cp_provider";
 import RevealCPButton from "./reveal_cp_button";
+
+const Histogram = dynamic(() => import("@/components/charts/histogram"), {
+  ssr: false,
+});
 
 type Props = {
   post: PostWithForecasts;
@@ -17,6 +21,9 @@ type Props = {
 const HistogramDrawer: React.FC<Props> = ({ post }) => {
   const t = useTranslations();
   const { hideCP } = useHideCP();
+
+  const { ref: chartContainerRef, width: chartWidth } =
+    useContainerSize<HTMLDivElement>();
 
   if (post.question?.type === "binary") {
     const question = post.question;
@@ -39,12 +46,15 @@ const HistogramDrawer: React.FC<Props> = ({ post }) => {
         {hideCP ? (
           <RevealCPButton />
         ) : (
-          <Histogram
-            histogramData={histogramData}
-            median={median}
-            mean={mean}
-            color={"gray"}
-          />
+          <div ref={chartContainerRef}>
+            <Histogram
+              histogramData={histogramData}
+              median={median}
+              mean={mean}
+              color={"gray"}
+              width={chartWidth}
+            />
+          </div>
         )}
       </SectionToggle>
     );
@@ -85,7 +95,7 @@ const HistogramDrawer: React.FC<Props> = ({ post }) => {
         {hideCP ? (
           <RevealCPButton />
         ) : (
-          <>
+          <div ref={chartContainerRef}>
             {histogramData_yes && (
               <>
                 <div className="mb-2 text-center text-xs">
@@ -96,6 +106,7 @@ const HistogramDrawer: React.FC<Props> = ({ post }) => {
                   median={median_yes}
                   mean={mean_yes}
                   color="gray"
+                  width={chartWidth}
                 />
               </>
             )}
@@ -109,10 +120,11 @@ const HistogramDrawer: React.FC<Props> = ({ post }) => {
                   median={median_no}
                   mean={mean_no}
                   color="blue"
+                  width={chartWidth}
                 />
               </>
             )}
-          </>
+          </div>
         )}
       </SectionToggle>
     );

--- a/front_end/src/app/(main)/questions/[id]/components/histogram_drawer.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/histogram_drawer.tsx
@@ -13,6 +13,7 @@ import RevealCPButton from "./reveal_cp_button";
 const Histogram = dynamic(() => import("@/components/charts/histogram"), {
   ssr: false,
 });
+const toggleSectionPadding = 24;
 
 type Props = {
   post: PostWithForecasts;
@@ -42,21 +43,21 @@ const HistogramDrawer: React.FC<Props> = ({ post }) => {
     const mean = question.aggregations.recency_weighted.latest.means![0];
 
     return (
-      <SectionToggle title={t("histogram")} defaultOpen>
-        {hideCP ? (
-          <RevealCPButton />
-        ) : (
-          <div ref={chartContainerRef}>
+      <div ref={chartContainerRef}>
+        <SectionToggle title={t("histogram")} defaultOpen>
+          {hideCP ? (
+            <RevealCPButton />
+          ) : (
             <Histogram
               histogramData={histogramData}
               median={median}
               mean={mean}
               color={"gray"}
-              width={chartWidth}
+              width={chartWidth - toggleSectionPadding}
             />
-          </div>
-        )}
-      </SectionToggle>
+          )}
+        </SectionToggle>
+      </div>
     );
   } else if (
     post.conditional?.question_yes.type === "binary" &&
@@ -91,42 +92,44 @@ const HistogramDrawer: React.FC<Props> = ({ post }) => {
     }
 
     return (
-      <SectionToggle title={t("histogram")}>
-        {hideCP ? (
-          <RevealCPButton />
-        ) : (
-          <div ref={chartContainerRef}>
-            {histogramData_yes && (
-              <>
-                <div className="mb-2 text-center text-xs">
-                  {t("parentResolvesAsYes")}
-                </div>
-                <Histogram
-                  histogramData={histogramData_yes}
-                  median={median_yes}
-                  mean={mean_yes}
-                  color="gray"
-                  width={chartWidth}
-                />
-              </>
-            )}
-            {histogramData_no && (
-              <>
-                <div className="mb-2 text-center text-xs">
-                  {t("parentResolvesAsNo")}
-                </div>
-                <Histogram
-                  histogramData={histogramData_no}
-                  median={median_no}
-                  mean={mean_no}
-                  color="blue"
-                  width={chartWidth}
-                />
-              </>
-            )}
-          </div>
-        )}
-      </SectionToggle>
+      <div ref={chartContainerRef}>
+        <SectionToggle title={t("histogram")}>
+          {hideCP ? (
+            <RevealCPButton />
+          ) : (
+            <>
+              {histogramData_yes && (
+                <>
+                  <div className="mb-2 text-center text-xs">
+                    {t("parentResolvesAsYes")}
+                  </div>
+                  <Histogram
+                    histogramData={histogramData_yes}
+                    median={median_yes}
+                    mean={mean_yes}
+                    color="gray"
+                    width={chartWidth - toggleSectionPadding}
+                  />
+                </>
+              )}
+              {histogramData_no && (
+                <>
+                  <div className="mb-2 text-center text-xs">
+                    {t("parentResolvesAsNo")}
+                  </div>
+                  <Histogram
+                    histogramData={histogramData_no}
+                    median={median_no}
+                    mean={mean_no}
+                    color="blue"
+                    width={chartWidth - toggleSectionPadding}
+                  />
+                </>
+              )}
+            </>
+          )}
+        </SectionToggle>
+      </div>
     );
   }
 };

--- a/front_end/src/components/charts/histogram.tsx
+++ b/front_end/src/components/charts/histogram.tsx
@@ -19,6 +19,7 @@ type HistogramProps = {
   median: number | undefined;
   mean: number | undefined;
   color: "blue" | "gray";
+  width?: number;
 };
 
 const Histogram: React.FC<HistogramProps> = ({
@@ -26,6 +27,7 @@ const Histogram: React.FC<HistogramProps> = ({
   median,
   mean,
   color,
+  width,
 }) => {
   const t = useTranslations();
   const { theme } = useAppTheme();
@@ -69,14 +71,15 @@ const Histogram: React.FC<HistogramProps> = ({
         }}
         containerComponent={<VictoryContainer responsive={true} />}
         padding={{ top: 0, bottom: 15, left: 10, right: 10 }}
-        height={48}
+        height={75}
+        width={width ?? undefined}
       >
         <VictoryAxis
           tickValues={range(0, 101)}
           tickFormat={(x: number) => (x % 10 === 0 ? `${x}%` : "")}
           style={{
             tickLabels: {
-              fontSize: 5,
+              fontSize: 8,
             },
             axis: { stroke: chartTheme.axis?.style?.axis?.stroke },
             grid: { stroke: "none" },

--- a/front_end/src/components/charts/histogram.tsx
+++ b/front_end/src/components/charts/histogram.tsx
@@ -72,7 +72,7 @@ const Histogram: React.FC<HistogramProps> = ({
         containerComponent={<VictoryContainer responsive={true} />}
         padding={{ top: 0, bottom: 15, left: 10, right: 10 }}
         height={75}
-        width={width ?? undefined}
+        width={!!width ? width : undefined}
       >
         <VictoryAxis
           tickValues={range(0, 101)}


### PR DESCRIPTION
Related to #670 and #253

- switched histogram render to client side so it always receives the correct theme value
- adjusted the width and height of histogram to adjust mobile view

Bonus:
- debugged and fixed issue in conditional binary forecast maker (community prediction was miscalculated and caused a horizontal scroll to appear)