### PR TITLE
Normalized frontend errors logging

### DIFF
--- a/front_end/src/utils/errors.ts
+++ b/front_end/src/utils/errors.ts
@@ -18,17 +18,26 @@ export function extractError(field_error: any): string | undefined {
 }
 
 export function logError(error: Error | unknown, message?: string) {
-  const statusCode = (error as ErrorResponse)?.response?.status;
-  const digest = (error as ErrorResponse)?.digest;
+  const errorResponse = (error as ErrorResponse) ?? {};
+  const { status = "unknown", url = "unknown" } = errorResponse?.response ?? {};
+  const { digest = "unknown" } = errorResponse;
 
-  if (!statusCode || statusCode >= 500) {
+  // Capture exception in Sentry for server errors or unknown status
+  if (!status || status >= 500) {
     Sentry.captureException(error);
   }
 
-  console.error(
-    `${message ?? "Error:"} status_code=${statusCode} digest=${JSON.stringify(digest)} message=${JSON.stringify(message)} error=${JSON.stringify(error)}`,
-    error
-  );
+  const logChunks = [
+    message ?? "Error:",
+    `status_code=${status}`,
+    `url=${url}`,
+    `digest=${JSON.stringify(digest)}`,
+    `message=${JSON.stringify(message)}`,
+    `error=${JSON.stringify(error)}`,
+  ];
+
+  // Log the complete message
+  console.error(logChunks.join(" "), error);
 }
 
 export function logErrorWithScope(

--- a/front_end/src/utils/errors.ts
+++ b/front_end/src/utils/errors.ts
@@ -1,5 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
+import { ErrorResponse } from "@/types/fetch";
+
 export function extractError(field_error: any): string | undefined {
   if (typeof field_error === "string") return field_error;
 
@@ -16,8 +18,17 @@ export function extractError(field_error: any): string | undefined {
 }
 
 export function logError(error: Error | unknown, message?: string) {
-  Sentry.captureException(error);
-  console.error(message ?? error);
+  const statusCode = (error as ErrorResponse)?.response?.status;
+  const digest = (error as ErrorResponse)?.digest;
+
+  if (!statusCode || statusCode >= 500) {
+    Sentry.captureException(error);
+  }
+
+  console.error(
+    `${message ?? "Error:"} status_code=${statusCode} digest=${JSON.stringify(digest)} message=${JSON.stringify(message)} error=${JSON.stringify(error)}`,
+    error
+  );
 }
 
 export function logErrorWithScope(

--- a/front_end/src/utils/fetch.ts
+++ b/front_end/src/utils/fetch.ts
@@ -9,7 +9,7 @@ import {
   FetchOptions,
 } from "@/types/fetch";
 
-import { extractError, logError } from "./errors";
+import { extractError } from "./errors";
 
 class ApiError extends Error {
   public digest: string;
@@ -140,23 +140,11 @@ const appFetch = async <T>(
     delete finalOptions.headers["Content-Type"];
   }
 
-  try {
-    const response = await fetch(finalUrl, finalOptions);
-    // consume response in order to fix SocketError: other side is closed
-    // https://stackoverflow.com/questions/76931498/typeerror-terminated-cause-socketerror-other-side-closed-in-fetch-nodejs
-    const clonedRes = response.clone();
-    return await handleResponse<T>(clonedRes);
-  } catch (error) {
-    const statusCode = (error as ErrorResponse)?.response?.status;
-    const digest = (error as ApiError)?.digest;
-
-    if (digest != "NEXT_NOT_FOUND" && (!statusCode || statusCode >= 500)) {
-      console.error("Fetch error:", error);
-    }
-
-    logError(error, `Fetch error: ${error}. finalUrl: ${finalUrl}`);
-    throw error;
-  }
+  const response = await fetch(finalUrl, finalOptions);
+  // consume response in order to fix SocketError: other side is closed
+  // https://stackoverflow.com/questions/76931498/typeerror-terminated-cause-socketerror-other-side-closed-in-fetch-nodejs
+  const clonedRes = response.clone();
+  return await handleResponse<T>(clonedRes);
 };
 
 const get = async <T>(


### PR DESCRIPTION
Attempt to normalize frontend error logging:

- **Removed logging from the app fetch utility**:  
  This was redundant and caused duplicate error logs. We already have many `try/catch` constructions elsewhere, so this utility was duplicating the logging. In cases where `try/catch` or `WithServerComponentErrorBoundary` is not used, errors will still be raised and sent directly to Sentry, ensuring no errors are missed.
- **Updated the `logError` function**:  
  - Excluded `4xx` errors from being sent to Sentry.  
  - Unified the error log format to allow parsing of `status` and other parameters in the Mezmo console.

Part of #1404
