### PR TITLE
Usernames with dashes fail in comment username mentions

### DIFF
--- a/comments/utils.py
+++ b/comments/utils.py
@@ -8,7 +8,7 @@ from comments.models import Comment
 from users.models import User
 
 # Regex pattern to find all @<username> mentions
-USERNAME_PATTERN = r"@\(?([\w.]+)\)?"
+USERNAME_PATTERN = r"@\(?([\w.+-_'~#%]+)\)?"
 
 
 def comment_extract_user_mentions(
@@ -18,7 +18,7 @@ def comment_extract_user_mentions(
     Extracts mentioned users query
     """
 
-    unique_mentions = {m.lower() for m in re.findall(USERNAME_PATTERN, comment.text)}
+    unique_mentions = {m.lower() for m in re.findall(USERNAME_PATTERN, comment.text, re.UNICODE)}
 
     if not unique_mentions:
         return User.objects.none(), {}

--- a/front_end/src/utils/comments.ts
+++ b/front_end/src/utils/comments.ts
@@ -31,7 +31,7 @@ export function parseUserMentions(
   markdown: string,
   mentionedUsers?: AuthorType[]
 ): string {
-  const userTagPattern = /@(\(([^)]+)\)|([\w.]+))/g;
+  const userTagPattern = /@(\(([^)]+)\)|([\w.+-_'~#%]+))/gu;
 
   function isInsideSquareBrackets(index: number) {
     let insideBrackets = false;
@@ -49,7 +49,10 @@ export function parseUserMentions(
         return match;
       }
 
-      const cleanedUsername = (group2 || group3).replace(/[@()]/g, "");
+      // remove only the leading "@" and clean parentheses around the username
+      let cleanedUsername = (group2 || group3).replace(/^@/, "");
+      cleanedUsername = cleanedUsername.replace(/^\(([^)]+)\)$/, "$1");
+
       switch (cleanedUsername.toLowerCase()) {
         case "moderators":
           return `[@${cleanedUsername}](/faq/#moderators-tag)`;


### PR DESCRIPTION
Related to #1741

Updated supported symbols for user mentions according to provided table

<img width="747" alt="image" src="https://github.com/user-attachments/assets/fd5d5455-bd3b-4d11-941c-e3567611cf8a" />