### PR TITLE
Add message about timezone to resolution modal

### DIFF
--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1002,5 +1002,6 @@
   "robustTrackRecordsInfo": "Pro Forecasters must have at least 75 resolved questions and must have made predictions across multiple subject areas, with at least one year of experience making predictions.<br></br><br></br>We also consider recruiting forecasters who have demonstrated excellent forecasting ability elsewhere.",
   "clearCommentsAndCommunicationTitle": "Clear Comments and Communication",
   "clearCommentsAndCommunicationInfo": "Our Pros work on projects for external partners who value clear reasoning to better interpret the forecasts. We select Pros who have a history of making clear and insightful comments, and who are willing to disagree with their peers, but in a polite and respectful manner.",
-  "expressionOfInterestFormMessage": "We sometimes recruit upstanding members of the community who are great at providing constructive feedback on submitted questions to become paid moderators. Fill out our <link>expression of interest form</link> if you would like to be considered."
+  "expressionOfInterestFormMessage": "We sometimes recruit upstanding members of the community who are great at providing constructive feedback on submitted questions to become paid moderators. Fill out our <link>expression of interest form</link> if you would like to be considered.",
+  "dateInputDetails": "Date and time is in your local timezone [{timezone}]"
 }

--- a/front_end/src/app/(main)/questions/components/question_form.tsx
+++ b/front_end/src/app/(main)/questions/components/question_form.tsx
@@ -3,7 +3,6 @@
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { format } from "date-fns";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -14,6 +13,7 @@ import * as z from "zod";
 import ProjectPickerInput from "@/app/(main)/questions/components/project_picker_input";
 import Button from "@/components/ui/button";
 import {
+  DateInput,
   FormError,
   FormErrorMessage,
   Input,
@@ -77,40 +77,50 @@ const createQuestionSchemas = (
     }),
     resolution_criteria: z.string().min(1, { message: t("errorRequired") }),
     fine_print: z.string().optional(),
-    open_time: z.nullable(z.date().optional()).refine(
-      (value) => {
-        if (!post) {
-          return true;
-        }
+    open_time: z
+      .string()
+      .datetime({ offset: true })
+      .nullable()
+      .optional()
+      .refine(
+        (value) => {
+          if (!post) {
+            return true;
+          }
 
-        if (post.status !== PostStatus.APPROVED) {
-          return true;
-        }
+          if (post.status !== PostStatus.APPROVED) {
+            return true;
+          }
 
-        return !!value;
-      },
-      {
-        message: t("errorRequired"),
-      }
-    ),
-    cp_reveal_time: z.nullable(z.date().optional()).refine(
-      (value) => {
-        if (!post) {
-          return true;
+          return !!value;
+        },
+        {
+          message: t("errorRequired"),
         }
+      ),
+    cp_reveal_time: z
+      .string()
+      .datetime({ offset: true })
+      .nullable()
+      .optional()
+      .refine(
+        (value) => {
+          if (!post) {
+            return true;
+          }
 
-        if (post.status !== PostStatus.APPROVED) {
-          return true;
+          if (post.status !== PostStatus.APPROVED) {
+            return true;
+          }
+
+          return !!value;
+        },
+        {
+          message: t("errorRequired"),
         }
-
-        return !!value;
-      },
-      {
-        message: t("errorRequired"),
-      }
-    ),
-    scheduled_close_time: z.date(),
-    scheduled_resolve_time: z.date(),
+      ),
+    scheduled_close_time: z.string().datetime({ offset: true }),
+    scheduled_resolve_time: z.string().datetime({ offset: true }),
     default_project: z.nullable(z.union([z.number(), z.string()])),
   });
 
@@ -404,108 +414,48 @@ const QuestionForm: FC<Props> = ({
         </InputContainer>
         <div className="flex w-full flex-col gap-4 md:flex-row">
           <InputContainer labelText={t("closingDate")} className="w-full gap-2">
-            <Input
-              type="datetime-local"
-              className="w-full rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
-              {...form.register("scheduled_close_time", {
-                setValueAs: (value: string) => {
-                  if (value === "" || value == null) {
-                    return null;
-                  }
-
-                  return new Date(value);
-                },
-              })}
+            <DateInput
+              control={form.control}
+              name="scheduled_close_time"
+              defaultValue={post?.question?.scheduled_close_time}
               errors={form.formState.errors.scheduled_close_time}
-              defaultValue={
-                post?.question?.scheduled_close_time
-                  ? format(
-                      new Date(post.question.scheduled_close_time),
-                      "yyyy-MM-dd'T'HH:mm"
-                    )
-                  : undefined
-              }
+              className="w-full rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
             />
           </InputContainer>
           <InputContainer
             labelText={t("resolvingDate")}
             className="w-full gap-2"
           >
-            <Input
-              type="datetime-local"
-              className="w-full rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
-              {...form.register("scheduled_resolve_time", {
-                setValueAs: (value: string) => {
-                  if (value === "" || value == null) {
-                    return null;
-                  }
-
-                  return new Date(value);
-                },
-              })}
+            <DateInput
+              control={form.control}
+              name="scheduled_resolve_time"
+              defaultValue={post?.question?.scheduled_resolve_time}
               errors={form.formState.errors.scheduled_resolve_time}
-              defaultValue={
-                post?.question?.scheduled_resolve_time
-                  ? format(
-                      new Date(post.question.scheduled_resolve_time),
-                      "yyyy-MM-dd'T'HH:mm"
-                    )
-                  : undefined
-              }
+              className="w-full rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
             />
           </InputContainer>
         </div>
         {isEditingActivePost && (
           <div className="flex w-full flex-col gap-4 md:flex-row">
             <InputContainer labelText={t("openTime")} className="w-full gap-2">
-              <Input
-                type="datetime-local"
-                className="w-full rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
-                {...form.register("open_time", {
-                  setValueAs: (value: string) => {
-                    if (value === "" || value == null) {
-                      return null;
-                    }
-
-                    return new Date(value);
-                  },
-                })}
+              <DateInput
+                control={form.control}
+                name="open_time"
+                defaultValue={post?.question?.open_time}
                 errors={form.formState.errors.open_time}
-                defaultValue={
-                  post?.question?.open_time
-                    ? format(
-                        new Date(post.question.open_time),
-                        "yyyy-MM-dd'T'HH:mm"
-                      )
-                    : undefined
-                }
+                className="w-full rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
               />
             </InputContainer>
             <InputContainer
               labelText={t("cpRevealTime")}
               className="w-full gap-2"
             >
-              <Input
-                type="datetime-local"
-                className="w-full rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
-                {...form.register("cp_reveal_time", {
-                  setValueAs: (value: string) => {
-                    if (value === "" || value == null) {
-                      return null;
-                    }
-
-                    return new Date(value);
-                  },
-                })}
+              <DateInput
+                control={form.control}
+                name="cp_reveal_time"
+                defaultValue={post?.question?.cp_reveal_time}
                 errors={form.formState.errors.cp_reveal_time}
-                defaultValue={
-                  post?.question?.cp_reveal_time
-                    ? format(
-                        new Date(post.question.cp_reveal_time),
-                        "yyyy-MM-dd'T'HH:mm"
-                      )
-                    : undefined
-                }
+                className="w-full rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
               />
             </InputContainer>
           </div>

--- a/front_end/src/components/ui/datetime_utc.tsx
+++ b/front_end/src/components/ui/datetime_utc.tsx
@@ -1,6 +1,8 @@
+"use client";
 import { format, formatISO, parseISO } from "date-fns";
 import { isNil } from "lodash";
-import React, { ChangeEvent, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import React, { ChangeEvent, forwardRef, useEffect, useState } from "react";
 
 import { Input, InputProps } from "@/components/ui/form_field";
 import { logError } from "@/utils/errors";
@@ -9,60 +11,79 @@ interface DatetimeUtcProps extends Omit<InputProps, "onChange"> {
   defaultValue?: string;
   onChange?: (value: string) => void;
   onError?: (error: any) => void;
+  withFormValidation?: boolean;
 }
 
 /**
  * Datetime input component which renders datetime in user's local timezone
  * but stores and accepts values in UTC format
  */
-const DatetimeUtc: React.FC<DatetimeUtcProps> = ({
-  defaultValue,
-  onChange,
-  onError,
-  ...props
-}) => {
-  const [localValue, setLocalValue] = useState<string>("");
+const DatetimeUtc = forwardRef<HTMLInputElement, DatetimeUtcProps>(
+  ({ defaultValue, onChange, onError, withFormValidation, ...props }, ref) => {
+    const t = useTranslations();
 
-  useEffect(() => {
-    if (!isNil(defaultValue)) {
-      // Convert stored UTC value to local time for rendering
-      const localDate = parseISO(defaultValue);
-      if (isNaN(localDate.getTime())) return;
+    const [localValue, setLocalValue] = useState<string>("");
 
-      const localDateString = format(localDate, "yyyy-MM-dd'T'HH:mm");
-      setLocalValue(localDateString);
-    }
-  }, [defaultValue]);
+    useEffect(() => {
+      if (!isNil(defaultValue)) {
+        // Convert stored UTC value to local time for rendering
+        const localDate = parseISO(defaultValue);
+        if (isNaN(localDate.getTime())) return;
 
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const localDateString = event.target.value;
-    setLocalValue(localDateString);
-
-    try {
-      // Convert local time to UTC for storage
-      if (onChange) {
-        const localDate = new Date(localDateString);
-        const utcDateString = formatISO(localDate, {
-          representation: "complete",
-        });
-
-        onChange(utcDateString);
+        const localDateString = format(localDate, "yyyy-MM-dd'T'HH:mm");
+        setLocalValue(localDateString);
       }
-    } catch (e) {
-      logError(e);
-      onError && onError(e);
-    }
-  };
+    }, [defaultValue]);
 
-  return (
-    <Input
-      type="datetime-local"
-      defaultValue={localValue}
-      onChange={handleChange}
-      onBlur={handleChange}
-      {...props}
-    />
-  );
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+      const localDateString = event.target.value;
+      setLocalValue(localDateString);
+
+      try {
+        // Convert local time to UTC for storage
+        if (onChange) {
+          const localDate = new Date(localDateString);
+          const utcDateString = formatISO(localDate, {
+            representation: "complete",
+          });
+
+          onChange(utcDateString);
+        }
+      } catch (e) {
+        if (withFormValidation) {
+          onChange?.("");
+          return;
+        }
+
+        logError(e);
+        onError && onError(e);
+      }
+    };
+
+    return (
+      <div className="flex flex-col gap-1">
+        <Input
+          ref={ref}
+          type="datetime-local"
+          defaultValue={
+            localValue ? format(localValue, "yyyy-MM-dd'T'HH:mm") : ""
+          }
+          onChange={handleChange}
+          onBlur={handleChange}
+          {...props}
+        />
+        <span className="text-center text-xs font-normal normal-case italic">
+          {t("dateInputDetails", { timezone: getTimezoneOffsetLabel() })}
+        </span>
+      </div>
+    );
+  }
+);
+DatetimeUtc.displayName = "DatetimeUtc";
+
+const getTimezoneOffsetLabel = (): string => {
+  const timezoneOffset = new Date().getTimezoneOffset() / -60;
+  return `UTC${timezoneOffset >= 0 ? "+" : ""}${timezoneOffset}`;
 };
 
 export default DatetimeUtc;

--- a/front_end/src/components/ui/form_field.tsx
+++ b/front_end/src/components/ui/form_field.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-hook-form";
 
 import MarkdownEditor from "@/components/markdown_editor";
+import DatetimeUtc from "@/components/ui/datetime_utc";
 import { ErrorResponse } from "@/types/fetch";
 import cn from "@/utils/cn";
 import { extractError } from "@/utils/errors";
@@ -111,6 +112,42 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   }
 );
 Input.displayName = "Input";
+
+type DateInputProps<T extends FieldValues = FieldValues> = {
+  control: Control<T>;
+  name: Path<T>;
+  defaultValue?: PathValue<T, Path<T>>;
+  errors?: ErrorResponse;
+  className?: string;
+};
+export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
+  ({ control, name, errors, defaultValue, className }) => {
+    const { field } = useController({ control, name, defaultValue });
+
+    return (
+      <>
+        <DatetimeUtc
+          ref={field.ref}
+          className={className}
+          name={field.name}
+          defaultValue={field.value}
+          onChange={(value) => {
+            if (!value) {
+              field.onChange(null);
+              return;
+            }
+
+            field.onChange(value);
+          }}
+          onBlur={field.onBlur}
+          withFormValidation
+        />
+        {errors && <FormError name={name} errors={errors} />}
+      </>
+    );
+  }
+);
+DateInput.displayName = "DateInput";
 
 export const Textarea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ({ className, name, children, errors, ...props }, ref) => {


### PR DESCRIPTION
Related to #1492

- updated `DatetimeUtc` component with timezone information
- refactored question creation page to utilize `DatetimeUtc` instead of regular input

<img width="913" alt="image" src="https://github.com/user-attachments/assets/37951964-4bff-41e3-bd8d-50d1e8e2802c" />

<img width="387" alt="image" src="https://github.com/user-attachments/assets/4c255544-07d4-46d7-a6fb-814fde5a6661" />
