### PR TITLE
add careful tag generation to update global leaderboard tags method

### DIFF
--- a/posts/services/common.py
+++ b/posts/services/common.py
@@ -93,12 +93,12 @@ def update_global_leaderboard_tags(post: Post):
                 # Unsure why this is happening, so for debugging purposes
                 # log error and continue - don't block the triggering event
                 # (e.g. question resolution)
-                logger.error(
-                    f"Error creating/getting global leaderboard tag for post {post.id}:"
-                    f" {e}.\nContext: tag_name: {tag_name}, tag_slug: {tag_slug}, "
+                logger.exception(
+                    f"Error creating/getting global leaderboard tag for post {post.id}."
+                    f" Context: tag_name: {tag_name}, tag_slug: {tag_slug}, "
                     f"question: {question.id}, dates: {dates}"
                 )
-                return
+                tag = Project.objects.get(type=Project.ProjectTypes.TAG, slug=tag_slug)
             to_set_tags.append(tag)
 
     # Update post's global leaderboard tags

--- a/posts/services/common.py
+++ b/posts/services/common.py
@@ -89,7 +89,7 @@ def update_global_leaderboard_tags(post: Post):
                     slug=tag_slug,
                     defaults={"name": tag_name, "order": 1},
                 )
-            except IntegrityError as e:
+            except IntegrityError:
                 # Unsure why this is happening, so for debugging purposes
                 # log error and continue - don't block the triggering event
                 # (e.g. question resolution)

--- a/posts/services/common.py
+++ b/posts/services/common.py
@@ -82,20 +82,11 @@ def update_global_leaderboard_tags(post: Post):
         dates = question.get_global_leaderboard_dates(gl_dates=gl_dates)
         if dates:
             tag_name, tag_slug = name_and_slug_for_global_leaderboard_dates(dates)
-            try:
-                tag, _ = Project.objects.get_or_create(
+            tag = Project.objects.filter(type=Project.ProjectTypes.TAG, slug=tag_slug).first()
+            if tag is None:
+                tag = Project.objects.create(
                     type=Project.ProjectTypes.TAG, name=tag_name, slug=tag_slug, order=1
                 )
-            except Exception as e:
-                # Unsure why this is happening, so for debugging purposes
-                # log error and continue - don't block the triggering event
-                # (e.g. question resolution)
-                logger.error(
-                    f"Error creating/getting global leaderboard tag for post {post.id}:"
-                    f" {e}.\nContext: tag_name: {tag_name}, tag_slug: {tag_slug}, "
-                    f"question: {question.id}, dates: {dates}"
-                )
-                return
             to_set_tags.append(tag)
 
     # Update post's global leaderboard tags

--- a/posts/services/common.py
+++ b/posts/services/common.py
@@ -82,9 +82,20 @@ def update_global_leaderboard_tags(post: Post):
         dates = question.get_global_leaderboard_dates(gl_dates=gl_dates)
         if dates:
             tag_name, tag_slug = name_and_slug_for_global_leaderboard_dates(dates)
-            tag, _ = Project.objects.get_or_create(
-                type=Project.ProjectTypes.TAG, name=tag_name, slug=tag_slug, order=1
-            )
+            try:
+                tag, _ = Project.objects.get_or_create(
+                    type=Project.ProjectTypes.TAG, name=tag_name, slug=tag_slug, order=1
+                )
+            except Exception as e:
+                # Unsure why this is happening, so for debugging purposes
+                # log error and continue - don't block the triggering event
+                # (e.g. question resolution)
+                logger.error(
+                    f"Error creating/getting global leaderboard tag for post {post.id}:"
+                    f" {e}.\nContext: tag_name: {tag_name}, tag_slug: {tag_slug}, "
+                    f"question: {question.id}, dates: {dates}"
+                )
+                return
             to_set_tags.append(tag)
 
     # Update post's global leaderboard tags

--- a/posts/services/common.py
+++ b/posts/services/common.py
@@ -4,6 +4,7 @@ from datetime import timedelta, date
 
 from django.db.models import Q, Count, Sum, Value, Case, When, F, QuerySet
 from django.db.models.functions import Coalesce
+from django.db.utils import IntegrityError
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 from sql_util.aggregates import SubqueryAggregate
@@ -82,11 +83,22 @@ def update_global_leaderboard_tags(post: Post):
         dates = question.get_global_leaderboard_dates(gl_dates=gl_dates)
         if dates:
             tag_name, tag_slug = name_and_slug_for_global_leaderboard_dates(dates)
-            tag = Project.objects.filter(type=Project.ProjectTypes.TAG, slug=tag_slug).first()
-            if tag is None:
-                tag = Project.objects.create(
-                    type=Project.ProjectTypes.TAG, name=tag_name, slug=tag_slug, order=1
+            try:
+                tag, _ = Project.objects.get_or_create(
+                    type=Project.ProjectTypes.TAG,
+                    slug=tag_slug,
+                    defaults={"name": tag_name, "order": 1},
                 )
+            except IntegrityError as e:
+                # Unsure why this is happening, so for debugging purposes
+                # log error and continue - don't block the triggering event
+                # (e.g. question resolution)
+                logger.error(
+                    f"Error creating/getting global leaderboard tag for post {post.id}:"
+                    f" {e}.\nContext: tag_name: {tag_name}, tag_slug: {tag_slug}, "
+                    f"question: {question.id}, dates: {dates}"
+                )
+                return
             to_set_tags.append(tag)
 
     # Update post's global leaderboard tags


### PR DESCRIPTION
This issue is blocking question resolution for an unknown reason. https://metaculus.sentry.io/issues/6160130642/events/18e871013d4d4309a950dd94083875dc/?project=4507883238129664

I couldn't figure out what is actually causing the bug, so I'm just making it simple to avoid constraint conflicts.