### PR TITLE
Mobile comment issue

### DIFF
--- a/front_end/src/components/markdown_editor/plugins/mentions/components/mention.tsx
+++ b/front_end/src/components/markdown_editor/plugins/mentions/components/mention.tsx
@@ -5,9 +5,15 @@ const CustomMentionComponent = forwardRef<
   HTMLAnchorElement,
   BeautifulMentionComponentProps
 >(({ trigger, value, data: myData, children, ...other }, ref) => {
+  // combination on inline-block and block is used as a workaround for Chrome bug on Android
+  // when element is duplicated when typing
+  // github.com/facebook/lexical/issues/4636
+  // https://issues.chromium.org/issues/41254240
   return (
-    <span {...other} ref={ref}>
-      {trigger + value}
+    <span className="inline-block">
+      <span {...other} ref={ref} className="block">
+        {trigger + value}
+      </span>
     </span>
   );
 });

--- a/front_end/src/components/markdown_editor/plugins/mentions/components/plugin.tsx
+++ b/front_end/src/components/markdown_editor/plugins/mentions/components/plugin.tsx
@@ -36,6 +36,7 @@ const MentionsPlugin: FC<Props> = ({ initialMention, isStuff }) => {
       menuItemComponent={MenuItem}
       menuItemLimit={false}
       autoSpace={false}
+      allowSpaces={false}
     />
   );
 };


### PR DESCRIPTION
Related to #1739

Implemented a workaround to Chrome bug on Android devices where typing in keyboard duplicated elements in rich text editor. The issue is not directly related to our editor implementation and was noticed in other packages.

