### PR TITLE
Post edition embedding indexing

### DIFF
--- a/front_end/src/app/(main)/(home)/components/home_search.tsx
+++ b/front_end/src/app/(main)/(home)/components/home_search.tsx
@@ -1,14 +1,18 @@
 "use client";
+import { sendGAEvent } from "@next/third-parties/google";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { FC, useState } from "react";
 
 import SearchInput from "@/components/search_input";
-import { POST_TEXT_SEARCH_FILTER } from "@/constants/posts_feed";
-import { encodeQueryParams } from "@/utils/navigation";
 import VisibilityObserver from "@/components/visibility_observer";
+import {
+  POST_ORDER_BY_FILTER,
+  POST_TEXT_SEARCH_FILTER,
+} from "@/constants/posts_feed";
 import { useGlobalSearchContext } from "@/contexts/global_search_context";
-import { sendGAEvent } from "@next/third-parties/google";
+import { QuestionOrder } from "@/types/question";
+import { encodeQueryParams } from "@/utils/navigation";
 
 type Props = {};
 
@@ -21,7 +25,10 @@ const HomeSearch: FC<Props> = () => {
   const handleSearchSubmit = (searchQuery: string) => {
     router.push(
       `/questions` +
-        encodeQueryParams({ [POST_TEXT_SEARCH_FILTER]: searchQuery })
+        encodeQueryParams({
+          [POST_TEXT_SEARCH_FILTER]: searchQuery,
+          [POST_ORDER_BY_FILTER]: QuestionOrder.RankDesc,
+        })
     );
 
     sendGAEvent({

--- a/front_end/src/app/(main)/components/global_search.tsx
+++ b/front_end/src/app/(main)/components/global_search.tsx
@@ -1,14 +1,18 @@
 "use client";
-import React, { useState, useEffect, useCallback } from "react";
+import { sendGAEvent } from "@next/third-parties/google";
+import { debounce } from "lodash";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
+import React, { useState, useEffect, useCallback } from "react";
+
 import SearchInput from "@/components/search_input";
-import { POST_TEXT_SEARCH_FILTER } from "@/constants/posts_feed";
-import { encodeQueryParams } from "@/utils/navigation";
+import {
+  POST_ORDER_BY_FILTER,
+  POST_TEXT_SEARCH_FILTER,
+} from "@/constants/posts_feed";
 import { useGlobalSearchContext } from "@/contexts/global_search_context";
-import { sendGAEvent } from "@next/third-parties/google";
-import useDebounce from "@/hooks/use_debounce";
-import { debounce } from "lodash";
+import { QuestionOrder } from "@/types/question";
+import { encodeQueryParams } from "@/utils/navigation";
 
 interface GlobalSearchProps {
   className?: string;
@@ -54,7 +58,10 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({
     onSubmit?.();
     router.push(
       `/questions` +
-        encodeQueryParams({ [POST_TEXT_SEARCH_FILTER]: searchQuery })
+        encodeQueryParams({
+          [POST_TEXT_SEARCH_FILTER]: searchQuery,
+          [POST_ORDER_BY_FILTER]: QuestionOrder.RankDesc,
+        })
     );
   };
 

--- a/posts/tasks.py
+++ b/posts/tasks.py
@@ -44,4 +44,7 @@ def run_notify_post_status_change(post_id: int, event: Post.PostStatusChange):
 
 @dramatiq.actor
 def run_post_indexing(post_id):
-    update_post_search_embedding_vector(Post.objects.get(pk=post_id))
+    try:
+        update_post_search_embedding_vector(Post.objects.get(pk=post_id))
+    except Post.DoesNotExist:
+        logger.warning(f"Post {post_id} does not exist")

--- a/tests/unit/test_posts/test_services/test_common.py
+++ b/tests/unit/test_posts/test_services/test_common.py
@@ -1,8 +1,12 @@
-from posts.services.common import get_posts_staff_users
+from django.utils import timezone
+
+from posts.services.common import get_posts_staff_users, update_post
 from projects.permissions import ObjectPermission
+from questions.models import Question
 from tests.unit.fixtures import *  # noqa
 from tests.unit.test_posts.factories import factory_post
 from tests.unit.test_projects.factories import factory_project
+from tests.unit.test_questions.factories import create_question
 
 
 def test_get_posts_staff_users(user1, user2):
@@ -42,3 +46,32 @@ def test_get_posts_staff_users(user1, user2):
     assert data[post_2][user2.id] == ObjectPermission.CURATOR
 
     assert data[post_3] == {}
+
+
+def test_update_post__run_post_indexing(user1, user2, mocker):
+    mock_run_post_indexing = mocker.patch("posts.tasks.run_post_indexing.send")
+
+    post_1 = factory_post(
+        author=user1,
+        title="Post",
+        question=create_question(
+            title="Binary Question", question_type=Question.QuestionType.BINARY
+        ),
+    )
+
+    # No text updated
+    update_post(post_1, scheduled_close_time=timezone.now())
+    mock_run_post_indexing.assert_not_called()
+
+    # Updated text - reindexing
+    update_post(post_1, title="Updated Post")
+    mock_run_post_indexing.assert_called_once()
+
+    # No text updated
+    mock_run_post_indexing.reset_mock()
+    update_post(post_1, scheduled_close_time=timezone.now())
+    mock_run_post_indexing.assert_not_called()
+
+    # Updated question text - reindexing
+    update_post(post_1, question={"title": "Updated Binary Question"})
+    mock_run_post_indexing.assert_called_once()


### PR DESCRIPTION
- Implemented post embedding re-generation during post updates. If the post text changes, the embedding reindexing process is triggered.
- Fixed the navbar and homepage search functionality: previously, searches were not sorted by rank, leading to irrelevant results.
- Updated the indexing function to fail gracefully when a post does not exist

**TODO:**
- [x] Re-index posts on Prod

fixes #1627