### PR TITLE
User tags are working unreliabily

### DIFF
--- a/front_end/src/utils/comments.ts
+++ b/front_end/src/utils/comments.ts
@@ -31,7 +31,7 @@ export function parseUserMentions(
   markdown: string,
   mentionedUsers?: AuthorType[]
 ): string {
-  const userTagPattern = /@(\(([^)]+)\)|(\w.+))/g;
+  const userTagPattern = /@(\(([^)]+)\)|([\w.]+))/g;
 
   function isInsideSquareBrackets(index: number) {
     let insideBrackets = false;


### PR DESCRIPTION
Related to #1658

- fixed the issue with regex when parsing user mentions that caused the entire comment to be matched