### PR TITLE
Remove trailing "News" label in /news/ page

### DIFF
--- a/front_end/src/app/(main)/news/components/news_filters.tsx
+++ b/front_end/src/app/(main)/news/components/news_filters.tsx
@@ -36,7 +36,7 @@ const NewsFilters: React.FC<Props> = ({ categories }) => {
   const categoryOptions = useMemo(
     () =>
       categories.map((obj) => ({
-        label: obj.name,
+        label: obj.name.replace(/\snews$/i, ""),
         value: obj.slug,
       })),
     [categories]


### PR DESCRIPTION
<img width="801" alt="image" src="https://github.com/user-attachments/assets/1573bdcf-a080-420d-9266-8fb2dcb74d7f" />
