### PR TITLE
Pro Forecasters (QA Feedback)

### DIFF
--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1001,5 +1001,5 @@
   "robustTrackRecordsInfo": "Pro Forecasters must have at least 75 resolved questions and must have made predictions across multiple subject areas, with at least one year of experience making predictions.<br></br><br></br>We also consider recruiting forecasters who have demonstrated excellent forecasting ability elsewhere.",
   "clearCommentsAndCommunicationTitle": "Clear Comments and Communication",
   "clearCommentsAndCommunicationInfo": "Our Pros work on projects for external partners who value clear reasoning to better interpret the forecasts. We select Pros who have a history of making clear and insightful comments, and who are willing to disagree with their peers, but in a polite and respectful manner.",
-  "expressionOfInterestFormMessage": "We sometimes recruit upstanding members of the community who are great at providing constructive feedback on submitted questions to become paid moderators. Fill out our <link>expression of interest form</link> if you would like to be considered.”"
+  "expressionOfInterestFormMessage": "We sometimes recruit upstanding members of the community who are great at providing constructive feedback on submitted questions to become paid moderators. Fill out our <link>expression of interest form</link> if you would like to be considered."
 }

--- a/front_end/src/app/(main)/(home)/components/engage_block.tsx
+++ b/front_end/src/app/(main)/(home)/components/engage_block.tsx
@@ -23,7 +23,14 @@ const EngageBlock: FC = () => {
         <div className="text-lg text-blue-200 dark:text-blue-200-dark lg:max-w-2xl">
           <p className="my-8">
             {t.rich("learnHowYouCanPartner", {
-              link: (chunks) => <Link href={"/pro-forecasters"}>{chunks}</Link>,
+              link: (chunks) => (
+                <Link
+                  href={"/pro-forecasters"}
+                  className="!text-blue-200 dark:!text-blue-200-dark"
+                >
+                  {chunks}
+                </Link>
+              ),
             })}
           </p>
           <p className="my-0">{t("workingWithNonProfits")}</p>

--- a/front_end/src/app/(main)/pro-forecasters/components/pro_forecasters_section.tsx
+++ b/front_end/src/app/(main)/pro-forecasters/components/pro_forecasters_section.tsx
@@ -18,6 +18,7 @@ const ProForecasterCard: FC<ProForecaster> = ({
         src={image}
         alt={name}
         className="size-[72px] shrink-0 rounded-2xl object-cover md:size-[180px]"
+        quality={100}
       />
 
       <div className="-mt-1 flex flex-col gap-2">


### PR DESCRIPTION
Minor fixes based on QA feedback for Pro Forecasters:

- fix text copy on engagement message on question creation page
- improve image quality in pro-forecaster cards