### PR TITLE
Tournament search bar is broken

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournaments/components/tournament_filters.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/components/tournament_filters.tsx
@@ -19,7 +19,7 @@ const TournamentFilters: FC = () => {
 
   const [searchQuery, setSearchQuery] = useSearchInputState(
     TOURNAMENTS_SEARCH,
-    { mode: "client", debounceTime: 300 }
+    { mode: "client", debounceTime: 300, modifySearchParams: true }
   );
 
   const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Related to #1564

- fixed search input didn’t trigger query params update on tournaments page