### PR TITLE
Expression of interest form links, QA feedback on Pro Forecasters page

### DIFF
--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1000,5 +1000,6 @@
   "robustTrackRecordsTitle": "Robust Track Records",
   "robustTrackRecordsInfo": "Pro Forecasters must have at least 75 resolved questions and must have made predictions across multiple subject areas, with at least one year of experience making predictions.<br></br><br></br>We also consider recruiting forecasters who have demonstrated excellent forecasting ability elsewhere.",
   "clearCommentsAndCommunicationTitle": "Clear Comments and Communication",
-  "clearCommentsAndCommunicationInfo": "Our Pros work on projects for external partners who value clear reasoning to better interpret the forecasts. We select Pros who have a history of making clear and insightful comments, and who are willing to disagree with their peers, but in a polite and respectful manner."
+  "clearCommentsAndCommunicationInfo": "Our Pros work on projects for external partners who value clear reasoning to better interpret the forecasts. We select Pros who have a history of making clear and insightful comments, and who are willing to disagree with their peers, but in a polite and respectful manner.",
+  "expressionOfInterestFormMessage": "We sometimes recruit upstanding members of the community who are great at providing constructive feedback on submitted questions to become paid moderators. Fill out our <link>expression of interest form</link> if you would like to be considered.”"
 }

--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/leaderboard_header.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/leaderboard_header.tsx
@@ -44,7 +44,7 @@ const LeaderboardHeader: FC<Props> = ({ filters }) => {
 
   return (
     <section className="flex w-full flex-col items-center gap-3.5 text-blue-800 dark:text-blue-800-dark max-sm:pt-3 sm:m-8 sm:mb-6 sm:gap-6">
-      <div className="flex flex-col gap-3.5">
+      <div className="flex flex-col gap-4">
         <div className="flex flex-col items-center justify-center gap-3">
           {category !== "all" && (
             <Link
@@ -64,7 +64,7 @@ const LeaderboardHeader: FC<Props> = ({ filters }) => {
             )}
           </div>
         </div>
-        <div className="max-w-3xl px-5 py-2 text-center text-sm font-normal text-gray-700 dark:text-gray-700-dark sm:py-0 sm:text-base">
+        <div className="max-w-3xl px-5 py-2 text-center text-sm font-normal text-gray-700 dark:text-gray-700-dark sm:py-0">
           {RANKING_CATEGORIES[category].explanation}
         </div>
       </div>

--- a/front_end/src/app/(main)/(leaderboards)/ranking_categories.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/ranking_categories.tsx
@@ -1,15 +1,26 @@
+import classNames from "classnames";
 import Link from "next/link";
 import { ReactNode } from "react";
 
+import { EXPRESSION_OF_INTEREST_FORM_URL } from "@/app/(main)/pro-forecasters/constants/expression_of_interest_form";
 import { CategoryKey } from "@/types/scoring";
 
+const baseLinkClassName =
+  "text-blue-700 hover:text-blue-800 dark:text-blue-700-dark dark:hover:text-blue-800-dark";
+const smallLinkClassName = classNames(baseLinkClassName, "text-xs font-medium");
+
 const ProForecastersInfo: ReactNode = (
-  <div>
-    These leaderboards award medals to decorate valued members of the Metaculus
-    community. We also use these leaderboards to select Pro Forecasters.
+  <div className="text-xs">
+    We sometimes recruit upstanding members of the community who are excellent
+    question writers to become paid moderators.
     <br />
-    Read more about becoming a Pro Forecaster{" "}
-    <Link href={"/pro-forecasters"}>here</Link>.
+    <div className="mt-2 font-medium">
+      Fill out our{" "}
+      <a href={EXPRESSION_OF_INTEREST_FORM_URL} className={smallLinkClassName}>
+        expression of interest form
+      </a>{" "}
+      if you would like to be considered.
+    </div>
   </div>
 );
 
@@ -27,13 +38,24 @@ export const RANKING_CATEGORIES: Record<
     translationKey: "all",
     shortTranslationKey: "all",
     explanation: (
-      <>
-        <span>
-          <Link href="/help/medals-faq/">Learn more</Link> about Metaculus
-          Medals
-        </span>
-        {ProForecastersInfo}
-      </>
+      <div className="flex flex-col gap-3">
+        <div>
+          These leaderboards award medals to decorate valued members of the
+          Metaculus community.
+          <br />
+          We also use these leaderboards to select{" "}
+          <strong>Pro Forecasters</strong>.
+          <br />
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-4">
+          <Link href="/help/medals-faq/" className={smallLinkClassName}>
+            Learn more about Metaculus Medals
+          </Link>
+          <Link href="/pro-forecasters" className={smallLinkClassName}>
+            Learn more about becoming a Pro Forecaster
+          </Link>
+        </div>
+      </div>
     ),
   },
   baseline: {
@@ -41,17 +63,29 @@ export const RANKING_CATEGORIES: Record<
     translationKey: "baselineAccuracy",
     shortTranslationKey: "baselineAccuracyShort",
     explanation: (
-      <>
+      <div className="flex flex-col gap-3">
         <span>
           <strong>Baseline Accuracy</strong> measures how accurate a user was
           compared to chance. User scores are determined by summing their{" "}
-          <Link href="/help/scores-faq/#baseline-score">Baseline scores</Link>{" "}
+          <Link
+            href="/help/scores-faq/#baseline-score"
+            className={baseLinkClassName}
+          >
+            Baseline scores
+          </Link>{" "}
           for all questions within a time period. This category rewards
           forecasters who are both accurate and forecast on many questions.
-          Learn more <Link href="/help/medals-faq/#baseline-medals">here</Link>.
+          Learn more{" "}
+          <Link
+            href="/help/medals-faq/#baseline-medals"
+            className={baseLinkClassName}
+          >
+            here
+          </Link>
+          .
         </span>
         {ProForecastersInfo}
-      </>
+      </div>
     ),
   },
   peer: {
@@ -59,20 +93,34 @@ export const RANKING_CATEGORIES: Record<
     translationKey: "peerAccuracy",
     shortTranslationKey: "peerAccuracyShort",
     explanation: (
-      <>
+      <div className="flex flex-col gap-3">
         <span>
           <strong>Peer Accuracy</strong> measures how accurate a user was
           compared to others. Users are ranked by the sum of their{" "}
-          <Link href="/help/scores-faq/#peer-score">Peer scores</Link>, divided
-          by the sum of their{" "}
-          <Link href="/help/scores-faq/#coverage">Coverages</Link>. This creates
-          a weighted average, where each prediction is counted proportionally to
-          how long it was standing. To reduce the impact of luck, all
-          forecasters start with a prior of 30 questions with a score of 0.
-          Learn more <Link href="/help/medals-faq/#peer-medals">here</Link>.
+          <Link
+            href="/help/scores-faq/#peer-score"
+            className={baseLinkClassName}
+          >
+            Peer scores
+          </Link>
+          , divided by the sum of their{" "}
+          <Link href="/help/scores-faq/#coverage" className={baseLinkClassName}>
+            Coverages
+          </Link>
+          . This creates a weighted average, where each prediction is counted
+          proportionally to how long it was standing. To reduce the impact of
+          luck, all forecasters start with a prior of 30 questions with a score
+          of 0. Learn more{" "}
+          <Link
+            href="/help/medals-faq/#peer-medals"
+            className={baseLinkClassName}
+          >
+            here
+          </Link>
+          .
         </span>
         {ProForecastersInfo}
-      </>
+      </div>
     ),
   },
   comments: {
@@ -80,17 +128,29 @@ export const RANKING_CATEGORIES: Record<
     translationKey: "comments",
     shortTranslationKey: "comments",
     explanation: (
-      <>
+      <div className="flex flex-col gap-3">
         <span>
           The <strong>Comments</strong> category rewards writing insightful
           comments determined by the number of upvotes. Medals are awarded
           annually with rankings determined by an{" "}
-          <Link href="/help/medals-faq/#h-indexes">h-index</Link> to reward a
-          balance of both the # of comments and their quality. Learn more{" "}
-          <Link href="/help/medals-faq/#comments-medals">here</Link>.
+          <Link
+            href="/help/medals-faq/#h-indexes"
+            className={baseLinkClassName}
+          >
+            h-index
+          </Link>{" "}
+          to reward a balance of both the # of comments and their quality. Learn
+          more{" "}
+          <Link
+            href="/help/medals-faq/#comments-medals"
+            className={baseLinkClassName}
+          >
+            here
+          </Link>
+          .
         </span>
         {ProForecastersInfo}
-      </>
+      </div>
     ),
   },
   questionWriting: {
@@ -98,17 +158,29 @@ export const RANKING_CATEGORIES: Record<
     translationKey: "questionWriting",
     shortTranslationKey: "questionWritingShort",
     explanation: (
-      <>
+      <div className="flex flex-col gap-3">
         <span>
           The <strong>Question Writing</strong> category rewards authoring
           engaging questions as determined by the number of forecasters divided
           by ten. Medals are awarded annually with rankings determined by an{" "}
-          <Link href="/help/medals-faq/#h-indexes">h-index</Link> to reward a
-          balance of both the # of questions and their engagement. Learn more{" "}
-          <Link href="/help/medals-faq/#question-writing-medals">here</Link>.
+          <Link
+            href="/help/medals-faq/#h-indexes"
+            className={baseLinkClassName}
+          >
+            h-index
+          </Link>{" "}
+          to reward a balance of both the # of questions and their engagement.
+          Learn more{" "}
+          <Link
+            href="/help/medals-faq/#question-writing-medals"
+            className={baseLinkClassName}
+          >
+            here
+          </Link>
+          .
         </span>
         {ProForecastersInfo}
-      </>
+      </div>
     ),
   },
   tournament: {

--- a/front_end/src/app/(main)/pro-forecasters/components/info_section.tsx
+++ b/front_end/src/app/(main)/pro-forecasters/components/info_section.tsx
@@ -3,21 +3,30 @@ import { FC, ReactNode } from "react";
 
 type Props = {
   title: string;
+  titleIcon?: ReactNode;
   info: string | ReactNode;
   size?: "md" | "lg";
 };
 
-const ProForecastersInfoSection: FC<Props> = ({ title, info, size = "md" }) => {
+const ProForecastersInfoSection: FC<Props> = ({
+  title,
+  info,
+  size = "md",
+  titleIcon = null,
+}) => {
   return (
     <>
-      <h2
-        className={classNames("m-0 font-bold", {
-          "text-2xl": size === "lg",
-          "text-xl": size === "md",
-        })}
-      >
-        {title}
-      </h2>
+      <div className="flex gap-3">
+        {titleIcon}
+        <h2
+          className={classNames("m-0 font-bold", {
+            "text-2xl": size === "lg",
+            "text-xl": size === "md",
+          })}
+        >
+          {title}
+        </h2>
+      </div>
       <p className="m-0">{info}</p>
     </>
   );

--- a/front_end/src/app/(main)/pro-forecasters/constants/expression_of_interest_form.ts
+++ b/front_end/src/app/(main)/pro-forecasters/constants/expression_of_interest_form.ts
@@ -1,0 +1,2 @@
+export const EXPRESSION_OF_INTEREST_FORM_URL =
+  "https://docs.google.com/forms/d/e/1FAIpQLSdebfiVQVoYj4WakqvwY-08k0x9Sfy8HMAUsKPE707YEChGlQ/viewform";

--- a/front_end/src/app/(main)/pro-forecasters/page.tsx
+++ b/front_end/src/app/(main)/pro-forecasters/page.tsx
@@ -1,3 +1,5 @@
+import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslations } from "next-intl";
 import { FC } from "react";
 
@@ -42,6 +44,7 @@ export default function ProForecastersPage() {
       />
       <ProForecastersInfoSection
         title={t("excellentForecastAbilityTitle")}
+        titleIcon={TitleIcon}
         info={
           <RichText>
             {(tags) =>
@@ -59,6 +62,7 @@ export default function ProForecastersPage() {
       />
       <ProForecastersInfoSection
         title={t("robustTrackRecordsTitle")}
+        titleIcon={TitleIcon}
         info={
           <RichText>
             {(tags) => t.rich("robustTrackRecordsInfo", tags)}
@@ -67,6 +71,7 @@ export default function ProForecastersPage() {
       />
       <ProForecastersInfoSection
         title={t("clearCommentsAndCommunicationTitle")}
+        titleIcon={TitleIcon}
         info={t("clearCommentsAndCommunicationInfo")}
       />
     </main>
@@ -75,4 +80,11 @@ export default function ProForecastersPage() {
 
 const Divider: FC = () => (
   <hr className="m-0 w-full border-blue-400 dark:border-blue-400-dark" />
+);
+
+const TitleIcon = (
+  <FontAwesomeIcon
+    icon={faCheck}
+    className="h-[28px] w-[25px] text-mc-option-3 dark:text-mc-option-3-dark"
+  />
 );

--- a/front_end/src/app/(main)/questions/create/page.tsx
+++ b/front_end/src/app/(main)/questions/create/page.tsx
@@ -3,11 +3,14 @@ import React from "react";
 
 import CommunityHeader from "@/app/(main)/components/headers/community_header";
 import Header from "@/app/(main)/components/headers/header";
-import WithServerComponentErrorBoundary from "@/components/server_component_error_boundary";
+import { EXPRESSION_OF_INTEREST_FORM_URL } from "@/app/(main)/pro-forecasters/constants/expression_of_interest_form";
 import ProjectsApi from "@/services/projects";
 import { SearchParams } from "@/types/navigation";
 
 import QuestionTypePicker from "../components/question_type_picker";
+
+const linkClassName =
+  "text-blue-800 hover:text-blue-900 dark:text-blue-800-dark dark:hover:text-blue-900-dark";
 
 export const metadata = {
   title: "Create a Question | Metaculus",
@@ -52,17 +55,14 @@ const Creator: React.FC<{ searchParams: SearchParams }> = async ({
           <p>
             {t.rich("createQuestionDescription1", {
               link1: (chunks) => (
-                <a
-                  href="/question-writing"
-                  className="text-blue-800 hover:text-blue-900 dark:text-blue-800-dark dark:hover:text-blue-900-dark"
-                >
+                <a href="/question-writing" className={linkClassName}>
                   {chunks}
                 </a>
               ),
               link2: (chunks) => (
                 <a
                   href="/questions/956/suggest-questions-to-launch/"
-                  className="text-blue-800 hover:text-blue-900 dark:text-blue-800-dark dark:hover:text-blue-900-dark"
+                  className={linkClassName}
                 >
                   {chunks}
                 </a>
@@ -70,6 +70,18 @@ const Creator: React.FC<{ searchParams: SearchParams }> = async ({
             })}
           </p>
           <p>{t("createQuestionDescription2")}</p>
+          <p>
+            {t.rich("expressionOfInterestFormMessage", {
+              link: (chunks) => (
+                <a
+                  href={EXPRESSION_OF_INTEREST_FORM_URL}
+                  className={linkClassName}
+                >
+                  {chunks}
+                </a>
+              ),
+            })}
+          </p>
         </div>
         <h2 className="mt-0 text-lg font-light capitalize">
           {t("singleQuestion")}

--- a/front_end/src/components/posts_feed/in_review_box.tsx
+++ b/front_end/src/components/posts_feed/in_review_box.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { FC, useState } from "react";
 
+import { EXPRESSION_OF_INTEREST_FORM_URL } from "@/app/(main)/pro-forecasters/constants/expression_of_interest_form";
+
 import CollapsibleBox from "../ui/collapsible_box";
 
 const InReviewBox: FC = () => {
@@ -24,6 +26,13 @@ const InReviewBox: FC = () => {
       <p className="mb-0 mt-2">
         {t.rich("inReviewBox4", {
           link: (chunks) => <Link href="/question-writing/">{chunks}</Link>,
+        })}
+      </p>
+      <p className="mb-0 mt-2 text-sm">
+        {t.rich("expressionOfInterestFormMessage", {
+          link: (chunks) => (
+            <a href={EXPRESSION_OF_INTEREST_FORM_URL}>{chunks}</a>
+          ),
         })}
       </p>
     </CollapsibleBox>


### PR DESCRIPTION
Addressed the latest feedback on Pro Forecasters feature:

- implemented links for the expression of interest form (in review box, create question page)
- implemented updated layout for top of the Leaderboards section
- added checkbox icons on pro forecasters page