### PR TITLE
Add links from front-end to django admin

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
@@ -21,6 +21,7 @@ import { ProjectVisibility, TournamentType } from "@/types/projects";
 import cn from "@/utils/cn";
 import { formatDate } from "@/utils/date_formatters";
 
+import TournamentDropdownMenu from "../components/dropdown_menu";
 import TournamentFeed from "../components/tournament_feed";
 
 const LazyProjectMembers = dynamic(() => import("../components/members"), {
@@ -73,7 +74,7 @@ export default async function TournamentSlug({ params }: Props) {
       <div className="bg-gray-0 dark:bg-gray-0-dark">
         <div
           className={cn(
-            " flex flex-wrap items-center justify-between gap-2.5 rounded-t px-3 py-1.5 text-[20px] uppercase text-gray-100 dark:text-gray-100-dark",
+            "flex flex-wrap items-center justify-between gap-2.5 rounded-t px-3 py-1.5 text-[20px] uppercase text-gray-100 dark:text-gray-100-dark",
             tournament.type === TournamentType.QuestionSeries
               ? "bg-gray-500 dark:bg-gray-500-dark"
               : "bg-blue-600 dark:bg-blue-600-dark"
@@ -85,6 +86,7 @@ export default async function TournamentSlug({ params }: Props) {
           >
             {title}
           </Link>
+          <TournamentDropdownMenu tournament={tournament} />
         </div>
         {!!tournament.header_image && (
           <div className="relative h-[130px] w-full">

--- a/front_end/src/app/(main)/(tournaments)/tournament/components/dropdown_menu.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/components/dropdown_menu.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { faEllipsis } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useTranslations } from "next-intl";
+import React, { FC } from "react";
+
+import Button from "@/components/ui/button";
+import DropdownMenu, { MenuItemProps } from "@/components/ui/dropdown_menu";
+import { useAuth } from "@/contexts/auth_context";
+import { Tournament } from "@/types/projects";
+
+type Props = {
+  tournament: Tournament;
+};
+
+const TournamentDropdownMenu: FC<Props> = ({ tournament }) => {
+  const t = useTranslations();
+
+  const { user } = useAuth();
+
+  const menuItems: MenuItemProps[] = [];
+  if (user?.is_superuser) {
+    menuItems.push({
+      id: "viewDjangoAdmin",
+      name: t("viewInDjangoAdmin"),
+      link: `/admin/projects/project/${tournament.id}/change/`,
+      openNewTab: true,
+    });
+  }
+
+  if (!menuItems.length) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu items={menuItems} className="normal-case">
+      <Button
+        className=" rounded border-0 bg-transparent hover:bg-blue-500 dark:hover:bg-blue-500-dark"
+        presentationType="icon"
+      >
+        <FontAwesomeIcon
+          icon={faEllipsis}
+          className="text-gray-0 dark:text-gray-0-dark"
+        />
+      </Button>
+    </DropdownMenu>
+  );
+};
+
+export default TournamentDropdownMenu;

--- a/front_end/src/app/(main)/accounts/profile/[id]/page.tsx
+++ b/front_end/src/app/(main)/accounts/profile/[id]/page.tsx
@@ -76,16 +76,20 @@ export default async function Profile({ params: { id }, searchParams }: Props) {
               <ChangeUsername />
             </span>
           )}
-          {currentUser?.is_staff && (
+          {(currentUser?.is_staff || currentUser?.is_superuser) && (
             <div className="mt-2 flex flex-col gap-3 text-sm md:flex-row">
               <div className="flex flex-wrap items-center gap-3">
-                <Button
-                  href={`/admin/users/user/${profile.id}/change/`}
-                  target="_blank"
-                >
-                  {t("viewInDjangoAdmin")}
-                </Button>
-                {!profile.is_spam && <SoftDeleteButton id={id} />}
+                {currentUser.is_superuser && (
+                  <Button
+                    href={`/admin/users/user/${profile.id}/change/`}
+                    target="_blank"
+                  >
+                    {t("viewInDjangoAdmin")}
+                  </Button>
+                )}
+                {!profile.is_spam && currentUser.is_staff && (
+                  <SoftDeleteButton id={id} />
+                )}
               </div>
               <div className="flex flex-wrap items-center gap-3">
                 <ProfileChip variant={profile.is_active ? "success" : "danger"}>

--- a/front_end/src/app/(main)/accounts/profile/[id]/page.tsx
+++ b/front_end/src/app/(main)/accounts/profile/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { Suspense } from "react";
+import { getTranslations } from "next-intl/server";
+import { FC, PropsWithChildren, Suspense } from "react";
 import { remark } from "remark";
 import strip from "strip-markdown";
 
@@ -8,11 +9,13 @@ import MedalsPage from "@/app/(main)/(leaderboards)/medals/components/medals_pag
 import MedalsWidget from "@/app/(main)/(leaderboards)/medals/components/medals_widget";
 import UserInfo from "@/app/(main)/accounts/profile/components/user_info";
 import CommentFeed from "@/components/comment_feed";
+import Button from "@/components/ui/button";
 import LoadingIndicator from "@/components/ui/loading_indicator";
 import { defaultDescription } from "@/constants/metadata";
 import ProfileApi from "@/services/profile";
 import { SearchParams } from "@/types/navigation";
 import { ProfilePageMode } from "@/types/users";
+import cn from "@/utils/cn";
 
 import ProfilePageTabs from "./components/profile_page_tab";
 import ChangeUsername from "../components/change_username";
@@ -58,6 +61,8 @@ export default async function Profile({ params: { id }, searchParams }: Props) {
   const mode = (searchParams.mode ||
     ProfilePageMode.Overview) as ProfilePageMode;
 
+  const t = await getTranslations();
+
   return (
     <main className="mx-auto my-4 flex min-h-min w-full max-w-5xl flex-col gap-4 px-3 lg:px-0">
       <div className="flex flex-col gap-4 rounded bg-white p-4 dark:bg-blue-900 md:p-6">
@@ -72,18 +77,24 @@ export default async function Profile({ params: { id }, searchParams }: Props) {
             </span>
           )}
           {currentUser?.is_staff && (
-            <div className="mt-2 flex gap-3 text-sm">
-              {!profile.is_spam && <SoftDeleteButton id={id} />}
-              <span
-                className={`rounded px-2 py-1 ${profile.is_active ? "bg-green-100 text-green-800" : "bg-red-100 text-red-800"} dark:bg-opacity-20`}
-              >
-                {profile.is_active ? "Active" : "Inactive"}
-              </span>
-              <span
-                className={`rounded px-2 py-1 ${profile.is_spam ? "bg-red-100 text-red-800" : "bg-green-100 text-green-800"} dark:bg-opacity-20`}
-              >
-                {profile.is_spam ? "Spam" : "Not Spam"}
-              </span>
+            <div className="mt-2 flex flex-col gap-3 text-sm md:flex-row">
+              <div className="flex flex-wrap items-center gap-3">
+                <Button
+                  href={`/admin/users/user/${profile.id}/change/`}
+                  target="_blank"
+                >
+                  {t("viewInDjangoAdmin")}
+                </Button>
+                {!profile.is_spam && <SoftDeleteButton id={id} />}
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <ProfileChip variant={profile.is_active ? "success" : "danger"}>
+                  {profile.is_active ? "Active" : "Inactive"}
+                </ProfileChip>
+                <ProfileChip variant={profile.is_spam ? "danger" : "success"}>
+                  {profile.is_spam ? "Spam" : "Not Spam"}
+                </ProfileChip>
+              </div>
             </div>
           )}
         </div>
@@ -122,3 +133,18 @@ export default async function Profile({ params: { id }, searchParams }: Props) {
     </main>
   );
 }
+
+const ProfileChip: FC<
+  PropsWithChildren<{ variant?: "success" | "danger" }>
+> = ({ variant = "success", children }) => (
+  <span
+    className={cn("rounded px-2 py-1 dark:bg-opacity-20", {
+      "dark:bg-green-100-dark bg-green-100 text-green-800 dark:text-green-800-dark":
+        variant === "success",
+      "dark:bg-red-100-dark dark:text-red-800-dark bg-red-100 text-red-800":
+        variant === "danger",
+    })}
+  >
+    {children}
+  </span>
+);

--- a/front_end/src/app/(main)/questions/components/conditional_form.tsx
+++ b/front_end/src/app/(main)/questions/components/conditional_form.tsx
@@ -8,12 +8,12 @@ import { useForm, UseFormReturn } from "react-hook-form";
 import * as z from "zod";
 
 import ProjectPickerInput from "@/app/(main)/questions/components/project_picker_input";
+import PostDjangoAdminLink from "@/app/(main)/questions/create/components/django_admin_link";
 import QuestionChartTile from "@/components/post_card/question_chart_tile";
 import Button from "@/components/ui/button";
 import { FormErrorMessage } from "@/components/ui/form_field";
 import { InputContainer } from "@/components/ui/input_container";
 import LoadingIndicator from "@/components/ui/loading_indicator";
-import { useAuth } from "@/contexts/auth_context";
 import { Post, PostWithForecasts } from "@/types/post";
 import {
   Tournament,
@@ -74,7 +74,6 @@ const ConditionalForm: React.FC<{
   const router = useRouter();
   const t = useTranslations();
   const { isLive, isDone } = getQuestionStatus(post);
-  const { user } = useAuth();
   const [isLoading, setIsLoading] = useState<boolean>();
   const [error, setError] = useState<
     (Error & { digest?: string }) | undefined
@@ -183,11 +182,8 @@ const ConditionalForm: React.FC<{
           )(e);
         }}
       >
-        {post && user?.is_superuser && (
-          <a href={`/admin/posts/post/${post.id}/change`}>
-            {t("viewInDjangoAdmin")}
-          </a>
-        )}
+        <PostDjangoAdminLink post={post} />
+
         {!community_id && defaultProject.type !== TournamentType.Community && (
           <ProjectPickerInput
             tournaments={tournaments}

--- a/front_end/src/app/(main)/questions/components/group_form.tsx
+++ b/front_end/src/app/(main)/questions/components/group_form.tsx
@@ -8,14 +8,14 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 import GroupFormBulkModal, {
   BulkBulkQuestionAttrs,
 } from "@/app/(main)/questions/components/group_form_bulk_modal";
 import ProjectPickerInput from "@/app/(main)/questions/components/project_picker_input";
-import MarkdownEditor from "@/components/markdown_editor";
+import PostDjangoAdminLink from "@/app/(main)/questions/create/components/django_admin_link";
 import Button from "@/components/ui/button";
 import DatetimeUtc from "@/components/ui/datetime_utc";
 import {
@@ -97,6 +97,7 @@ const GroupForm: React.FC<Props> = ({
 }) => {
   const router = useRouter();
   const t = useTranslations();
+
   const [isLoading, setIsLoading] = useState<boolean>();
   const [isBulkModalOpen, setIsBulkModalOpen] = useState(false);
   const [error, setError] = useState<
@@ -319,6 +320,8 @@ const GroupForm: React.FC<Props> = ({
         }}
         className="mt-4 flex w-full flex-col gap-4 rounded"
       >
+        <PostDjangoAdminLink post={post} />
+
         {!community_id && defaultProject.type !== TournamentType.Community && (
           <ProjectPickerInput
             tournaments={tournaments}

--- a/front_end/src/app/(main)/questions/components/notebook_form.tsx
+++ b/front_end/src/app/(main)/questions/components/notebook_form.tsx
@@ -8,6 +8,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import ProjectPickerInput from "@/app/(main)/questions/components/project_picker_input";
+import PostDjangoAdminLink from "@/app/(main)/questions/create/components/django_admin_link";
 import Button from "@/components/ui/button";
 import {
   FormErrorMessage,
@@ -17,7 +18,6 @@ import {
 } from "@/components/ui/form_field";
 import { InputContainer } from "@/components/ui/input_container";
 import LoadingIndicator from "@/components/ui/loading_indicator";
-import { useAuth } from "@/contexts/auth_context";
 import useConfirmPageLeave from "@/hooks/use_confirm_page_leave";
 import { Category, Post, PostWithForecasts } from "@/types/post";
 import {
@@ -79,7 +79,6 @@ const NotebookForm: React.FC<Props> = ({
   siteMain,
   news_category_id,
 }) => {
-  const { user } = useAuth();
   const [isLoading, setIsLoading] = useState<boolean>();
   const [error, setError] = useState<
     (Error & { digest?: string }) | undefined
@@ -176,11 +175,8 @@ const NotebookForm: React.FC<Props> = ({
           )(e);
         }}
       >
-        {post && user?.is_superuser && (
-          <a href={`/admin/posts/post/${post.id}/change`}>
-            {t("viewInDjangoAdmin")}
-          </a>
-        )}
+        <PostDjangoAdminLink post={post} />
+
         {!community_id &&
           !news_category_id &&
           defaultProject?.type !== TournamentType.Community &&

--- a/front_end/src/app/(main)/questions/components/question_form.tsx
+++ b/front_end/src/app/(main)/questions/components/question_form.tsx
@@ -11,6 +11,7 @@ import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 import ProjectPickerInput from "@/app/(main)/questions/components/project_picker_input";
+import PostDjangoAdminLink from "@/app/(main)/questions/create/components/django_admin_link";
 import Button from "@/components/ui/button";
 import {
   DateInput,
@@ -23,7 +24,6 @@ import {
 import { InputContainer } from "@/components/ui/input_container";
 import LoadingIndicator from "@/components/ui/loading_indicator";
 import { MarkdownText } from "@/components/ui/markdown_text";
-import { useAuth } from "@/contexts/auth_context";
 import { Category, Post, PostStatus, PostWithForecasts } from "@/types/post";
 import {
   Tournament,
@@ -199,10 +199,9 @@ const QuestionForm: FC<Props> = ({
   community_id = null,
   post = null,
 }) => {
-  const { user } = useAuth();
   const router = useRouter();
   const t = useTranslations();
-  const { isLive, isDone, hasForecasts } = getQuestionStatus(post);
+  const { isDone, hasForecasts } = getQuestionStatus(post);
   const [isLoading, setIsLoading] = useState<boolean>();
   const [error, setError] = useState<
     (Error & { digest?: string }) | undefined
@@ -355,11 +354,8 @@ const QuestionForm: FC<Props> = ({
         }}
         className="mt-4 flex w-full flex-col gap-6"
       >
-        {post && user?.is_superuser && (
-          <a href={`/admin/posts/post/${post.id}/change`}>
-            {t("viewInDjangoAdmin")}
-          </a>
-        )}
+        <PostDjangoAdminLink post={post} />
+
         {!community_id && defaultProject.type !== TournamentType.Community && (
           <ProjectPickerInput
             tournaments={tournaments}

--- a/front_end/src/app/(main)/questions/create/components/django_admin_link.tsx
+++ b/front_end/src/app/(main)/questions/create/components/django_admin_link.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { useTranslations } from "next-intl";
+import { FC } from "react";
+
+import { useAuth } from "@/contexts/auth_context";
+import { PostWithForecasts } from "@/types/post";
+
+type Props = {
+  post: PostWithForecasts | null;
+};
+
+const PostDjangoAdminLink: FC<Props> = ({ post }) => {
+  const t = useTranslations();
+  const { user } = useAuth();
+
+  if (!post || !user?.is_superuser) {
+    return null;
+  }
+
+  return (
+    <a href={`/admin/posts/post/${post.id}/change`} target="_blank">
+      {t("viewInDjangoAdmin")}
+    </a>
+  );
+};
+
+export default PostDjangoAdminLink;

--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -302,6 +302,13 @@ const Comment: FC<CommentProps> = ({
       onClick: () => copyToClipboard(comment.id.toString()),
     },
     {
+      hidden: !user?.is_staff,
+      id: "viewDjangoAdmin",
+      name: t("viewInDjangoAdmin"),
+      link: `/admin/comments/comment/${comment.id}/change/`,
+      openNewTab: true,
+    },
+    {
       hidden: !user?.id,
       id: "report",
       name: t("report"),

--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -302,7 +302,7 @@ const Comment: FC<CommentProps> = ({
       onClick: () => copyToClipboard(comment.id.toString()),
     },
     {
-      hidden: !user?.is_staff,
+      hidden: !user?.is_superuser,
       id: "viewDjangoAdmin",
       name: t("viewInDjangoAdmin"),
       link: `/admin/comments/comment/${comment.id}/change/`,

--- a/front_end/src/components/post_actions/post_dropdown_menu.tsx
+++ b/front_end/src/components/post_actions/post_dropdown_menu.tsx
@@ -100,7 +100,7 @@ export const PostDropdownMenu: FC<Props> = ({ post }) => {
       <DropdownMenu items={items}>
         <Button
           variant="secondary"
-          className="!rounded border-0"
+          className="rounded border-0"
           presentationType="icon"
         >
           <FontAwesomeIcon icon={faEllipsis} className="text-lg" />


### PR DESCRIPTION
Related to #398

* added Django link to questions group form
* added Django link to comment menu
  * used dropdown menu instead of edit presentation for comment component as we disabled editing comments for non-authors in #1160 (PR: https://github.com/Metaculus/metaculus/pull/1172)
* added Django link to tournament menu
* added Django link on profile page