### PR TITLE
Pro forecasters image is fuzzy

### DIFF
--- a/front_end/src/app/(main)/pro-forecasters/components/pro_forecasters_section.tsx
+++ b/front_end/src/app/(main)/pro-forecasters/components/pro_forecasters_section.tsx
@@ -15,6 +15,8 @@ const ProForecasterCard: FC<ProForecaster> = ({
   return (
     <div className="flex gap-6">
       <Image
+        width={180}
+        height={180}
         src={image}
         alt={name}
         className="size-[72px] shrink-0 rounded-2xl object-cover md:size-[180px]"


### PR DESCRIPTION
- updated `width` and `size` to be match container aspect ratio (next.js was setting wrong values based on local file)

Before:

<img width="952" alt="image" src="https://github.com/user-attachments/assets/28fe5cb6-3e27-4dd4-9aec-c6b7887f50c6" />

<img width="426" alt="image" src="https://github.com/user-attachments/assets/47b996b3-8190-4ba8-ba46-11570c1208fe" />


After:

<img width="947" alt="image" src="https://github.com/user-attachments/assets/e5236972-7dbe-4ac1-9175-c760774381b8" />

<img width="417" alt="image" src="https://github.com/user-attachments/assets/6ffa48de-c80c-4229-b29f-fd0d45c581db" />
