### PR TITLE
Fix search with custom ordering

### DIFF
--- a/metaculus_web/settings.py
+++ b/metaculus_web/settings.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.postgres",
     # third-party:
     "django_extensions",
     "rest_framework",


### PR DESCRIPTION
This PR implements an ad-hoc improvement for in-tournament search with non-rank ordering. 

#### Problem:
- Regular post searches rely on relevance ranking without additional thresholds or filtering.
- When searching by a parameter like creation date (instead of rank), the ranking mechanism is neglected, which compromises the search's effectiveness.
- A workaround of setting a 0.3 threshold was in place but proved insufficient.

#### Solution:
- Added a full-text search fallback specifically for in-tournament post searches.
- The fallback ensures that only posts containing the exact search string are selected, combining this with the regular embedding search and a cosine distance threshold of 0.3.

fixes #1728 