### PR TITLE
don't allow email activation for users already marked as spam

### DIFF
--- a/authentication/services.py
+++ b/authentication/services.py
@@ -26,7 +26,7 @@ def send_activation_email(user: User, redirect_url: str | None):
             "activation_link": activation_link,
             "redirect_url": redirect_url,
         },
-        from_email=settings.EMAIL_HOST_USER
+        from_email=settings.EMAIL_HOST_USER,
     )
 
 
@@ -42,7 +42,7 @@ def send_password_reset_email(user: User):
             "username": user.username,
             "reset_link": reset_link,
         },
-        from_email=settings.EMAIL_HOST_USER
+        from_email=settings.EMAIL_HOST_USER,
     )
 
 
@@ -52,6 +52,9 @@ def check_and_activate_user(user_id: int, token: str):
     """
 
     user = User.objects.filter(pk=user_id, is_active=False).first()
+
+    if user.is_spam:
+        raise ValidationError({"user": ["User is marked as spam"]})
 
     if not user or not default_token_generator.check_token(user, token):
         raise ValidationError({"token": ["Activation Token is expired or invalid"]})


### PR DESCRIPTION
If user activates their email after already being marked spam, they awkwardly have both "is_active" and "is_spam" flags set to True. This intercepts activation.