### PR TITLE
Pressing preview & edit in a reply adds a tag

### DIFF
--- a/front_end/src/components/comment_feed/comment_editor.tsx
+++ b/front_end/src/components/comment_feed/comment_editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { sendGAEvent } from "@next/third-parties/google";
+import classNames from "classnames";
 import { useTranslations } from "next-intl";
 import { FC, useEffect, useState } from "react";
 
@@ -139,27 +140,25 @@ const CommentEditor: FC<CommentEditorProps> = ({
       {/*comment.included_forecast && (
         <IncludedForecast author="test" forecastValue={test} />
       )*/}
-      {isEditing && (
-        <div className="border border-gray-500 dark:border-gray-500-dark">
-          <MarkdownEditor
-            key={rerenderKey}
-            mode="write"
-            markdown={markdown}
-            onChange={handleMarkdownChange}
-            shouldConfirmLeave={isMarkdownDirty}
-            withUgcLinks
-            withUserMentions
-            initialMention={replyUsername}
-          />
-        </div>
-      )}
-      {!isEditing && (
+      <div
+        className={classNames(
+          "border border-gray-500 dark:border-gray-500-dark",
+          { hidden: !isEditing }
+        )}
+      >
         <MarkdownEditor
-          mode="read"
+          key={rerenderKey}
+          mode="write"
           markdown={markdown}
+          onChange={handleMarkdownChange}
+          shouldConfirmLeave={isMarkdownDirty}
           withUgcLinks
           withUserMentions
+          initialMention={replyUsername}
         />
+      </div>
+      {!isEditing && (
+        <MarkdownEditor mode="read" markdown={markdown} withUgcLinks />
       )}
       {(isReplying || hasInteracted) && (
         <div className="my-4 flex items-center justify-end gap-3">


### PR DESCRIPTION
Related to #1623

- updated the logic to switch into preview mode so comment editor wouldn’t unmount during transition, which caused redundant reply mention to be added