### PR TITLE
Improve TypeScript rules to enforce unchecked indexes check

### DIFF
--- a/front_end/.eslintrc.json
+++ b/front_end/.eslintrc.json
@@ -1,6 +1,9 @@
 {
-  "extends": ["plugin:prettier/recommended", "next/core-web-vitals"],
+  "extends": ["plugin:prettier/recommended", "next/core-web-vitals", "next/typescript"],
   "rules": {
+    "@typescript-eslint/no-non-null-assertion": "error",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unused-expressions": "warn",
     "import/order": [
       "error",
       {

--- a/front_end/package-lock.json
+++ b/front_end/package-lock.json
@@ -67,9 +67,8 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@types/file-saver": "^2.0.7",
         "eslint": "^8.57.0",
-        "eslint-config-next": "14.2.3",
+        "eslint-config-next": "14.2.18",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "husky": "^9.0.11",
@@ -2258,9 +2257,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.3.tgz",
-      "integrity": "sha512-L3oDricIIjgj1AVnRdRor21gI7mShlSwU/1ZGHmqM3LzHhXXhdkrfeNY5zif25Bi5Dd7fiJHsbhoZCHfXYvlAw==",
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.18.tgz",
+      "integrity": "sha512-KyYTbZ3GQwWOjX3Vi1YcQbekyGP0gdammb7pbmmi25HBUCINzDReyrzCMOJIeZisK1Q3U6DT5Rlc4nm2/pQeXA==",
       "dev": true,
       "dependencies": {
         "glob": "10.3.10"
@@ -4905,12 +4904,6 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/@types/file-saver": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.7.tgz",
-      "integrity": "sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==",
-      "dev": true
-    },
     "node_modules/@types/geojson": {
       "version": "7946.0.14",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
@@ -5072,27 +5065,60 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.2.0.tgz",
-      "integrity": "sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==",
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.15.0.tgz",
+      "integrity": "sha512-+zkm9AR1Ds9uLWN3fkoeXgFppaQ+uEVtfOV62dDmsy9QCNqlRHWNEck4yarvRNrvRcHQLGfqBNui3cimoz8XAg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.2.0",
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/typescript-estree": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
-        "debug": "^4.3.4"
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.15.0",
+        "@typescript-eslint/type-utils": "8.15.0",
+        "@typescript-eslint/utils": "8.15.0",
+        "@typescript-eslint/visitor-keys": "8.15.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.15.0.tgz",
+      "integrity": "sha512-7n59qFpghG4uazrF9qtGKBZXn7Oz4sOMm8dwNWDQY96Xlm2oX67eipqcblDj+oY1lLCbf1oltMZFpUso66Kl1A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.15.0",
+        "@typescript-eslint/types": "8.15.0",
+        "@typescript-eslint/typescript-estree": "8.15.0",
+        "@typescript-eslint/visitor-keys": "8.15.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -5101,29 +5127,56 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz",
-      "integrity": "sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.15.0.tgz",
+      "integrity": "sha512-QRGy8ADi4J7ii95xz4UoiymmmMd/zuy9azCaamnZ3FM8T5fZcex8UfJcjkiEZjJSztKfEBe3dZ5T/5RHAmw2mA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0"
+        "@typescript-eslint/types": "8.15.0",
+        "@typescript-eslint/visitor-keys": "8.15.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.15.0.tgz",
+      "integrity": "sha512-UU6uwXDoI3JGSXmcdnP5d8Fffa2KayOhUUqr/AiBnG1Gl7+7ut/oyagVeSkh7bxQ0zSXV9ptRh/4N15nkCqnpw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.15.0",
+        "@typescript-eslint/utils": "8.15.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.2.0.tgz",
-      "integrity": "sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.15.0.tgz",
+      "integrity": "sha512-n3Gt8Y/KyJNe0S3yDCD2RVKrHBC4gTUcLTebVBXacPy091E6tNspFLKRXlk3hwT4G55nfr1n2AdFqi/XMxzmPQ==",
       "dev": true,
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5131,22 +5184,22 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.2.0.tgz",
-      "integrity": "sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.15.0.tgz",
+      "integrity": "sha512-1eMp2JgNec/niZsR7ioFBlsh/Fk0oJbhaqO0jRyQBMgkz7RrFfkqF9lYYmBoGBaSiLnu8TAPQTwoTUiSTUW9dg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
+        "@typescript-eslint/types": "8.15.0",
+        "@typescript-eslint/visitor-keys": "8.15.0",
         "debug": "^4.3.4",
-        "globby": "^11.1.0",
+        "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5168,9 +5221,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -5182,21 +5235,60 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.2.0.tgz",
-      "integrity": "sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==",
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.15.0.tgz",
+      "integrity": "sha512-k82RI9yGhr0QM3Dnq+egEpz9qB6Un+WLYhmoNcvl8ltMEededhh7otBVVIDDsEEttauwdY/hQoSsOv13lxrFzQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.15.0",
+        "@typescript-eslint/types": "8.15.0",
+        "@typescript-eslint/typescript-estree": "8.15.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.15.0.tgz",
+      "integrity": "sha512-h8vYOulWec9LhpwfAdZf2bjr8xIp0KNKnpgqSz0qqYYKAW/QZKw3ktRndbiAtUz4acH4QLQavwZBYCc0wulA/Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.15.0",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -5557,15 +5649,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/array.prototype.findlast": {
@@ -7168,18 +7251,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -7669,14 +7740,15 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.3.tgz",
-      "integrity": "sha512-ZkNztm3Q7hjqvB1rRlOX8P9E/cXRL9ajRcs8jufEtwMfTVYRqnmtnaSu57QqHyBlovMuiB8LEzfLBkh5RYV6Fg==",
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.18.tgz",
+      "integrity": "sha512-SuDRcpJY5VHBkhz5DijJ4iA4bVnBA0n48Rb+YSJSCDr+h7kKAcb1mZHusLbW+WA8LDB6edSolomXA55eG3eOVA==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "14.2.3",
+        "@next/eslint-plugin-next": "14.2.18",
         "@rushstack/eslint-patch": "^1.3.3",
-        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0",
+        "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.28.1",
@@ -8760,26 +8832,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/goober": {
@@ -12232,15 +12284,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -13693,15 +13736,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "license": "MIT"
-    },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/slice-ansi": {
       "version": "5.0.0",

--- a/front_end/package.json
+++ b/front_end/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "eslint": "^8.57.0",
-    "eslint-config-next": "14.2.3",
+    "eslint-config-next": "14.2.18",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "husky": "^9.0.11",

--- a/front_end/src/app/(embed)/questions/helpers/embed_theme.ts
+++ b/front_end/src/app/(embed)/questions/helpers/embed_theme.ts
@@ -33,7 +33,10 @@ function processCssVariables(
     variables.reduce(
       (acc, param) => {
         const [key, value] = param.split("=");
-        acc[key.replace(/-/g, "_")] = value;
+        if (key && value) {
+          acc[key.replace(/-/g, "_")] = value;
+        }
+
         return acc;
       },
       {} as Record<string, string>

--- a/front_end/src/app/(main)/(leaderboards)/contributions/components/contributions_table.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/contributions/components/contributions_table.tsx
@@ -62,21 +62,33 @@ const ContributionsTable: FC<Props> = ({
       [...contributions].sort((a, b) => {
         switch (sortingColumn) {
           case "score":
+            const aScore = a.score ?? 0;
+            const bScore = b.score ?? 0;
+
             return sortingDirection === "asc"
-              ? (a.score ?? 0) - (b.score ?? 0)
-              : (b.score ?? 0) - (a.score ?? 0);
+              ? aScore - bScore
+              : bScore - aScore;
           case "title":
+            const aTitle = a.question_title ?? "";
+            const bTitle = b.question_title ?? "";
+
             return sortingDirection === "asc"
-              ? a.question_title!.localeCompare(b.question_title!)
-              : b.question_title!.localeCompare(a.question_title!);
+              ? aTitle.localeCompare(bTitle)
+              : bTitle.localeCompare(aTitle);
           case "type":
+            const aType = a.question_type ?? "";
+            const bType = b.question_type ?? "";
+
             return sortingDirection === "asc"
-              ? a.question_type!.localeCompare(b.question_type!)
-              : b.question_type!.localeCompare(a.question_type!);
+              ? aType.localeCompare(bType)
+              : bType.localeCompare(aType);
           case "coverage":
+            const aCoverage = a.coverage ?? 0;
+            const bCoverage = b.coverage ?? 0;
+
             return sortingDirection === "asc"
-              ? (a.coverage ?? 0) - (b.coverage ?? 0)
-              : (b.coverage ?? 0) - (a.coverage ?? 0);
+              ? aCoverage - bCoverage
+              : bCoverage - aCoverage;
           default:
             return 0;
         }
@@ -101,7 +113,7 @@ const ContributionsTable: FC<Props> = ({
       : "-";
   };
 
-  const getQuestionTypeLabel = (type: QuestionType) => {
+  const getQuestionTypeLabel = (type: QuestionType | undefined) => {
     switch (type) {
       case QuestionType.Binary:
         return t("binary");
@@ -218,25 +230,23 @@ const ContributionsTable: FC<Props> = ({
               {["peer", "baseline"].includes(category) && (
                 <Link
                   className="no-underline"
-                  href={`/questions/${contribution.question_id!}`}
+                  href={`/questions/${contribution?.question_id}`}
                 >
-                  {contribution.question_title!}
+                  {contribution?.question_title}
                 </Link>
               )}
               {category === "questionWriting" && (
                 <Link
                   className="no-underline"
-                  /* TODO: change to actual comment url once BE support it */
-                  href={`/questions/${contribution.post_id!}`}
+                  href={`/questions/${contribution.post_id}`}
                 >
-                  {contribution.post_title!}
+                  {contribution.post_title}
                 </Link>
               )}
               {category === "comments" && (
                 <Link
                   className="block max-h-[15px] truncate no-underline"
-                  /* TODO: change to actual comment url once BE support it */
-                  href={`/questions/${contribution.post_id!}/#comment-${contribution.comment_id}`}
+                  href={`/questions/${contribution.post_id}/#comment-${contribution.comment_id}`}
                 >
                   <MarkdownEditor
                     mode="read"
@@ -250,7 +260,7 @@ const ContributionsTable: FC<Props> = ({
             </td>
             {isQuestionCategory && (
               <td className="flex items-center gap-2 self-stretch px-4 py-1.5 text-sm font-medium leading-4 text-blue-700 dark:text-blue-700-dark max-sm:hidden">
-                {getQuestionTypeLabel(contribution.question_type!)}
+                {getQuestionTypeLabel(contribution.question_type)}
               </td>
             )}
           </tr>
@@ -299,7 +309,7 @@ const getIsResolved = (contribution: Contribution) =>
   !isUnsuccessfullyResolved(contribution.question_resolution);
 
 const getCommentSummary = (markdown: string) => {
-  if ([">", "*"].includes(markdown[0])) {
+  if ([">", "*"].includes(markdown[0] ?? "")) {
     markdown = markdown.slice(1);
   }
   markdown = markdown.replace(/\<.*?\>/g, "");

--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/categories_tab_bar.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/categories_tab_bar.tsx
@@ -28,7 +28,10 @@ const LeaderboardCategoriesTabBar: FC<Props> = ({ categoryKeys }) => {
   useEffect(() => {
     const activeCategoryIsMissing = !categoryKeys.includes(activeCategoryKey);
     if (activeCategoryIsMissing) {
-      updateActiveCategoryKey(categoryKeys[0]);
+      const fallbackCategory = categoryKeys[0];
+      if (fallbackCategory) {
+        updateActiveCategoryKey(fallbackCategory);
+      }
     }
   }, [activeCategoryKey, categoryKeys, updateActiveCategoryKey]);
 

--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/leaderboard_table/index.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/leaderboard_table/index.tsx
@@ -107,7 +107,7 @@ const LeaderboardTable: FC<Props> = ({
               } else {
                 return (
                   <LeaderboardRow
-                    key={`ranking-row-${category}-${entry.user ? entry.user.id : entry.aggregation_method!}`}
+                    key={`ranking-row-${category}-${entry.user ? entry.user.id : entry.aggregation_method}`}
                     rowEntry={entry}
                     scoreType={leaderboardDetails.score_type}
                     href={navigationUrl}

--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/leaderboard_table/table_row.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/leaderboard_table/table_row.tsx
@@ -11,9 +11,7 @@ import cn from "@/utils/cn";
 import { abbreviatedNumber } from "@/utils/number_formatters";
 
 import MedalIcon from "../../../components/medal_icon";
-import { CONTRIBUTIONS_USER_FILTER } from "../../../contributions/search_params";
 import {
-  SCORING_CATEGORY_FILTER,
   SCORING_DURATION_FILTER,
   SCORING_YEAR_FILTER,
 } from "../../../search_params";
@@ -137,7 +135,7 @@ export const UserLeaderboardRow: FC<UserLeaderboardRowProps> = ({
 
   const userHref = userEntry.medal
     ? "/medals"
-    : `/contributions/${category}/${userEntry.user!.id}/?${SCORING_YEAR_FILTER}=${year}&${SCORING_DURATION_FILTER}=${duration}`;
+    : `/contributions/${category}/${userEntry.user?.id}/?${SCORING_YEAR_FILTER}=${year}&${SCORING_DURATION_FILTER}=${duration}`;
 
   return (
     <LeaderboardRow

--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/filters.ts
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/filters.ts
@@ -1,4 +1,5 @@
 import { CategoryKey } from "@/types/scoring";
+import { isNil } from "lodash";
 
 export const LEADERBOARD_CATEGORIES = [
   "baseline",
@@ -29,7 +30,13 @@ const LEADERBOARD_YEARS = [
   "2016,2",
   "2016,1",
 ];
-export const LEADERBOARD_YEAR_OPTIONS = LEADERBOARD_YEARS.map((opt) => {
+export const LEADERBOARD_YEAR_OPTIONS = LEADERBOARD_YEARS.reduce<
+  Array<{ year: string; duration: string }>
+>((acc, opt) => {
   const [year, duration] = opt.split(",");
-  return { year, duration };
-});
+  if (!isNil(year) && !isNil(duration)) {
+    acc.push({ year, duration });
+  }
+
+  return acc;
+}, []);

--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/helpers/filter.ts
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/helpers/filter.ts
@@ -54,7 +54,7 @@ export function extractLeaderboardFiltersFromParams(
     DEFAULT_LEADERBOARD_CATEGORY) as CategoryKey;
 
   const durations = getLeaderboardDurationFilters(t);
-  let duration: string = durations[0].value;
+  let duration: string = durations[0]?.value ?? "1";
   if (
     params[SCORING_DURATION_FILTER] &&
     typeof params[SCORING_DURATION_FILTER] === "string" &&
@@ -64,7 +64,7 @@ export function extractLeaderboardFiltersFromParams(
   }
 
   const periods = getLeaderboardTimePeriodFilters(duration);
-  let year: string = periods[periods.length - 1].value;
+  let year: string = periods[periods.length - 1]?.value ?? "2024";
   if (
     params[SCORING_YEAR_FILTER] &&
     typeof params[SCORING_YEAR_FILTER] === "string" &&

--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/page.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/page.tsx
@@ -36,6 +36,8 @@ export default function GlobalLeaderboards({
   // single category view
   if (categoryKeys.length === 1) {
     const categoryKey = categoryKeys[0];
+    if (!categoryKey) return null;
+
     const leaderboardType = mapCategoryKeyToLeaderboardType(
       categoryKey,
       Number(year) + Number(duration)

--- a/front_end/src/app/(main)/(leaderboards)/medals/helpers/medal_title.ts
+++ b/front_end/src/app/(main)/(leaderboards)/medals/helpers/medal_title.ts
@@ -1,4 +1,5 @@
 import { Medal, MedalProjectType } from "@/types/scoring";
+import { isNil } from "lodash";
 
 export function getMedalDisplayTitle(medal: Medal): string {
   if (medal.projectType === MedalProjectType.Tournament) {
@@ -11,8 +12,14 @@ export function getMedalDisplayTitle(medal: Medal): string {
     return "";
   }
 
-  const startYear = parseInt(match[1], 10);
-  const duration = parseInt(match[2], 10);
+  const rawStartYear = match[1];
+  const rawDuration = match[2];
+  if (isNil(rawStartYear) || isNil(rawDuration)) {
+    return "";
+  }
+
+  const startYear = parseInt(rawStartYear, 10);
+  const duration = parseInt(rawDuration, 10);
 
   if (duration === 1) {
     return `${startYear}`;

--- a/front_end/src/app/(main)/(leaderboards)/medals/page.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/medals/page.tsx
@@ -35,7 +35,7 @@ export default async function Medals({
     MedalsPath.Profile;
 
   const userMedals = await LeaderboardApi.getUserMedals(userId);
-  const username = userMedals.at(0)?.user!.username;
+  const username = userMedals.at(0)?.user?.username;
 
   return (
     <main className="mb-auto pb-3 text-blue-700 dark:text-blue-700-dark sm:px-3">

--- a/front_end/src/app/(main)/accounts/activate/route.ts
+++ b/front_end/src/app/(main)/accounts/activate/route.ts
@@ -4,6 +4,7 @@ import AuthApi from "@/services/auth";
 import { setServerSession } from "@/services/session";
 import { SocialProviderType } from "@/types/auth";
 import { logError } from "@/utils/errors";
+import invariant from "ts-invariant";
 
 export async function GET(
   request: Request,
@@ -13,6 +14,8 @@ export async function GET(
   const search_params = Object.fromEntries(url.searchParams.entries());
 
   const { user_id: userId, token, redirect_url } = search_params;
+  invariant(userId, "User id param is missing");
+  invariant(token, "Token param is missing");
 
   try {
     const response = await AuthApi.activateAccount(userId, token);

--- a/front_end/src/app/(main)/accounts/change-email/route.ts
+++ b/front_end/src/app/(main)/accounts/change-email/route.ts
@@ -8,7 +8,9 @@ export async function GET(request: Request) {
 
   const { token } = search_params;
 
-  await ProfileApi.changeEmailConfirm(token);
+  if (token) {
+    await ProfileApi.changeEmailConfirm(token);
+  }
 
   return redirect("/accounts/settings");
 }

--- a/front_end/src/app/(main)/aggregation-explorer/components/aggregation_tab.tsx
+++ b/front_end/src/app/(main)/aggregation-explorer/components/aggregation_tab.tsx
@@ -43,10 +43,7 @@ const AggregationsTab: FC<Props> = ({ questionData, activeTab }) => {
     [actual_close_time]
   );
   const [cursorTimestamp, setCursorTimestamp] = useState<number | null>(
-    activeAggregation
-      ? activeAggregation.history[activeAggregation.history.length - 1]
-          .start_time
-      : null
+    activeAggregation?.history?.at(-1)?.start_time ?? null
   );
   const aggregationTimestamp = useDebouncedValue(cursorTimestamp, 500);
 
@@ -61,8 +58,11 @@ const AggregationsTab: FC<Props> = ({ questionData, activeTab }) => {
 
     const forecast =
       index === -1
-        ? activeAggregation.history[activeAggregation.history.length - 1]
+        ? activeAggregation.history.at(-1)
         : activeAggregation.history[index];
+    if (!forecast) {
+      return null;
+    }
 
     return {
       timestamp: forecast.start_time ?? cursorTimestamp,
@@ -75,10 +75,7 @@ const AggregationsTab: FC<Props> = ({ questionData, activeTab }) => {
 
   const handleCursorChange = useCallback(
     (value: number | null) => {
-      const fallback = activeAggregation
-        ? activeAggregation.history[activeAggregation.history.length - 1]
-            .start_time
-        : null;
+      const fallback = activeAggregation?.history?.at(-1)?.start_time ?? null;
 
       setCursorTimestamp(value ?? fallback);
     },

--- a/front_end/src/app/(main)/aggregation-explorer/components/aggregations_drawer.tsx
+++ b/front_end/src/app/(main)/aggregation-explorer/components/aggregations_drawer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { isNil, uniq } from "lodash";
+import { uniq } from "lodash";
+import { isNil } from "lodash";
 import { FC, useCallback, useState, memo, useMemo } from "react";
 
 import MultipleChoiceChart from "@/components/charts/multiple_choice_chart";
@@ -117,11 +118,12 @@ const AggregationsDrawer: FC<Props> = ({ questionData, onTabChange }) => {
 function getQuestionTooltipLabel(
   timestamps: number[],
   values: (number | null)[],
-  cursorTimestamp: number,
+  cursorTimestamp: number | null,
   qType: QuestionType,
   scaling: Scaling
 ) {
   const hasValue =
+    !isNil(cursorTimestamp) &&
     cursorTimestamp >= Math.min(...timestamps) &&
     cursorTimestamp <= Math.max(...timestamps);
   if (!hasValue) {
@@ -133,18 +135,15 @@ function getQuestionTooltipLabel(
     (timestamp) => timestamp === closestTimestamp
   );
 
-  if (values[cursorIndex] === undefined) {
+  const cursorValue = values[cursorIndex];
+  if (isNil(cursorValue)) {
     return "...";
   }
 
-  const val = values[cursorIndex];
-  if (isNil(val)) {
-    return "...";
-  }
   if (qType === QuestionType.Binary) {
-    return displayValue(val, qType);
+    return displayValue(cursorValue, qType);
   } else {
-    const scaledValue = scaleInternalLocation(val, {
+    const scaledValue = scaleInternalLocation(cursorValue, {
       range_min: scaling.range_min ?? 0,
       range_max: scaling.range_max ?? 1,
       zero_point: scaling.zero_point,

--- a/front_end/src/app/(main)/aggregation-explorer/components/continuous_aggregations_chart.tsx
+++ b/front_end/src/app/(main)/aggregation-explorer/components/continuous_aggregations_chart.tsx
@@ -1,4 +1,3 @@
-import { fromUnixTime } from "date-fns";
 import { useTranslations } from "next-intl";
 import { FC, useCallback, useMemo, useState } from "react";
 
@@ -66,13 +65,15 @@ const ContinuousAggregationChart: FC<Props> = ({
       const timestampIndex = activeAggregation.history.findIndex(
         (item) => item.start_time === selectedTimestamp
       );
-      charts.push({
-        pmf: cdfToPmf(
-          activeAggregation.history[timestampIndex].forecast_values
-        ),
-        cdf: activeAggregation.history[timestampIndex].forecast_values,
-        type: "community",
-      });
+      const historyItem = activeAggregation.history[timestampIndex];
+
+      if (historyItem) {
+        charts.push({
+          pmf: cdfToPmf(historyItem.forecast_values),
+          cdf: historyItem.forecast_values,
+          type: "community",
+        });
+      }
     }
 
     return charts;

--- a/front_end/src/app/(main)/aggregation-explorer/components/histogram_drawer.tsx
+++ b/front_end/src/app/(main)/aggregation-explorer/components/histogram_drawer.tsx
@@ -32,8 +32,8 @@ const HistogramDrawer: FC<Props> = ({
       x: index,
       y: value,
     }));
-    const median = activeAggregation.history[timestampIndex]?.centers?.[0];
-    const mean = activeAggregation.history[timestampIndex]?.means?.[0];
+    const median = activeAggregation.history?.[timestampIndex]?.centers?.[0];
+    const mean = activeAggregation.history?.[timestampIndex]?.means?.[0];
 
     return (
       histogramData && (

--- a/front_end/src/app/(main)/c/[slug]/settings/components/settings.tsx
+++ b/front_end/src/app/(main)/c/[slug]/settings/components/settings.tsx
@@ -34,7 +34,7 @@ type VisibilityType = "public" | "unlisted" | "draft";
 
 const propsToVisibilityType = (
   community: CommunityUpdateParams
-): VisibilityType | undefined => {
+): VisibilityType => {
   if (community.default_permission) {
     if (community.visibility == ProjectVisibility.Unlisted) return "unlisted";
 
@@ -140,7 +140,7 @@ const CommunitySettings: FC<Props> = ({ community }) => {
           </Label>
           <ButtonGroup
             buttons={visibilityOptions}
-            value={propsToVisibilityType(visibilityType)!}
+            value={propsToVisibilityType(visibilityType)}
             onChange={(val) => {
               Object.entries(visibilityTypeToProps(community, val)).forEach(
                 ([key, value]) => {

--- a/front_end/src/app/(main)/c/components/community_info.tsx
+++ b/front_end/src/app/(main)/c/components/community_info.tsx
@@ -37,6 +37,7 @@ const CommunityInfo: FC<Props> = ({ community }) => {
     const currentRef = communityNameRef.current;
     const observer = new IntersectionObserver(
       ([entry]) => {
+        if (!entry) return;
         setShowActiveCommunity(!entry.isIntersecting);
       },
       { threshold: 1.0 }

--- a/front_end/src/app/(main)/components/global_search_visibility_controller.tsx
+++ b/front_end/src/app/(main)/components/global_search_visibility_controller.tsx
@@ -13,6 +13,8 @@ export default function GlobalSearchVisibilityController({
   useEffect(() => {
     const observer = new IntersectionObserver(
       ([entry]) => {
+        if (!entry) return;
+
         document.body.setAttribute(
           "data-existing-search-visible",
           entry.isIntersecting.toString()

--- a/front_end/src/app/(main)/experiments/components/experiment_map/index.tsx
+++ b/front_end/src/app/(main)/experiments/components/experiment_map/index.tsx
@@ -192,7 +192,7 @@ const ExperimentMap = <T extends BaseMapArea>({
         const x = bbox.x + bbox.width / 2 + mapArea.x_adjust;
         const y = bbox.y + bbox.height / 2 + mapArea.y_adjust;
         const stateLabel = createAreaLabelElement(mapArea, x, y);
-        mapAreas[0].appendChild(stateLabel);
+        mapAreas[0]?.appendChild(stateLabel);
         stateLabel.addEventListener("mouseenter", onMouseEnter);
         stateLabel.addEventListener("mouseleave", onMouseLeave);
         cleanupData.push({ areaPath, onMouseEnter, onMouseLeave, stateLabel });
@@ -205,7 +205,7 @@ const ExperimentMap = <T extends BaseMapArea>({
           areaPath.removeEventListener("mouseleave", onMouseLeave);
           stateLabel.removeEventListener("mouseenter", onMouseEnter);
           stateLabel.removeEventListener("mouseleave", onMouseLeave);
-          mapAreas[0].removeChild(stateLabel);
+          mapAreas[0]?.removeChild(stateLabel);
         }
       );
     };

--- a/front_end/src/app/(main)/experiments/elections/components/expected_electoral_votes_forecast/index.tsx
+++ b/front_end/src/app/(main)/experiments/elections/components/expected_electoral_votes_forecast/index.tsx
@@ -116,14 +116,22 @@ function getForecastData(
     return null;
   }
   const latest_democrat = democratQuestion.aggregations.recency_weighted.latest;
+  if (!latest_democrat) {
+    return null;
+  }
+
   const latest_republican =
     republicanQuestion.aggregations.recency_weighted.latest;
+  if (!latest_republican) {
+    return null;
+  }
+
   const democratQuartiles = computeQuartilesFromCDF(
-    latest_democrat!.forecast_values,
+    latest_democrat?.forecast_values,
     true
   );
   const republicanQuartiles = computeQuartilesFromCDF(
-    latest_republican!.forecast_values,
+    latest_republican.forecast_values,
     true
   );
 
@@ -137,8 +145,8 @@ function getForecastData(
       color: "#E0152B",
     },
   ];
-  const democratPrediction = latest_democrat!.centers![0];
-  const republicanPrediction = latest_republican!.centers![0];
+  const democratPrediction = latest_democrat?.centers?.[0];
+  const republicanPrediction = latest_republican?.centers?.[0];
 
   return {
     candles,

--- a/front_end/src/app/(main)/experiments/elections/components/state_by_forecast/index.tsx
+++ b/front_end/src/app/(main)/experiments/elections/components/state_by_forecast/index.tsx
@@ -172,7 +172,7 @@ const getStateByItems = (
     }
 
     const aggregation = questionData.aggregations.recency_weighted;
-    const prediction = aggregation.latest?.centers![0];
+    const prediction = aggregation?.latest?.centers?.[0];
     if (!prediction) {
       return area;
     }
@@ -214,9 +214,9 @@ function getDemocratRepublicanPrediction({
   }
 
   const rawDemocratPrediction =
-    demQuestion.aggregations.recency_weighted.latest?.centers![0];
+    demQuestion?.aggregations?.recency_weighted?.latest?.centers?.[0];
   const rawRepublicanPrediction =
-    repQuestion.aggregations.recency_weighted.latest?.centers![0];
+    repQuestion?.aggregations?.recency_weighted?.latest?.centers?.[0];
 
   return {
     democratPrediction: rawDemocratPrediction

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/fan_graph_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/fan_graph_group_chart.tsx
@@ -36,7 +36,7 @@ const FanGraphGroupChart: FC<Props> = ({
   return (
     <FanChart
       options={
-        questions[0].type === QuestionType.Binary
+        questions[0]?.type === QuestionType.Binary
           ? getFanOptionsFromBinaryGroup(questions)
           : getFanOptionsFromContinuousGroup(questions)
       }

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/continuous_chart_card.tsx
@@ -104,8 +104,8 @@ const DetailedContinuousChartCard: FC<Props> = ({
       scaling: question.scaling,
       range: cursorData?.interval_lower_bound
         ? [
-            cursorData!.interval_lower_bound as number,
-            cursorData!.interval_upper_bound as number,
+            cursorData?.interval_lower_bound as number,
+            cursorData?.interval_upper_bound as number,
           ]
         : [],
     });

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_slider.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { faClose } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { isNil } from "lodash";
 import { useTranslations } from "next-intl";
 import { FC, useState } from "react";
 
@@ -87,29 +88,35 @@ const ContinuousSlider: FC<Props> = ({
       />
       {!disabled &&
         forecast.map((x, index) => {
+          const forecastValue = forecast[index];
+          const weightValue = weights[index];
+
           return (
             <div className="px-2.5" key={index}>
-              <MultiSlider
-                disabled={disabled}
-                key={`multi-slider-${index}`}
-                value={forecast[index]}
-                step={0.00001}
-                clampStep={0.035}
-                onChange={(value) => {
-                  const newForecast = [
-                    ...forecast.slice(0, index),
-                    {
-                      left: value.left,
-                      center: value.center,
-                      right: value.right,
-                    },
-                    ...forecast.slice(index + 1, forecast.length),
-                  ];
-                  onChange(newForecast, weights);
-                }}
-                shouldSyncWithDefault
-              />
-              {forecast.length > 1 ? (
+              {!isNil(forecastValue) && (
+                <MultiSlider
+                  disabled={disabled}
+                  key={`multi-slider-${index}`}
+                  value={forecastValue}
+                  step={0.00001}
+                  clampStep={0.035}
+                  onChange={(value) => {
+                    const newForecast = [
+                      ...forecast.slice(0, index),
+                      {
+                        left: value.left,
+                        center: value.center,
+                        right: value.right,
+                      },
+                      ...forecast.slice(index + 1, forecast.length),
+                    ];
+                    onChange(newForecast, weights);
+                  }}
+                  shouldSyncWithDefault
+                />
+              )}
+
+              {!!forecast.length && !isNil(weightValue) && (
                 <div className="flex flex-row justify-between">
                   <span className="inline pr-2 pt-2">weight:</span>
                   <div className="inline w-3/4">
@@ -118,7 +125,7 @@ const ContinuousSlider: FC<Props> = ({
                       inputMin={0}
                       inputMax={1}
                       step={0.00001}
-                      defaultValue={weights[index]}
+                      defaultValue={weightValue}
                       round={true}
                       onChange={(value) => {
                         const newWeights = [
@@ -148,7 +155,7 @@ const ContinuousSlider: FC<Props> = ({
                     }}
                   />
                 </div>
-              ) : null}
+              )}
             </div>
           );
         })}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
@@ -222,6 +222,8 @@ const ForecastMakerConditionalBinary: FC<Props> = ({
     const response = await createForecasts(
       postId,
       questionsToSubmit.map((q) => {
+        // Okay to disable no-non-null-assertion rule, as value is checked in questionsToSubmit definition
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const forecastValue = round(q.value! / 100, BINARY_FORECAST_PRECISION);
 
         return {

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_continuous.tsx
@@ -14,7 +14,7 @@ import { useServerAction } from "@/hooks/use_server_action";
 import { ErrorResponse } from "@/types/fetch";
 import { Post, PostConditional } from "@/types/post";
 import { Quartiles, QuestionWithNumericForecasts } from "@/types/question";
-import { getDisplayValue } from "@/utils/charts";
+import { getCdfBounds, getDisplayValue } from "@/utils/charts";
 import cn from "@/utils/cn";
 import {
   extractPrevNumericForecastValue,
@@ -283,8 +283,8 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
           continuousCdf: getNumericForecastDataset(
             sliderForecast,
             weights,
-            question.open_lower_bound!,
-            question.open_upper_bound!
+            question.open_lower_bound,
+            question.open_upper_bound
           ).cdf,
           probabilityYesPerCategory: null,
           probabilityYes: null,
@@ -355,8 +355,8 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
     getNumericForecastDataset(
       activeOptionData.sliderForecast,
       activeOptionData.weights,
-      activeOptionData.question.open_lower_bound!,
-      activeOptionData.question.open_upper_bound!
+      activeOptionData.question.open_lower_bound,
+      activeOptionData.question.open_upper_bound
     ).cdf;
   const userPreviousCdf: number[] | undefined =
     overlayPreviousForecast && previousForecast
@@ -405,8 +405,8 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
             dataset={getNumericForecastDataset(
               option.sliderForecast,
               option.weights,
-              option.question.open_lower_bound!,
-              option.question.open_upper_bound!
+              option.question.open_lower_bound,
+              option.question.open_upper_bound
             )}
             onChange={(forecast, weight) =>
               handleChange(option.id, forecast, weight)
@@ -490,27 +490,10 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
       {!!activeOptionData && (
         <NumericForecastTable
           question={activeOptionData.question}
-          userBounds={
-            userCdf && {
-              belowLower: userCdf![0],
-              aboveUpper: 1 - userCdf![userCdf!.length - 1],
-            }
-          }
+          userBounds={getCdfBounds(userCdf)}
           userQuartiles={userCdf && computeQuartilesFromCDF(userCdf)}
-          communityBounds={
-            communityCdf && {
-              belowLower: communityCdf![0],
-              aboveUpper: 1 - communityCdf![communityCdf!.length - 1],
-            }
-          }
-          userPreviousBounds={
-            userPreviousCdf
-              ? {
-                  belowLower: userPreviousCdf[0],
-                  aboveUpper: 1 - userPreviousCdf[userPreviousCdf.length - 1],
-                }
-              : undefined
-          }
+          communityBounds={getCdfBounds(communityCdf)}
+          userPreviousBounds={getCdfBounds(userPreviousCdf)}
           userPreviousQuartiles={
             userPreviousCdf
               ? computeQuartilesFromCDF(userPreviousCdf)

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
@@ -177,6 +177,8 @@ const ForecastMakerGroupBinary: FC<Props> = ({
       postId,
       questionsToSubmit.map((q) => {
         const forecastValue = round(
+          // okay to use non-null assertion here because we handle nullable state in questionsToSubmit calculation
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           q.forecast! / 100,
           BINARY_FORECAST_PRECISION
         );
@@ -329,7 +331,8 @@ function generateChoiceOptions(
     return {
       id: question.id,
       name: question.label,
-      communityForecast: latest && !latest.end_time ? latest.centers![0] : null,
+      communityForecast:
+        latest && !latest.end_time ? latest.centers?.[0] ?? null : null,
       forecast: prevForecastValuesMap[question.id] ?? null,
       resolution: question.resolution,
       isDirty: false,

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
@@ -30,6 +30,7 @@ import {
   PredictionInputMessage,
   QuestionWithNumericForecasts,
 } from "@/types/question";
+import { getCdfBounds } from "@/utils/charts";
 import cn from "@/utils/cn";
 import {
   extractPrevNumericForecastValue,
@@ -242,8 +243,8 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
             continuousCdf: getNumericForecastDataset(
               getNormalizedUserForecast(userForecast),
               userWeights,
-              question.open_lower_bound!,
-              question.open_upper_bound!
+              question.open_lower_bound,
+              question.open_upper_bound
             ).cdf,
             probabilityYesPerCategory: null,
             probabilityYes: null,
@@ -285,8 +286,8 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
     getNumericForecastDataset(
       getNormalizedUserForecast(activeGroupOption.userForecast),
       activeGroupOption?.userWeights,
-      activeGroupOption?.question.open_lower_bound!,
-      activeGroupOption?.question.open_upper_bound!
+      activeGroupOption?.question.open_lower_bound,
+      activeGroupOption?.question.open_upper_bound
     ).cdf;
   const userPreviousCdf: number[] | undefined =
     overlayPreviousForecast && previousForecast
@@ -314,8 +315,8 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
         const dataset = getNumericForecastDataset(
           normalizedUserForecast,
           option.userWeights,
-          option.question.open_lower_bound!,
-          option.question.open_upper_bound!
+          option.question.open_lower_bound,
+          option.question.open_upper_bound
         );
 
         return (
@@ -396,32 +397,15 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
         <>
           <NumericForecastTable
             question={activeGroupOption.question}
-            userBounds={
-              userCdf && {
-                belowLower: userCdf[0],
-                aboveUpper: 1 - userCdf[userCdf.length - 1],
-              }
-            }
+            userBounds={getCdfBounds(userCdf)}
             userQuartiles={activeGroupOption.userQuartiles ?? undefined}
-            userPreviousBounds={
-              userPreviousCdf
-                ? {
-                    belowLower: userPreviousCdf[0],
-                    aboveUpper: 1 - userPreviousCdf[userPreviousCdf.length - 1],
-                  }
-                : undefined
-            }
+            userPreviousBounds={getCdfBounds(userPreviousCdf)}
             userPreviousQuartiles={
               userPreviousCdf
                 ? computeQuartilesFromCDF(userPreviousCdf)
                 : undefined
             }
-            communityBounds={
-              communityCdf && {
-                belowLower: communityCdf[0],
-                aboveUpper: 1 - communityCdf[communityCdf.length - 1],
-              }
-            }
+            communityBounds={getCdfBounds(communityCdf)}
             communityQuartiles={
               activeGroupOption.communityQuartiles ?? undefined
             }
@@ -429,7 +413,8 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
             withCommunityQuartiles={!user || !hideCP}
             isDirty={activeGroupOption.isDirty}
             hasUserForecast={
-              !!prevForecastValuesMap[activeTableOption!].forecast
+              !isNil(activeTableOption) &&
+              !!prevForecastValuesMap[activeTableOption]?.forecast
             }
           />
 

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_menu.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_menu.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { isNil } from "lodash";
 import { useTranslations } from "next-intl";
 import React, { FC, ReactNode, useState } from "react";
 
@@ -89,13 +90,15 @@ const ForecastMakerGroupControls: FC<Props> = ({
           ...(canWithdrawForecast(
             question as QuestionWithForecasts,
             permission
-          ) && question.withdraw_permitted // Feature Flag: prediction-withdrawal
+          ) &&
+          question.withdraw_permitted && // Feature Flag: prediction-withdrawal
+          !isNil(post)
             ? [
                 {
                   id: "withdraw",
                   name: t("withdrawForecast"),
                   onClick: () =>
-                    withdrawForecasts(post!.id, [{ question: question.id }]),
+                    withdrawForecasts(post.id, [{ question: question.id }]),
                 },
               ]
             : []),

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
@@ -48,7 +48,7 @@ const ForecastMakerBinary: FC<Props> = ({
   const { hideCP } = useHideCP();
   const latest = question.aggregations.recency_weighted.latest;
   const communityForecast =
-    latest && !latest.end_time ? latest.centers![0] : undefined;
+    latest && !latest.end_time ? latest?.centers?.[0] : undefined;
 
   const prevForecastValue = extractPrevBinaryForecastValue(prevForecast);
   const hasUserForecast = !!prevForecastValue;

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
@@ -16,6 +16,7 @@ import { useServerAction } from "@/hooks/use_server_action";
 import { ErrorResponse } from "@/types/fetch";
 import { PostWithForecasts, ProjectPermissions } from "@/types/post";
 import { QuestionWithNumericForecasts } from "@/types/question";
+import { getCdfBounds } from "@/utils/charts";
 import {
   extractPrevNumericForecastValue,
   getNumericForecastDataset,
@@ -84,8 +85,8 @@ const ForecastMakerContinuous: FC<Props> = ({
       getNumericForecastDataset(
         forecast,
         weights,
-        question.open_lower_bound!,
-        question.open_upper_bound!
+        question.open_lower_bound,
+        question.open_upper_bound
       ),
     [forecast, question.open_lower_bound, question.open_upper_bound, weights]
   );
@@ -225,30 +226,13 @@ const ForecastMakerContinuous: FC<Props> = ({
       )}
       <NumericForecastTable
         question={question}
-        userBounds={{
-          belowLower: userCdf[0],
-          aboveUpper: 1 - userCdf[userCdf.length - 1],
-        }}
+        userBounds={getCdfBounds(userCdf)}
         userQuartiles={userCdf ? computeQuartilesFromCDF(userCdf) : undefined}
-        userPreviousBounds={
-          userPreviousCdf
-            ? {
-                belowLower: userPreviousCdf[0],
-                aboveUpper: 1 - userPreviousCdf[userPreviousCdf.length - 1],
-              }
-            : undefined
-        }
+        userPreviousBounds={getCdfBounds(userPreviousCdf)}
         userPreviousQuartiles={
           userPreviousCdf ? computeQuartilesFromCDF(userPreviousCdf) : undefined
         }
-        communityBounds={
-          communityCdf
-            ? {
-                belowLower: communityCdf[0],
-                aboveUpper: 1 - communityCdf[communityCdf.length - 1],
-              }
-            : undefined
-        }
+        communityBounds={getCdfBounds(communityCdf)}
         communityQuartiles={
           communityCdf ? computeQuartilesFromCDF(communityCdf) : undefined
         }

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/numeric_table.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/numeric_table.tsx
@@ -69,7 +69,7 @@ const NumericForecastTable: FC<Props> = ({
             {question.open_lower_bound && (
               <div className="w-full">
                 {"<"}
-                {displayValue(question.scaling.range_min!, question.type)}
+                {displayValue(question.scaling.range_min, question.type)}
               </div>
             )}
             <div className="w-full">{t("firstQuartile")}</div>
@@ -78,7 +78,7 @@ const NumericForecastTable: FC<Props> = ({
             {question.open_upper_bound && (
               <div className="w-full">
                 {">"}
-                {displayValue(question.scaling.range_max!, question.type)}
+                {displayValue(question.scaling.range_max, question.type)}
               </div>
             )}
           </div>
@@ -119,8 +119,8 @@ const NumericForecastTable: FC<Props> = ({
                     precision: 4,
                   })}
                 </div>
-                {question.open_upper_bound && (
-                  <div>{(userBounds!.aboveUpper * 100).toFixed(1)}%</div>
+                {question.open_upper_bound && userBounds && (
+                  <div>{(userBounds.aboveUpper * 100).toFixed(1)}%</div>
                 )}
               </>
             ) : (
@@ -171,8 +171,8 @@ const NumericForecastTable: FC<Props> = ({
                   precision: 4,
                 })}
               </div>
-              {question.open_upper_bound && (
-                <div>{(userPreviousBounds!.aboveUpper * 100).toFixed(1)}%</div>
+              {question.open_upper_bound && userPreviousBounds && (
+                <div>{(userPreviousBounds.aboveUpper * 100).toFixed(1)}%</div>
               )}
             </>
           </div>
@@ -183,7 +183,7 @@ const NumericForecastTable: FC<Props> = ({
             {question.open_lower_bound && (
               <div>
                 {communityBounds
-                  ? (communityBounds!.belowLower * 100).toFixed(1) + "%"
+                  ? (communityBounds.belowLower * 100).toFixed(1) + "%"
                   : "..."}
               </div>
             )}
@@ -217,7 +217,7 @@ const NumericForecastTable: FC<Props> = ({
             {question.open_upper_bound && (
               <div>
                 {communityBounds
-                  ? (communityBounds!.aboveUpper * 100).toFixed(1) + "%"
+                  ? (communityBounds.aboveUpper * 100).toFixed(1) + "%"
                   : "..."}
               </div>
             )}

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/prediction_status_message.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/prediction_status_message.tsx
@@ -1,3 +1,4 @@
+import { isNil } from "lodash";
 import { useTranslations } from "next-intl";
 import { FC } from "react";
 
@@ -37,11 +38,11 @@ const PredictionStatusMessage: FC<Props> = ({ post }) => {
             QuestionStatus.RESOLVED,
           ];
 
-          const closedQuestion = questions.find((obj) =>
-            targetStatuses.includes(obj.status!)
+          const closedQuestion = questions.find(
+            (obj) => !isNil(obj.status) && targetStatuses.includes(obj.status)
           );
           const activeQuestion = questions.find(
-            (obj) => !targetStatuses.includes(obj.status!)
+            (obj) => !isNil(obj.status) && !targetStatuses.includes(obj.status)
           );
 
           if (closedQuestion && activeQuestion) {

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/resolution/resolution_modal.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/resolution/resolution_modal.tsx
@@ -118,7 +118,7 @@ const QuestionResolutionModal: FC<Props> = ({ isOpen, onClose, question }) => {
       if (responses && "errors" in responses && !!responses.errors) {
         setSubmitErrors(responses.errors);
       } else {
-        onClose && onClose(true);
+        onClose?.(true);
       }
     },
     [onClose, question.id]
@@ -167,8 +167,16 @@ const QuestionResolutionModal: FC<Props> = ({ isOpen, onClose, question }) => {
                 step="any"
                 placeholder="numeric resolution"
                 className="max-w-xs bg-transparent"
-                min={open_lower_bound ? undefined : question.scaling.range_min!}
-                max={open_upper_bound ? undefined : question.scaling.range_max!}
+                min={
+                  open_lower_bound
+                    ? undefined
+                    : question?.scaling.range_min ?? undefined
+                }
+                max={
+                  open_upper_bound
+                    ? undefined
+                    : question?.scaling.range_max ?? undefined
+                }
                 {...register("resolutionValue")}
               />
             )}

--- a/front_end/src/app/(main)/questions/[id]/components/histogram_drawer.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/histogram_drawer.tsx
@@ -39,8 +39,9 @@ const HistogramDrawer: React.FC<Props> = ({ post }) => {
           y: value,
         })
       );
-    const median = question.aggregations.recency_weighted.latest.centers![0];
-    const mean = question.aggregations.recency_weighted.latest.means![0];
+    const median =
+      question?.aggregations?.recency_weighted?.latest?.centers?.[0];
+    const mean = question?.aggregations?.recency_weighted?.latest?.means?.[0];
 
     return (
       <div ref={chartContainerRef}>
@@ -72,8 +73,8 @@ const HistogramDrawer: React.FC<Props> = ({ post }) => {
       x: index,
       y: value,
     }));
-    const median_yes = latest_yes.centers![0];
-    const mean_yes = latest_yes.means![0];
+    const median_yes = latest_yes.centers?.[0];
+    const mean_yes = latest_yes.means?.[0];
 
     const latest_no =
       post.conditional.question_no.aggregations.recency_weighted.latest;
@@ -84,8 +85,8 @@ const HistogramDrawer: React.FC<Props> = ({ post }) => {
       x: index,
       y: value,
     }));
-    const median_no = latest_no.centers![0];
-    const mean_no = latest_no.means![0];
+    const median_no = latest_no.centers?.[0];
+    const mean_no = latest_no.means?.[0];
 
     if (!histogramData_yes && !histogramData_no) {
       return null;

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
@@ -253,7 +253,7 @@ const MultipleChoiceGroupChart: FC<Props> = ({
       isClosed={isClosed}
       actualCloseTime={actualCloseTime}
       openTime={openTime}
-      questionType={questions[0].type}
+      questionType={questions[0]?.type}
       scaling={scaling}
       title={t("forecastTimelineHeading")}
       yLabel={t("communityPredictionLabel")}
@@ -278,12 +278,13 @@ function getQuestionTooltipLabel({
 }: {
   timestamps: number[];
   values: (number | null)[];
-  cursorTimestamp: number;
+  cursorTimestamp: number | null;
   question?: Question;
   isUserPrediction?: boolean;
   closeTime?: number | undefined;
 }) {
   const hasValue =
+    !isNil(cursorTimestamp) &&
     cursorTimestamp >= Math.min(...timestamps) &&
     cursorTimestamp <= Math.max(...timestamps, closeTime ?? 0);
   if (!hasValue || !question) {

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/choices_tooltip.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/choices_tooltip.tsx
@@ -48,7 +48,7 @@ const ChoicesTooltip: FC<Props> = ({ date, choices, userChoices }) => {
             <td className="px-1.5 py-1 text-right text-sm">{valueElement}</td>
             {containUserChoices && (
               <td className="px-1.5 py-1 text-right text-sm">
-                {userChoices!.find((item) => item.choiceLabel === choiceLabel)
+                {userChoices?.find((item) => item.choiceLabel === choiceLabel)
                   ?.valueElement || "?"}
               </td>
             )}

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/similar_question_prediction_chip.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/similar_question_prediction_chip.tsx
@@ -7,7 +7,7 @@ import { getDisplayValue } from "@/utils/charts";
 import cn from "@/utils/cn";
 
 type Props = {
-  question: QuestionWithNumericForecasts;
+  question: QuestionWithNumericForecasts | null;
   isGroup?: boolean;
   className?: string;
 };
@@ -17,6 +17,10 @@ const SimilarPredictionChip: FC<Props> = ({
   isGroup = false,
   className,
 }) => {
+  if (!question) {
+    return null;
+  }
+
   if (
     ![QuestionType.Numeric, QuestionType.Date, QuestionType.Binary].includes(
       question.type
@@ -34,7 +38,7 @@ const SimilarPredictionChip: FC<Props> = ({
   if (isForecastEmpty) return null;
 
   const latest = question.aggregations.recency_weighted.latest;
-  const prediction = latest?.centers![0];
+  const prediction = latest?.centers?.[0];
 
   {
     return (

--- a/front_end/src/app/(main)/questions/components/conditional_form.tsx
+++ b/front_end/src/app/(main)/questions/components/conditional_form.tsx
@@ -118,7 +118,7 @@ const ConditionalForm: React.FC<{
       );
     }
 
-    let post_data: PostCreationData = {
+    const post_data: PostCreationData = {
       default_project: data["default_project"],
       conditional: {
         condition_id: parentId as number,
@@ -149,7 +149,9 @@ const ConditionalForm: React.FC<{
   const defaultProject = post
     ? post.projects.default_project
     : tournament_id
-      ? [...tournaments, siteMain].filter((x) => x.id === tournament_id)[0]
+      ? ([...tournaments, siteMain].filter(
+          (x) => x.id === tournament_id
+        )[0] as Tournament)
       : siteMain;
 
   return (
@@ -208,6 +210,8 @@ const ConditionalForm: React.FC<{
             <QuestionChartTile
               question={conditionParent}
               authorUsername={conditionParent.author_username}
+              // we expect status to be populated on BE for conditional questions
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               curationStatus={conditionParent.status!}
             />
           ) : (
@@ -234,6 +238,8 @@ const ConditionalForm: React.FC<{
             <QuestionChartTile
               question={conditionChild}
               authorUsername={conditionChild.author_username}
+              // we expect status to be populated on BE for conditional questions
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               curationStatus={conditionChild.status!}
             />
           ) : (
@@ -262,15 +268,11 @@ const ConditionalForm: React.FC<{
 };
 
 async function setConditionQuestion(
-  control: UseFormReturn<
-    {
-      condition_id: string | undefined;
-      condition_child_id: string | undefined;
-      default_project: number | null;
-    },
-    any,
-    undefined
-  >,
+  control: UseFormReturn<{
+    condition_id: string | undefined;
+    condition_child_id: string | undefined;
+    default_project: number | null;
+  }>,
   setQuestionState: (
     value: SetStateAction<QuestionWithForecasts | null>
   ) => void,
@@ -281,10 +283,10 @@ async function setConditionQuestion(
   try {
     let question: QuestionWithForecasts | null = null;
     if (parsedInput.questionId) {
-      question = await getQuestion(parsedInput.questionId!);
-    } else {
-      const post = await getPost(parsedInput.postId!);
-      question = post.question!;
+      question = await getQuestion(parsedInput.questionId);
+    } else if (parsedInput.postId) {
+      const post = await getPost(parsedInput.postId);
+      question = post.question ?? null;
     }
     if (
       question &&
@@ -302,7 +304,7 @@ async function setConditionQuestion(
       });
       setQuestionState(null);
     }
-  } catch (e) {
+  } catch {
     control.setError(fieldName, {
       type: "manual",
       message: "Invalid question ID/URL",

--- a/front_end/src/app/(main)/questions/components/group_form.tsx
+++ b/front_end/src/app/(main)/questions/components/group_form.tsx
@@ -74,8 +74,14 @@ const createGroupQuestionSchema = (t: ReturnType<typeof useTranslations>) => {
   });
 };
 
+type SupportedType =
+  | QuestionType.Binary
+  | QuestionType.Numeric
+  | QuestionType.MultipleChoice
+  | string;
+
 type Props = {
-  subtype: "binary" | "numeric" | "date";
+  subtype: SupportedType;
   tournament_id?: number;
   community_id?: number;
   post?: PostWithForecasts | null;
@@ -107,7 +113,9 @@ const GroupForm: React.FC<Props> = ({
   const defaultProject = post
     ? post.projects.default_project
     : tournament_id
-      ? [...tournaments, siteMain].filter((x) => x.id === tournament_id)[0]
+      ? ([...tournaments, siteMain].filter(
+          (x) => x.id === tournament_id
+        )[0] as Tournament)
       : siteMain;
 
   const submitQuestion = async (data: any) => {
@@ -183,13 +191,13 @@ const GroupForm: React.FC<Props> = ({
     }
     const questionToDelete: number[] = [];
     if (post?.group_of_questions?.questions) {
-      forEach(post?.group_of_questions.questions, (sq, index) => {
+      forEach(post?.group_of_questions.questions, (sq) => {
         if (!subQuestions.map((x) => x.id).includes(sq.id)) {
           questionToDelete.push(sq.id);
         }
       });
     }
-    let post_data: PostCreationData = {
+    const post_data: PostCreationData = {
       title: data["title"],
       url_title: data["url_title"],
       default_project: data["default_project"],
@@ -248,8 +256,8 @@ const GroupForm: React.FC<Props> = ({
   const [categoriesList, setCategoriesList] = useState<Category[]>(
     post?.projects.category ? post?.projects.category : ([] as Category[])
   );
-  const [collapsedSubQuestions, setCollapsedSubQuestions] = useState<any[]>(
-    subQuestions.map((x) => true)
+  const [collapsedSubQuestions, setCollapsedSubQuestions] = useState<boolean[]>(
+    subQuestions.map(() => true)
   );
   const groupQuestionSchema = createGroupQuestionSchema(t);
   const form = useForm({
@@ -592,13 +600,10 @@ const GroupForm: React.FC<Props> = ({
                     {(subtype === QuestionType.Date ||
                       subtype === QuestionType.Numeric) && (
                       <NumericQuestionInput
-                        // @ts-ignore
                         questionType={subtype}
                         defaultMin={subQuestion.scaling.range_min}
                         defaultMax={subQuestion.scaling.range_max}
-                        // @ts-ignore
                         defaultOpenLowerBound={subQuestion.open_lower_bound}
-                        // @ts-ignore
                         defaultOpenUpperBound={subQuestion.open_upper_bound}
                         defaultZeroPoint={subQuestion.scaling.zero_point}
                         hasForecasts={

--- a/front_end/src/app/(main)/questions/components/numeric_question_input.tsx
+++ b/front_end/src/app/(main)/questions/components/numeric_question_input.tsx
@@ -110,8 +110,8 @@ const NumericQuestionInput: React.FC<{
     },
     type: questionType,
     scaling: {
-      range_max: max!,
-      range_min: min!,
+      range_max: max as number,
+      range_min: min as number,
       zero_point: zeroPoint,
     },
     open_lower_bound: openLowerBound,
@@ -186,8 +186,8 @@ const NumericQuestionInput: React.FC<{
       open_upper_bound: openUpperBound,
       open_lower_bound: openLowerBound,
       scaling: {
-        range_max: max!,
-        range_min: min!,
+        range_max: max as number,
+        range_min: min as number,
         zero_point: zeroPoint,
       },
     }));

--- a/front_end/src/app/(main)/questions/components/question_form.tsx
+++ b/front_end/src/app/(main)/questions/components/question_form.tsx
@@ -24,6 +24,7 @@ import {
 import { InputContainer } from "@/components/ui/input_container";
 import LoadingIndicator from "@/components/ui/loading_indicator";
 import { MarkdownText } from "@/components/ui/markdown_text";
+import { ErrorResponse } from "@/types/fetch";
 import { Category, Post, PostStatus, PostWithForecasts } from "@/types/post";
 import {
   Tournament,
@@ -210,7 +211,9 @@ const QuestionForm: FC<Props> = ({
   const defaultProject = post
     ? post.projects.default_project
     : tournament_id
-      ? [...tournaments, siteMain].filter((x) => x.id === tournament_id)[0]
+      ? ([...tournaments, siteMain].filter(
+          (x) => x.id === tournament_id
+        )[0] as Tournament)
       : siteMain;
 
   if (isDone) {
@@ -255,7 +258,7 @@ const QuestionForm: FC<Props> = ({
         ? optionsList.map((option) => option.trim())
         : [];
 
-    let post_data: PostCreationData = {
+    const post_data: PostCreationData = {
       title: data["title"],
       url_title: data["url_title"],
       default_project: data["default_project"],
@@ -460,11 +463,9 @@ const QuestionForm: FC<Props> = ({
           questionType === QuestionType.Numeric) && (
           <NumericQuestionInput
             questionType={questionType}
-            defaultMin={post?.question?.scaling.range_min!}
-            defaultMax={post?.question?.scaling.range_max!}
-            // @ts-ignore
+            defaultMin={post?.question?.scaling.range_min ?? undefined}
+            defaultMax={post?.question?.scaling.range_max ?? undefined}
             defaultOpenLowerBound={post?.question?.open_lower_bound}
-            // @ts-ignore
             defaultOpenUpperBound={post?.question?.open_upper_bound}
             defaultZeroPoint={post?.question?.scaling.zero_point}
             hasForecasts={hasForecasts && mode !== "create"}
@@ -533,8 +534,11 @@ const QuestionForm: FC<Props> = ({
                             );
                           }}
                           errors={
-                            // @ts-ignore
-                            form.formState.errors.options?.[opt_index]
+                            (
+                              form.formState.errors.options as
+                                | ErrorResponse[]
+                                | undefined
+                            )?.[opt_index]
                           }
                         />
                       </div>

--- a/front_end/src/app/(main)/questions/components/topic_item.tsx
+++ b/front_end/src/app/(main)/questions/components/topic_item.tsx
@@ -16,6 +16,7 @@ const TopicItem: FC<Props> = ({ isActive, onClick, text, emoji, href }) => {
   return (
     <Button
       as={href ? Link : undefined}
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       href={href!}
       className={cn(
         "w-auto cursor-pointer snap-start rounded-full p-1.5 px-2 text-sm leading-4 no-underline sm:w-full sm:p-2 sm:px-2.5 sm:text-base sm:leading-5",

--- a/front_end/src/app/(main)/questions/create/group/page.tsx
+++ b/front_end/src/app/(main)/questions/create/group/page.tsx
@@ -1,3 +1,5 @@
+import { isNil } from "lodash";
+
 import CommunityHeader from "@/app/(main)/components/headers/community_header";
 import Header from "@/app/(main)/components/headers/header";
 import ProjectsApi from "@/services/projects";
@@ -31,29 +33,30 @@ const GroupQuestionCreator: React.FC<{ searchParams: SearchParams }> = async ({
     ? communitiesResponse.results[0]
     : undefined;
 
+  const groupType = post
+    ? post.group_of_questions?.questions[0]?.type
+    : (searchParams["subtype"] as string);
+
   return (
     <>
       {community ? <CommunityHeader community={community} /> : <Header />}
 
-      <GroupForm
-        // @ts-ignore
-        subtype={
-          post
-            ? post.group_of_questions?.questions[0]?.type
-            : searchParams["subtype"]
-        }
-        post={post}
-        mode={mode}
-        allCategories={allCategories}
-        tournament_id={
-          searchParams["tournament_id"]
-            ? Number(searchParams["tournament_id"])
-            : undefined
-        }
-        community_id={community?.id}
-        tournaments={allTournaments}
-        siteMain={siteMain}
-      />
+      {!isNil(groupType) && (
+        <GroupForm
+          subtype={groupType}
+          post={post}
+          mode={mode}
+          allCategories={allCategories}
+          tournament_id={
+            searchParams["tournament_id"]
+              ? Number(searchParams["tournament_id"])
+              : undefined
+          }
+          community_id={community?.id}
+          tournaments={allTournaments}
+          siteMain={siteMain}
+        />
+      )}
     </>
   );
 };

--- a/front_end/src/app/(thecurve)/components/curve_histogram/curve_histogram.tsx
+++ b/front_end/src/app/(thecurve)/components/curve_histogram/curve_histogram.tsx
@@ -75,7 +75,7 @@ const CurveHistogram: FC<Props> = ({
             grid: { stroke: "none" },
           }}
         />
-        {choiceOptions[0].forecast && (
+        {choiceOptions[0]?.forecast && (
           <VictoryScatter
             data={[{ y: 0, x: choiceOptions[0].forecast * 100 }]}
             dataComponent={<CustomPoint color="#ff7000" />}

--- a/front_end/src/app/(thecurve)/components/curve_histogram/curve_histogram_drawer.tsx
+++ b/front_end/src/app/(thecurve)/components/curve_histogram/curve_histogram_drawer.tsx
@@ -61,7 +61,7 @@ const CurveHistogramDrawer: FC<Props> = ({ postId, onNextQuestion }) => {
   if (
     post &&
     post.group_of_questions?.questions &&
-    post.group_of_questions.questions[0].type === QuestionType.Binary
+    post.group_of_questions.questions[0]?.type === QuestionType.Binary
   ) {
     const histogramQuestion = post.group_of_questions.questions[0];
     const histogramData =
@@ -72,7 +72,7 @@ const CurveHistogramDrawer: FC<Props> = ({ postId, onNextQuestion }) => {
         })
       );
     const median =
-      histogramQuestion.aggregations.recency_weighted.latest?.centers![0];
+      histogramQuestion.aggregations.recency_weighted.latest?.centers?.[0];
     const choiceOptions = generateCurveChoiceOptions(
       post.group_of_questions.questions
     );
@@ -104,7 +104,7 @@ const CurveHistogramDrawer: FC<Props> = ({ postId, onNextQuestion }) => {
             ref={nextBtnRef}
             className="!bg-blue-900 !px-5 !text-lg !text-gray-200"
             onClick={() => {
-              onNextQuestion && onNextQuestion();
+              onNextQuestion?.();
             }}
           >
             {t("nextQuestion")}

--- a/front_end/src/app/(thecurve)/components/forecast_maker/index.tsx
+++ b/front_end/src/app/(thecurve)/components/forecast_maker/index.tsx
@@ -68,6 +68,8 @@ const CurveForecastMaker: FC<Props> = ({
       post.id,
       questionsToSubmit.map((q) => {
         const forecastValue = round(
+          // okay to use no-non-null-assertion as forecast is checked in questionsToSubmit
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           q.forecast! / 100,
           BINARY_FORECAST_PRECISION
         );

--- a/front_end/src/app/providers.tsx
+++ b/front_end/src/app/providers.tsx
@@ -14,18 +14,20 @@ import { getAnalyticsCookieConsentGiven } from "@/app/(main)/components/cookies_
 
 export function CSPostHogProvider({ children }: { children: any }) {
   useEffect(() => {
-    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-      api_host: process.env.NEXT_PUBLIC_POSTHOG_BASE_URL,
-      ui_host: process.env.NEXT_PUBLIC_POSTHOG_BASE_URL,
-      // set to 'always' to create profiles for anonymous users as well
-      person_profiles: "identified_only",
-      // Disable automatic pageview capture, as we capture manually
-      capture_pageview: false,
-      persistence:
-        getAnalyticsCookieConsentGiven() === "yes"
-          ? "localStorage+cookie"
-          : "memory",
-    });
+    if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+      posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+        api_host: process.env.NEXT_PUBLIC_POSTHOG_BASE_URL,
+        ui_host: process.env.NEXT_PUBLIC_POSTHOG_BASE_URL,
+        // set to 'always' to create profiles for anonymous users as well
+        person_profiles: "identified_only",
+        // Disable automatic pageview capture, as we capture manually
+        capture_pageview: false,
+        persistence:
+          getAnalyticsCookieConsentGiven() === "yes"
+            ? "localStorage+cookie"
+            : "memory",
+      });
+    }
   }, []);
 
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>;

--- a/front_end/src/components/carousel.tsx
+++ b/front_end/src/components/carousel.tsx
@@ -52,12 +52,14 @@ const Carousel: FC<PropsWithChildren<Props>> = ({
   const goPrevious = () => {
     const element = forecastsRef.current;
     if (!element) return;
-    element.scrollLeft = element.scrollLeft - element.children[1].clientWidth;
+    element.scrollLeft =
+      element.scrollLeft - (element.children[1]?.clientWidth ?? 0);
   };
   const goNext = () => {
     const element = forecastsRef.current;
     if (!element) return;
-    element.scrollLeft = element.scrollLeft + element.children[1].clientWidth;
+    element.scrollLeft =
+      element.scrollLeft + (element.children[1]?.clientWidth ?? 0);
   };
 
   return (

--- a/front_end/src/components/charts/continuous_area_chart.tsx
+++ b/front_end/src/components/charts/continuous_area_chart.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { merge } from "lodash";
+import { isNil, merge } from "lodash";
 import React, { FC, useMemo } from "react";
 import {
   Tuple,
@@ -269,7 +269,7 @@ const ContinuousAreaChart: FC<Props> = ({
               }}
             />
           ))}
-          {resolutionPoint && (
+          {resolutionPoint && !isNil(resolutionPoint[0]) && (
             <VictoryScatter
               data={[
                 {
@@ -344,12 +344,12 @@ function generateNumericAreaGraph(data: {
     pmf.forEach((value, index) => {
       if (index === 0) {
         // add a point at the beginning to extend pmf to the edge
-        graph.push({ x: -1e-10, y: pmf[1] });
+        graph.push({ x: -1e-10, y: pmf[1] ?? null });
         return;
       }
       if (index === pmf.length - 1) {
         // add a point at the end to extend pmf to the edge
-        graph.push({ x: 1 + 1e-10, y: pmf[pmf.length - 2] });
+        graph.push({ x: 1 + 1e-10, y: pmf[pmf.length - 2] ?? null });
         return;
       }
       graph.push({ x: (index - 0.5) / (pmf.length - 2), y: value });

--- a/front_end/src/components/charts/primitives/chart_container.tsx
+++ b/front_end/src/components/charts/primitives/chart_container.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Tab, TabGroup, TabList } from "@headlessui/react";
+import { isNil } from "lodash";
 import { forwardRef, Fragment, PropsWithChildren, useState } from "react";
 
 import { TimelineChartZoomOption } from "@/types/charts";
@@ -21,7 +22,10 @@ const ChartContainer = forwardRef<HTMLDivElement, PropsWithChildren<Props>>(
 
     const handleTabChange = (index: number) => {
       setSelectedIndex(index);
-      onZoomChange?.(tabOptions[index].value as TimelineChartZoomOption);
+      const tabOption = tabOptions[index];
+      if (onZoomChange && !isNil(tabOption)) {
+        onZoomChange(tabOption.value);
+      }
     };
 
     return (

--- a/front_end/src/components/charts/primitives/chart_fan_tooltip.tsx
+++ b/front_end/src/components/charts/primitives/chart_fan_tooltip.tsx
@@ -37,13 +37,13 @@ const ChartFanTooltip: FC<Props> = ({
     return null;
   }
 
-  const quartiles = items[option].quartiles;
-  const question = items[option].question;
-  const resolved = !!question.resolution;
+  const quartiles = items[option]?.quartiles;
+  const question = items[option]?.question;
+  const resolved = !!question?.resolution;
 
   const padding = 10;
   const position = y + padding + HEIGHT > chartHeight ? "top" : "bottom";
-  if (!quartiles) {
+  if (!quartiles || !question) {
     return null;
   }
 

--- a/front_end/src/components/choice_icon.tsx
+++ b/front_end/src/components/choice_icon.tsx
@@ -1,16 +1,20 @@
 "use client";
 import { FC } from "react";
 
+import { METAC_COLORS } from "@/constants/colors";
 import useAppTheme from "@/hooks/use_app_theme";
 import { ThemeColor } from "@/types/theme";
 import cn from "@/utils/cn";
 
 type Props = {
-  color: ThemeColor;
+  color?: ThemeColor;
   className?: string;
 };
 
-const ChoiceIcon: FC<Props> = ({ color, className }) => {
+const ChoiceIcon: FC<Props> = ({
+  color = METAC_COLORS["mc-option"]["1"],
+  className,
+}) => {
   const { getThemeColor } = useAppTheme();
 
   return (

--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -472,10 +472,15 @@ const Comment: FC<CommentProps> = ({
           <>
             <Button
               onClick={async () => {
+                if (!user) {
+                  // usually, don't expect this, as action is available only for logged-in users
+                  return;
+                }
+
                 const response = await editComment({
                   id: comment.id,
                   text: commentMarkdown,
-                  author: user!.id,
+                  author: user.id,
                 });
                 if (response && "errors" in response) {
                   console.error(t("errorDeletingComment"), response.errors);

--- a/front_end/src/components/comment_feed/comment_cmm.tsx
+++ b/front_end/src/components/comment_feed/comment_cmm.tsx
@@ -17,13 +17,13 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { sendGAEvent } from "@next/third-parties/google";
+import { isNil } from "lodash";
 import { useTranslations } from "next-intl";
 import React, { useState, forwardRef, FC } from "react";
 
 import ForecastTextInput from "@/app/(main)/questions/[id]/components/forecast_maker/forecast_text_input";
 import { toggleCMMComment } from "@/app/(main)/questions/actions";
 import Button from "@/components/ui/button";
-import { FormErrorMessage } from "@/components/ui/form_field";
 import cn from "@/utils/cn";
 import { logError } from "@/utils/errors";
 
@@ -76,7 +76,15 @@ const CmmMakeForecast: FC<{
     });
   };
 
-  const onUpdateVal = (step: number) => {
+  const onUpdateVal = (step: number | undefined) => {
+    if (isNil(step)) {
+      logError(
+        new Error("Step is undefined"),
+        "Error updating comment forecast"
+      );
+      return;
+    }
+
     let newPred = clampPrediction(forecast + step);
     newPred = Math.floor(10 * newPred) / 10;
     setValue(predictionToInputVal(newPred));
@@ -90,7 +98,7 @@ const CmmMakeForecast: FC<{
           size="xs"
           className="py-1"
           onClick={() => {
-            onUpdateVal(-stepBig);
+            onUpdateVal(!isNil(stepBig) ? -stepBig : undefined);
           }}
         >
           <FontAwesomeIcon icon={faChevronLeft} size="sm" />
@@ -101,7 +109,7 @@ const CmmMakeForecast: FC<{
           size="xs"
           className="py-1"
           onClick={() => {
-            onUpdateVal(-stepSmall);
+            onUpdateVal(!isNil(stepSmall) ? -stepSmall : undefined);
           }}
         >
           <FontAwesomeIcon icon={faChevronLeft} size="sm" />
@@ -243,7 +251,7 @@ const CmmOverlay = ({
   cmmContext,
 }: CmmOverlayProps) => {
   const t = useTranslations();
-  const { floatingStyles, context } = useFloating({
+  const { floatingStyles } = useFloating({
     placement: "bottom-start",
     middleware: [
       offset(10), // Adjust offset as needed
@@ -293,14 +301,10 @@ const CmmToggleButton = forwardRef<HTMLButtonElement, CmmToggleButtonProps>(
   ({ comment_id, disabled, cmmContext }, ref) => {
     const t = useTranslations();
     const [isLoading, setIsLoading] = useState(false);
-    const [error, setError] = useState<
-      (Error & { digest?: string }) | undefined
-    >();
 
     const onChangedMyMind = async () => {
       try {
         setIsLoading(true);
-        setError(undefined);
         await toggleCMMComment({
           id: comment_id,
           enabled: !cmmContext.cmmEnabled,
@@ -309,8 +313,6 @@ const CmmToggleButton = forwardRef<HTMLButtonElement, CmmToggleButtonProps>(
         sendGAEvent("event", "commentChangedMind");
       } catch (e) {
         logError(e);
-        const error = e as Error & { digest?: string };
-        setError(error);
         cmmContext.onCMMToggled(cmmContext.cmmEnabled);
       } finally {
         setIsLoading(false);

--- a/front_end/src/components/comment_feed/index.tsx
+++ b/front_end/src/components/comment_feed/index.tsx
@@ -67,11 +67,15 @@ function parseCommentsArray(
 
   beComments.forEach((comment) => {
     if (comment.parent_id === null) {
-      rootComments.push(commentMap.get(comment.id)!);
+      const commentData = commentMap.get(comment.id);
+      if (commentData) {
+        rootComments.push(commentData);
+      }
     } else {
       const parentComment = commentMap.get(comment.parent_id);
-      if (parentComment) {
-        parentComment.children.push(commentMap.get(comment.id)!);
+      const childComment = commentMap.get(comment.id);
+      if (parentComment && childComment) {
+        parentComment.children.push(childComment);
       }
     }
   });
@@ -261,7 +265,7 @@ const CommentFeed: FC<Props> = ({
 
   // Handling filters change
   useEffect(() => {
-    let finalFilters = {
+    const finalFilters = {
       ...feedFilters,
       offset,
     };

--- a/front_end/src/components/communities_feed/index.tsx
+++ b/front_end/src/components/communities_feed/index.tsx
@@ -14,19 +14,20 @@ const AwaitedCommunitiesFeed: FC = async () => {
       limit: POSTS_PER_PAGE,
       is_subscribed: false,
     }),
-  ];
-
-  if (user) {
-    requests.push(
-      ProjectsApi.getCommunities({
-        is_subscribed: true,
-      })
-    );
-  }
+    ...(user
+      ? [
+          ProjectsApi.getCommunities({
+            is_subscribed: true,
+          }),
+        ]
+      : []),
+  ] as const;
 
   const [{ results: initialCommunities }, followedCommunitiesResponse] =
     await Promise.all(requests);
-  const followedCommunities = user ? followedCommunitiesResponse.results : [];
+  const followedCommunities = user
+    ? followedCommunitiesResponse?.results ?? []
+    : [];
   return (
     <PaginatedCommunitiesFeed
       followedCommunities={user ? followedCommunities : []}

--- a/front_end/src/components/conditional_tile/conditional_chart.tsx
+++ b/front_end/src/components/conditional_tile/conditional_chart.tsx
@@ -59,7 +59,7 @@ const ConditionalChart: FC<Props> = ({
     case QuestionType.Binary: {
       const pctCandidate =
         aggregateLatest && !aggregateLatest.end_time
-          ? aggregateLatest.centers![0]
+          ? aggregateLatest.centers?.[0]
           : undefined;
       const pct = pctCandidate ? Math.round(pctCandidate * 100) : null;
       const userForecast =
@@ -120,7 +120,7 @@ const ConditionalChart: FC<Props> = ({
 
       const prediction =
         aggregateLatest && !aggregateLatest.end_time
-          ? aggregateLatest.centers![0]
+          ? aggregateLatest.centers?.[0]
           : undefined;
       const formattedPrediction = prediction
         ? getDisplayValue({
@@ -148,8 +148,8 @@ const ConditionalChart: FC<Props> = ({
           ? getNumericForecastDataset(
               prevForecastValue.forecast,
               prevForecastValue.weights,
-              question.open_lower_bound!,
-              question.open_upper_bound!
+              question.open_lower_bound,
+              question.open_upper_bound
             )
           : null;
 

--- a/front_end/src/components/markdown_editor/embedded_math_jax/helpers.ts
+++ b/front_end/src/components/markdown_editor/embedded_math_jax/helpers.ts
@@ -23,7 +23,8 @@ export const transformMathJax = (markdown: string): string => {
   // Restore the links
   markdown = markdown.replace(
     /__LINK_PLACEHOLDER_(\d+)__/g,
-    (_match, index) => links[index]
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    (_match, index) => links[index]!
   );
 
   return markdown;

--- a/front_end/src/components/markdown_editor/embedded_question/embed_question_modal.tsx
+++ b/front_end/src/components/markdown_editor/embedded_question/embed_question_modal.tsx
@@ -120,7 +120,7 @@ const PredictionInfo: FC<{ question: QuestionWithNumericForecasts }> = ({
   question,
 }) => {
   const latest = question.aggregations.recency_weighted.latest;
-  const prediction = latest?.centers![0];
+  const prediction = latest?.centers?.[0];
 
   return (
     <div className="flex flex-row gap-2">

--- a/front_end/src/components/multiple_choice_tile/choice_option.tsx
+++ b/front_end/src/components/multiple_choice_tile/choice_option.tsx
@@ -55,7 +55,7 @@ const ChoiceOption: FC<Props> = ({
       {isNil(resolution) ? (
         <div className="resize-label py-0.5 pr-1.5 text-right text-sm font-bold leading-4 text-gray-900 dark:text-gray-900-dark">
           {getChoiceOptionValue(
-            values[values.length - 1],
+            values[values.length - 1] ?? null,
             questionType,
             scaling
           )}

--- a/front_end/src/components/onboarding/onboarding_modal.tsx
+++ b/front_end/src/components/onboarding/onboarding_modal.tsx
@@ -57,6 +57,8 @@ const OnboardingModal: React.FC<OnboardingModalProps> = ({
   useEffect(() => {
     if (isOpen && selectedTopicId !== null && !posts.length) {
       const topicObject = ONBOARDING_TOPICS[selectedTopicId];
+      if (!topicObject) return;
+
       setIsLoading(true);
       setTopic(topicObject);
 
@@ -141,22 +143,20 @@ const OnboardingModal: React.FC<OnboardingModalProps> = ({
     >
       {isLoading ? (
         <OnboardingLoading />
-      ) : (
-        <>
-          <StepsRouter
-            topic={topic!}
-            onNext={onNext}
-            onPrev={onPrev}
-            onComplete={handleCompleteTutorial}
-            setTopic={setTopicId}
-            onboardingState={onboardingState}
-            setOnboardingState={setOnboardingState}
-            posts={posts}
-            handleComplete={handleCompleteTutorial}
-            handlePostpone={handlePostponeTutorial}
-          />
-        </>
-      )}
+      ) : !!topic ? (
+        <StepsRouter
+          topic={topic}
+          onNext={onNext}
+          onPrev={onPrev}
+          onComplete={handleCompleteTutorial}
+          setTopic={setTopicId}
+          onboardingState={onboardingState}
+          setOnboardingState={setOnboardingState}
+          posts={posts}
+          handleComplete={handleCompleteTutorial}
+          handlePostpone={handlePostponeTutorial}
+        />
+      ) : null}
     </BaseModal>
   );
 };

--- a/front_end/src/components/onboarding/steps/index.tsx
+++ b/front_end/src/components/onboarding/steps/index.tsx
@@ -1,6 +1,7 @@
 import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { sendGAEvent } from "@next/third-parties/google";
+import { isNil } from "lodash";
 import { useTranslations } from "next-intl";
 import React, { useMemo } from "react";
 
@@ -38,7 +39,7 @@ const StepsRouter: React.FC<OnboardingStep> = (props) => {
           <FontAwesomeIcon icon={faArrowLeft} />
         </button>
       )}
-      <CurrentStep {...props} />
+      {!isNil(CurrentStep) && <CurrentStep {...props} />}
       {currentStep < STEPS.length - 1 && (
         <>
           <div className="mt-4 flex w-full justify-center gap-3">

--- a/front_end/src/components/onboarding/steps/step_1.tsx
+++ b/front_end/src/components/onboarding/steps/step_1.tsx
@@ -26,7 +26,7 @@ const Step1: React.FC<OnboardingStep> = ({
   const post = posts.find((obj) => obj.id === topic.questions[0]);
 
   // Should not be the case
-  if (!post) return;
+  if (!post) return null;
 
   const communityForecast = extractCommunityForecast(post);
 

--- a/front_end/src/components/onboarding/steps/step_2.tsx
+++ b/front_end/src/components/onboarding/steps/step_2.tsx
@@ -15,9 +15,12 @@ const Step2: React.FC<OnboardingStep> = ({
   onboardingState: { step3Prediction },
   setOnboardingState,
 }) => {
-  // Find related post for Step
-  const post = posts.find((obj) => obj.id === topic.questions[1])!;
   const t = useTranslations();
+
+  // Find related post for Step
+  const post = posts.find((obj) => obj.id === topic.questions[1]);
+  // Should not be the case
+  if (!post) return null;
   const communityForecast = extractCommunityForecast(post);
 
   const handleSubmit = () => {

--- a/front_end/src/components/onboarding/steps/step_3.tsx
+++ b/front_end/src/components/onboarding/steps/step_3.tsx
@@ -15,9 +15,12 @@ const Step3: React.FC<OnboardingStep> = ({
   onboardingState: { step3Prediction },
   setOnboardingState,
 }) => {
-  // Find related post for Step
-  const post = posts.find((obj) => obj.id === topic.questions[1])!;
   const t = useTranslations();
+
+  // Find related post for Step
+  const post = posts.find((obj) => obj.id === topic.questions[1]);
+  // Should not be the case
+  if (!post) return null;
   const communityForecast = extractCommunityForecast(post);
 
   const handleSubmit = async () => {

--- a/front_end/src/components/post_card/group_of_questions_tile/group_continuous_tile.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/group_continuous_tile.tsx
@@ -37,7 +37,7 @@ const GroupContinuousTile: FC<Props> = ({ questions, post, hideCP }) => {
   const { user } = useAuth();
   const locale = useLocale();
 
-  const questionType = questions[0].type;
+  const questionType = questions[0]?.type;
   const isBinaryGroup = questionType === QuestionType.Binary;
   const scaling = useMemo(
     () => (isBinaryGroup ? undefined : getContinuousGroupScaling(questions)),
@@ -69,7 +69,7 @@ const GroupContinuousTile: FC<Props> = ({ questions, post, hideCP }) => {
           choices={choices}
           visibleChoicesCount={VISIBLE_CHOICES_COUNT}
           questions={questions}
-          questionType={questions[0].type}
+          questionType={questions[0]?.type}
           hideCP={hideCP}
           forecastAvailability={forecastAvailability}
           chartHeight={CHART_HEIGHT}

--- a/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
@@ -35,7 +35,7 @@ const QuestionNumericTile: FC<Props> = ({
   forecastAvailability,
 }) => {
   const latest = question.aggregations.recency_weighted.latest;
-  const prediction = latest?.centers![0];
+  const prediction = latest?.centers?.[0];
 
   const continuousAreaChartData = [];
   if (latest && !latest.end_time) {

--- a/front_end/src/components/post_status/status_icon.tsx
+++ b/front_end/src/components/post_status/status_icon.tsx
@@ -53,14 +53,14 @@ const PostStatusIcon: FC<Props> = ({
     const nodes = svgRef.current.children;
 
     const shadedPath = nodes[0];
-    shadedPath.setAttribute("d", pathD);
+    shadedPath?.setAttribute("d", pathD);
 
     const outerCircle = nodes[1];
-    outerCircle.setAttribute("r", CLOCK_RADIUS.toString());
+    outerCircle?.setAttribute("r", CLOCK_RADIUS.toString());
 
     const radius = nodes[2];
-    radius.setAttribute("x2", x.toString());
-    radius.setAttribute("y2", y.toString());
+    radius?.setAttribute("x2", x.toString());
+    radius?.setAttribute("y2", y.toString());
   }, [scheduled_close_time, published_at, showClock]);
 
   const renderIcon = () => {

--- a/front_end/src/components/post_subscribe/post_subscribe_customise_modal.tsx
+++ b/front_end/src/components/post_subscribe/post_subscribe_customise_modal.tsx
@@ -247,32 +247,34 @@ const PostSubscribeCustomizeModal: FC<Props> = ({
           </div>
         )}
         <div className="mt-8 flex flex-col gap-4 pb-16">
-          {subscriptionTypes.map(({ type, title, render }, idx) => (
-            <section key={`subscription-${type}`}>
-              <div className="flex items-center gap-4">
-                <Switch
-                  checked={checkSubscriptionEnabled(type)}
-                  onChange={(checked) =>
-                    handleSwitchSubscription(checked, type)
-                  }
-                />
-                <h4 className="m-0">{title}</h4>
-              </div>
-              {checkSubscriptionEnabled(type) && (
-                <>
-                  <div>
-                    {render &&
-                      render(
-                        modalSubscriptions.find((sub) => sub.type === type)!
-                      )}
-                  </div>
-                  {render && idx < subscriptionTypes.length - 1 && (
-                    <hr className="mb-4 mt-8 border-gray-400 dark:border-gray-400-dark" />
-                  )}
-                </>
-              )}
-            </section>
-          ))}
+          {subscriptionTypes.map(({ type, title, render }, idx) => {
+            const enabled = checkSubscriptionEnabled(type);
+            const subscription = modalSubscriptions.find(
+              (sub) => sub.type === type
+            );
+
+            return (
+              <section key={`subscription-${type}`}>
+                <div className="flex items-center gap-4">
+                  <Switch
+                    checked={checkSubscriptionEnabled(type)}
+                    onChange={(checked) =>
+                      handleSwitchSubscription(checked, type)
+                    }
+                  />
+                  <h4 className="m-0">{title}</h4>
+                </div>
+                {enabled && !!subscription && (
+                  <>
+                    <div>{!!render && render(subscription)}</div>
+                    {!!render && idx < subscriptionTypes.length - 1 && (
+                      <hr className="mb-4 mt-8 border-gray-400 dark:border-gray-400-dark" />
+                    )}
+                  </>
+                )}
+              </section>
+            );
+          })}
         </div>
         <div className="flex w-full justify-end">
           <div className="flex w-fit gap-2">

--- a/front_end/src/components/server_component_error_boundary.tsx
+++ b/front_end/src/components/server_component_error_boundary.tsx
@@ -4,7 +4,7 @@ import { logError } from "@/utils/errors";
 
 import RefreshButton from "./refresh_button";
 
-const WithServerComponentErrorBoundary = <P extends {}>(
+const WithServerComponentErrorBoundary = <P extends Record<string, any>>(
   Component: FC<P>
 ): FC<P> => {
   const WrappedComponent = async (props: P) => {

--- a/front_end/src/components/sliders/multi_slider.tsx
+++ b/front_end/src/components/sliders/multi_slider.tsx
@@ -122,7 +122,11 @@ const MultiSlider: FC<Props> = ({
         return (
           <SliderThumb
             {...origin.props}
-            value={controlledValue[props.index]} // Pass the correct value
+            value={
+              // Pass the correct value
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              controlledValue[props.index]!
+            }
             active={props.index === 1}
             onClickIn={() => {
               handlePressIn(props.index);

--- a/front_end/src/components/sliders/slider.tsx
+++ b/front_end/src/components/sliders/slider.tsx
@@ -116,7 +116,9 @@ function dynamicRound(
   const split = stepString.split(".");
   let decimalPlaces = 0;
   if (split.length > 1) {
-    decimalPlaces = split[1].length;
+    // okay to do no-non-null-assertion because we know split.length > 1
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    decimalPlaces = split[1]!.length;
   }
   const multiplier = Math.pow(10, decimalPlaces);
   return clamp(Math.round(num * multiplier) / multiplier, inputMin, inputMax);

--- a/front_end/src/components/ui/chip.tsx
+++ b/front_end/src/components/ui/chip.tsx
@@ -62,6 +62,7 @@ const Chip: FC<PropsWithChildren<Props>> = ({
     >
       <Button
         as={href ? Link : undefined}
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         href={href!}
         onClick={onClick}
         className={cn(

--- a/front_end/src/components/visibility_observer.tsx
+++ b/front_end/src/components/visibility_observer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, ReactNode, PropsWithChildren } from "react";
+import React, { useEffect, useRef, PropsWithChildren } from "react";
 
 type VisibilityObserverProps = {
   onVisibilityChange: (isVisible: boolean) => void;
@@ -12,7 +12,7 @@ const VisibilityObserver: React.FC<
   useEffect(() => {
     const observer = new IntersectionObserver(
       ([entry]) => {
-        onVisibilityChange(entry.isIntersecting);
+        onVisibilityChange(entry?.isIntersecting ?? false);
       },
       { threshold: 0.1 } // Adjust threshold as needed
     );

--- a/front_end/src/contexts/global_search_context.tsx
+++ b/front_end/src/contexts/global_search_context.tsx
@@ -26,9 +26,7 @@ const GlobalSearchContext = createContext<GlobalSearchContextProps>({
   setModifySearchParams: (b: boolean) => {},
 });
 
-export const GlobalSearchProvider: FC<PropsWithChildren<{}>> = ({
-  children,
-}) => {
+export const GlobalSearchProvider: FC<PropsWithChildren> = ({ children }) => {
   const [isVisible, setIsVisible] = useState(false);
   const [modifySearchParams, setModifySearchParams] = useState(false);
   const [globalSearch, setGlobalSearch] = useSearchInputState(

--- a/front_end/src/hooks/use_section_headings.ts
+++ b/front_end/src/hooks/use_section_headings.ts
@@ -1,3 +1,4 @@
+import { isNil } from "lodash";
 import { useEffect, useState } from "react";
 
 const useSectionHeadings = (sectionId: string) => {
@@ -20,7 +21,8 @@ const useSectionHeadings = (sectionId: string) => {
         const id = generateSlug(heading.textContent ?? "");
         headingCountMap[id] = (headingCountMap[id] || 0) + 1;
 
-        if (headingCountMap[id] > 1) {
+        const headingCount = headingCountMap[id];
+        if (!isNil(headingCount) && headingCount > 1) {
           heading.id = `${id}-${headingCountMap[id]}`;
         } else {
           heading.id = id;

--- a/front_end/src/hooks/use_timestamp_cursor.ts
+++ b/front_end/src/hooks/use_timestamp_cursor.ts
@@ -4,7 +4,7 @@ import { TickFormat } from "@/types/charts";
 
 const useTimestampCursor = (timestamps: number[]) => {
   const [cursorTimestamp, setCursorTimestamp] = useState(
-    timestamps[timestamps.length - 1]
+    timestamps.at(-1) ?? null
   );
   const [tooltipDate, setTooltipDate] = useState("");
 

--- a/front_end/src/services/posthog.ts
+++ b/front_end/src/services/posthog.ts
@@ -1,6 +1,7 @@
 import { PostHog } from "posthog-node";
 
 export default function PostHogClient() {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
     host: process.env.NEXT_PUBLIC_POSTHOG_BASE_URL,
     flushAt: 1,

--- a/front_end/src/types/comment.ts
+++ b/front_end/src/types/comment.ts
@@ -47,7 +47,7 @@ export type ForecastType = {
   probability_yes_per_category: number[];
   options: string[];
   continuous_cdf: number[];
-  quartiles: number[];
+  quartiles: [number, number, number];
   question_type: QuestionType;
 };
 

--- a/front_end/src/types/question.ts
+++ b/front_end/src/types/question.ts
@@ -221,6 +221,7 @@ export type QuestionWithNumericForecasts = Question & {
 export type QuestionWithMultipleChoiceForecasts = Question & {
   type: QuestionType.MultipleChoice;
   forecasts: MultipleChoiceForecast;
+  options: string[];
 };
 
 export type QuestionWithForecasts =

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -32,6 +32,7 @@ import {
   Aggregations,
   QuestionWithForecasts,
   AggregateForecastHistory,
+  Bounds,
 } from "@/types/question";
 import { computeQuartilesFromCDF } from "@/utils/math";
 import { abbreviatedNumber } from "@/utils/number_formatters";
@@ -67,7 +68,7 @@ export function generateNumericDomain(
   if (latestTimestamp === undefined) {
     return [0, 0];
   }
-  const latestDate = fromUnixTime(latestTimestamp!);
+  const latestDate = fromUnixTime(latestTimestamp);
   let startDate: Date;
   switch (zoom) {
     case TimelineChartZoomOption.OneDay:
@@ -192,17 +193,21 @@ export function generateTimestampXScale(
  * scaling determined by zero_point
  */
 export function scaleInternalLocation(x: number, scaling: Scaling) {
-  let scaled_location = null;
   const { range_min, range_max, zero_point } = scaling;
+  if (isNil(range_max) || isNil(range_min)) {
+    return x;
+  }
+
+  let scaled_location: number;
   if (zero_point !== null) {
-    const derivRatio = (range_max! - zero_point) / (range_min! - zero_point);
+    const derivRatio = (range_max - zero_point) / (range_min - zero_point);
     scaled_location =
-      range_min! +
-      ((range_max! - range_min!) * (derivRatio ** x - 1)) / (derivRatio - 1);
+      range_min +
+      ((range_max - range_min) * (derivRatio ** x - 1)) / (derivRatio - 1);
   } else if (range_min === null || range_max === null) {
     scaled_location = x;
   } else {
-    scaled_location = range_min! + (range_max! - range_min!) * x;
+    scaled_location = range_min + (range_max - range_min) * x;
   }
   return scaled_location;
 }
@@ -213,16 +218,20 @@ export function scaleInternalLocation(x: number, scaling: Scaling) {
  * taking into account any logarithmic scaling determined by zero_point
  */
 export function unscaleNominalLocation(x: number, scaling: Scaling) {
-  let unscaled_location = null;
   const { range_min, range_max, zero_point } = scaling;
+  if (isNil(range_max) || isNil(range_min)) {
+    return x;
+  }
+
+  let unscaled_location: number;
   if (zero_point !== null) {
-    const derivRatio = (range_max! - zero_point) / (range_min! - zero_point);
+    const derivRatio = (range_max - zero_point) / (range_min - zero_point);
     unscaled_location =
       Math.log(
-        ((x - range_min!) * (derivRatio - 1)) / (range_max! - range_min!) + 1
+        ((x - range_min) * (derivRatio - 1)) / (range_max - range_min) + 1
       ) / Math.log(derivRatio);
   } else {
-    unscaled_location = (x - range_min!) / (range_max! - range_min!);
+    unscaled_location = (x - range_min) / (range_max - range_min);
   }
   return unscaled_location;
 }
@@ -298,14 +307,20 @@ export function getDisplayValue({
     truncation
   );
   if (range) {
-    const scaledLower = scaleInternalLocation(range[0], scaling);
+    const lowerX = range[0];
+    const upperX = range[1];
+    if (isNil(lowerX) || isNil(upperX)) {
+      return "...";
+    }
+
+    const scaledLower = scaleInternalLocation(lowerX, scaling);
     const lowerDisplay = displayValue(
       scaledLower,
       questionType,
       precision,
       truncation
     );
-    const scaledUpper = scaleInternalLocation(range[1], scaling);
+    const scaledUpper = scaleInternalLocation(upperX, scaling);
     const upperDisplay = displayValue(
       scaledUpper,
       questionType,
@@ -372,20 +387,24 @@ export function getUserPredictionDisplayValue(
     return "...";
   }
 
-  let center: number;
+  let center: number | undefined;
   let lower: number | undefined = undefined;
   let upper: number | undefined = undefined;
   if (questionType === QuestionType.Binary) {
     center = closestUserForecast.forecast_values[1];
   } else {
-    center = closestUserForecast.centers![0];
+    center = closestUserForecast.centers?.[0];
     lower = showRange
-      ? closestUserForecast.interval_lower_bounds![0]
+      ? closestUserForecast.interval_lower_bounds?.[0]
       : undefined;
     upper = showRange
-      ? closestUserForecast.interval_upper_bounds![0]
+      ? closestUserForecast.interval_upper_bounds?.[0]
       : undefined;
   }
+  if (isNil(center)) {
+    return "...";
+  }
+
   const scaledCenter = scaleInternalLocation(
     center,
     scaling ?? { range_min: 0, range_max: 1, zero_point: null }
@@ -473,11 +492,9 @@ export function generateScale({
   scaling = null,
   displayLabel = "",
   withCursorFormat = false,
-  cursorDisplayLabel = null,
 }: GenerateScaleParams): Scale {
   const domainMin = domain[0];
   const domainMax = domain[1];
-  const domainSize = domainMax - domainMin;
   const domainScaling = {
     range_min: domainMin,
     range_max: domainMax,
@@ -486,7 +503,6 @@ export function generateScale({
 
   const rangeMin = scaling?.range_min ?? domainMin;
   const rangeMax = scaling?.range_max ?? domainMax;
-  const rangeSize = rangeMax - rangeMin;
   const zeroPoint = scaling?.zero_point ?? null;
   const rangeScaling = {
     range_min: rangeMin,
@@ -512,7 +528,7 @@ export function generateScale({
   } else {
     maxLabelCount = direction === "horizontal" ? 21 : 26;
   }
-  const tickCount = (maxLabelCount! - 1) * 5 + 1;
+  const tickCount = (maxLabelCount - 1) * 5 + 1;
 
   // console.log({
   //   displayType,
@@ -601,7 +617,7 @@ export function generateChoiceItemsFromMultipleChoiceForecast(
 
   const latest = question.aggregations.recency_weighted.latest;
 
-  const choiceOrdering: number[] = question.options!.map((_, i) => i);
+  const choiceOrdering: number[] = question.options?.map((_, i) => i) ?? [];
   if (!preserveOrder) {
     choiceOrdering.sort((a, b) => {
       const aCenter = latest?.forecast_values[a] ?? 0;
@@ -657,17 +673,17 @@ export function generateChoiceItemsFromMultipleChoiceForecast(
       });
       aggregationValues.push(
         !!aggregationForecast?.centers
-          ? aggregationForecast.centers[index]
+          ? aggregationForecast.centers[index] ?? null
           : null
       );
       aggregationMinValues.push(
         !!aggregationForecast?.interval_lower_bounds
-          ? aggregationForecast.interval_lower_bounds[index]
+          ? aggregationForecast.interval_lower_bounds[index] ?? null
           : null
       );
       aggregationMaxValues.push(
         !!aggregationForecast?.interval_upper_bounds
-          ? aggregationForecast.interval_upper_bounds[index]
+          ? aggregationForecast.interval_upper_bounds[index] ?? null
           : null
       );
       aggregationForecasterCounts.push(
@@ -699,19 +715,24 @@ export function generateChoiceItemsFromMultipleChoiceForecast(
   const orderedChoiceItems = choiceOrdering.map((order) => choiceItems[order]);
   // move resolved choice to the front
   const resolutionIndex = choiceOrdering.findIndex(
-    (order) => question.options![order] === question.resolution
+    (order) => question.options?.[order] === question.resolution
   );
   if (resolutionIndex !== -1) {
     const [resolutionItem] = orderedChoiceItems.splice(resolutionIndex, 1);
-    orderedChoiceItems.unshift(resolutionItem);
+    if (resolutionItem) {
+      orderedChoiceItems.unshift(resolutionItem);
+    }
   }
   // set inactive items
   if (activeCount) {
     orderedChoiceItems.forEach((item, index) => {
-      item.active = index < activeCount;
+      if (!isNil(item)) {
+        item.active = index < activeCount;
+      }
     });
   }
-  return orderedChoiceItems;
+
+  return orderedChoiceItems.filter((el) => !isNil(el)) as ChoiceItem[];
 }
 
 export function generateChoiceItemsFromAggregations(
@@ -758,12 +779,12 @@ export function generateChoiceItemsFromAggregations(
           (forecast.end_time === null || forecast.end_time > timestamp)
         );
       });
-      aggregationValues.push(aggregationForecast?.centers![0] || null);
+      aggregationValues.push(aggregationForecast?.centers?.[0] || null);
       aggregationMinValues.push(
-        aggregationForecast?.interval_lower_bounds![0] || null
+        aggregationForecast?.interval_lower_bounds?.[0] || null
       );
       aggregationMaxValues.push(
-        aggregationForecast?.interval_upper_bounds![0] || null
+        aggregationForecast?.interval_upper_bounds?.[0] || null
       );
       aggregationForecasterCounts.push(
         aggregationForecast?.forecaster_count || 0
@@ -836,7 +857,10 @@ export function generateChoiceItemsFromGroupQuestions(
     : undefined;
 
   const choiceItems: ChoiceItem[] = choiceOrdering.map((order, index) => {
-    const question = questions[order];
+    // that's okay to do no-non-null-assertion, as choiceOrdering is generated based on questions array
+    // so we don't expect that it will have a different length
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const question = questions[order]!;
     const label = question.label;
     const userHistory = question.my_forecasts?.history;
 
@@ -897,9 +921,9 @@ export function generateChoiceItemsFromGroupQuestions(
         userValues.push(userForecast?.forecast_values[1] || null);
       } else {
         // continuous
-        userValues.push(userForecast?.centers![0] || null);
-        userMinValues.push(userForecast?.interval_lower_bounds![0] || null);
-        userMaxValues.push(userForecast?.interval_upper_bounds![0] || null);
+        userValues.push(userForecast?.centers?.[0] || null);
+        userMinValues.push(userForecast?.interval_lower_bounds?.[0] || null);
+        userMaxValues.push(userForecast?.interval_upper_bounds?.[0] || null);
       }
     });
     sortedAggregationTimestamps.forEach((timestamp) => {
@@ -909,12 +933,12 @@ export function generateChoiceItemsFromGroupQuestions(
           (forecast.end_time === null || forecast.end_time > timestamp)
         );
       });
-      aggregationValues.push(aggregationForecast?.centers![0] || null);
+      aggregationValues.push(aggregationForecast?.centers?.[0] || null);
       aggregationMinValues.push(
-        aggregationForecast?.interval_lower_bounds![0] || null
+        aggregationForecast?.interval_lower_bounds?.[0] || null
       );
       aggregationMaxValues.push(
-        aggregationForecast?.interval_upper_bounds![0] || null
+        aggregationForecast?.interval_upper_bounds?.[0] || null
       );
       aggregationForecasterCounts.push(
         aggregationForecast?.forecaster_count || 0
@@ -1056,8 +1080,12 @@ export function getGroupQuestionsTimestamps(
 
 export function findPreviousTimestamp(
   timestamps: number[],
-  timestamp: number
+  timestamp: number | null | undefined
 ): number {
+  if (isNil(timestamp)) {
+    return 0;
+  }
+
   return timestamps.reduce(
     (prev, curr) => (curr <= timestamp && curr > prev ? curr : prev),
     0
@@ -1088,7 +1116,7 @@ export const interpolateYValue = (xValue: number, line: Line) => {
   const p1 = line[i];
   const p2 = line[i + 1] ?? line[i];
 
-  if (!p1.y || !p2.y) return 0;
+  if (!p1?.y || !p2?.y) return 0;
 
   const t = (xValue - p1.x) / (p2.x - p1.x);
   return p1.y + t * (p2.y - p1.y);
@@ -1120,19 +1148,25 @@ export function getTickLabelFontSize(actualTheme: VictoryThemeDefinition) {
 export function getContinuousGroupScaling(
   questions: QuestionWithNumericForecasts[]
 ) {
+  const rangeMaxPoints: number[] = [];
+  const rangeMinPoints: number[] = [];
   const zeroPoints: number[] = [];
   questions.forEach((question) => {
+    if (question.scaling.range_max !== null) {
+      rangeMaxPoints.push(question.scaling.range_max);
+    }
+
+    if (question.scaling.range_min !== null) {
+      rangeMinPoints.push(question.scaling.range_min);
+    }
+
     if (question.scaling.zero_point !== null) {
       zeroPoints.push(question.scaling.zero_point);
     }
   });
   const scaling: Scaling = {
-    range_max: Math.max(
-      ...questions.map((question) => question.scaling.range_max!)
-    ),
-    range_min: Math.min(
-      ...questions.map((question) => question.scaling.range_min!)
-    ),
+    range_max: Math.max(...rangeMaxPoints),
+    range_min: Math.min(...rangeMinPoints),
     zero_point: zeroPoints.length > 0 ? Math.min(...zeroPoints) : null,
   };
   // we can have mixes of log and linear scaled options
@@ -1140,8 +1174,10 @@ export function getContinuousGroupScaling(
   // so just igore the log scaling in this case
   if (
     scaling.zero_point !== null &&
-    scaling.range_min! <= scaling.zero_point &&
-    scaling.zero_point <= scaling.range_max!
+    !isNil(scaling.range_min) &&
+    !isNil(scaling.range_max) &&
+    scaling.range_min <= scaling.zero_point &&
+    scaling.zero_point <= scaling.range_max
   ) {
     scaling.zero_point = null;
   }
@@ -1228,5 +1264,24 @@ export function getCursorForecast(
   } else if (cursorTimestamp === null && isNil(aggregation.latest?.end_time)) {
     forecastIndex = aggregation.history.length - 1;
   }
-  return forecastIndex === -1 ? null : aggregation.history[forecastIndex];
+  return forecastIndex === -1
+    ? null
+    : aggregation.history[forecastIndex] ?? null;
+}
+
+export function getCdfBounds(cdf: number[] | undefined): Bounds | undefined {
+  if (!cdf) {
+    return;
+  }
+
+  const start = cdf.at(0);
+  const end = cdf.at(-1);
+  if (isNil(start) || isNil(end)) {
+    return;
+  }
+
+  return {
+    belowLower: start,
+    aboveUpper: 1 - end,
+  };
 }

--- a/front_end/src/utils/colors.ts
+++ b/front_end/src/utils/colors.ts
@@ -23,7 +23,9 @@ export function getColorInSpectrum(
   value = value < 0.5 ? value : value - 0.5;
 
   const result = startColor.map((c1, i) =>
-    Math.round(c1 + (endColor[i] - c1) * value * 2)
+    // okay to do no-non-null-assertion, as both startColor and endColor are tuples of 3 numbers
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    Math.round(c1 + (endColor[i]! - c1) * value * 2)
   ) as RGBColor;
 
   return rgbToHex(result);

--- a/front_end/src/utils/files.ts
+++ b/front_end/src/utils/files.ts
@@ -1,6 +1,17 @@
+import { isNil } from "lodash";
+
 export function base64ToBlob(base64: string): Blob {
-  const byteString = atob(base64.split(",")[1]);
-  const mimeString = base64.split(",")[0].split(":")[1].split(";")[0];
+  const data = base64.split(",")[1];
+  if (isNil(data)) {
+    throw new Error("Invalid base64 string");
+  }
+  const byteString = atob(data);
+
+  const mimeString = base64.split(",")[0]?.split(":")?.[1]?.split(";")?.[0];
+  if (isNil(mimeString)) {
+    throw new Error("Invalid base64 string");
+  }
+
   const ab = new ArrayBuffer(byteString.length);
   const ia = new Uint8Array(ab);
   for (let i = 0; i < byteString.length; i++) {

--- a/front_end/src/utils/forecasts.ts
+++ b/front_end/src/utils/forecasts.ts
@@ -90,8 +90,9 @@ export function getNumericForecastDataset(
           lowerOpen,
           upperOpen
         ),
-        normalizedWeights[index]
-      ) as number[]
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        normalizedWeights[index]!
+      ) as unknown as number[]
   );
   let cdf = componentCdfs.reduce((acc, componentCdf) =>
     math.add(acc, componentCdf)

--- a/front_end/src/utils/math.ts
+++ b/front_end/src/utils/math.ts
@@ -65,14 +65,16 @@ function logisticCDF(
 
 export function cdfToPmf(cdf: number[]) {
   const pdf = [];
+  /* eslint-disable @typescript-eslint/no-non-null-assertion */
   for (let i = 0; i < cdf.length; i++) {
     if (i === 0) {
-      pdf.push(cdf[i]);
+      pdf.push(cdf[i]!);
     } else {
-      pdf.push(cdf[i] - cdf[i - 1]);
+      pdf.push(cdf[i]! - cdf[i - 1]!);
     }
   }
-  pdf.push(1 - cdf[cdf.length - 1]);
+  pdf.push(1 - cdf[cdf.length - 1]!);
+  /* eslint-enable @typescript-eslint/no-non-null-assertion */
   return pdf;
 }
 
@@ -95,8 +97,8 @@ export function cdfFromSliders(
     ),
   ];
   // clip cdf from closed_bounds
-  const scale_lower_to = lowerOpen ? 0 : cdf[0];
-  const scale_upper_to = upperOpen ? 1 : cdf[cdf.length - 1];
+  const scale_lower_to = lowerOpen ? 0 : cdf[0] ?? 0;
+  const scale_upper_to = upperOpen ? 1 : cdf[cdf.length - 1] ?? 1;
   const rescaled_inbound_mass = scale_upper_to - scale_lower_to;
   cdf = cdf.map((x) => (x - scale_lower_to) / rescaled_inbound_mass);
 
@@ -126,13 +128,15 @@ export function computeQuartilesFromCDF(
     const target = percentile / 100;
 
     for (let i = 0; i < cdf.length; i++) {
-      if (cdf[i] >= target) {
+      /* eslint-disable @typescript-eslint/no-non-null-assertion */
+      if (cdf[i]! >= target) {
         if (i === 0) return 0;
 
-        const diff = cdf[i] - cdf[i - 1];
-        const adjustedPercentile = (target - cdf[i - 1]) / diff;
+        const diff = cdf[i]! - cdf[i - 1]!;
+        const adjustedPercentile = (target - cdf[i - 1]!) / diff;
         return (i - 1 + adjustedPercentile) / (cdf.length - 1);
       }
+      /* eslint-enable @typescript-eslint/no-non-null-assertion */
     }
     return 1;
   }

--- a/front_end/src/utils/questions.ts
+++ b/front_end/src/utils/questions.ts
@@ -45,7 +45,7 @@ export function extractPostResolution(post: Post): Resolution | null {
   }
 
   if (post.group_of_questions) {
-    return post.group_of_questions?.questions[0]?.resolution;
+    return post.group_of_questions?.questions[0]?.resolution ?? null;
   }
 
   if (post.conditional) {
@@ -258,12 +258,13 @@ export function getPredictionQuestion(
     .sort((a, b) => differenceInMilliseconds(a.resolvedAt, b.resolvedAt));
 
   if (curationStatus === PostStatus.RESOLVED) {
-    return sortedQuestions[sortedQuestions.length - 1];
+    return sortedQuestions[sortedQuestions.length - 1] ?? null;
   }
 
   return (
     sortedQuestions.find((q) => q.resolution === null) ??
-    sortedQuestions[sortedQuestions.length - 1]
+    sortedQuestions[sortedQuestions.length - 1] ??
+    null
   );
 }
 
@@ -271,16 +272,16 @@ export const generateUserForecastsForMultipleQuestion = (
   question: QuestionWithMultipleChoiceForecasts
 ): UserChoiceItem[] | undefined => {
   const latest = question.aggregations.recency_weighted.latest;
-  const options = question.options!;
+  const options = question.options;
 
-  const choiceOrdering: number[] = options.map((_, i) => i);
+  const choiceOrdering: number[] = options?.map((_, i) => i) ?? [];
   choiceOrdering.sort((a, b) => {
     const aCenter = latest?.forecast_values[a] ?? 0;
     const bCenter = latest?.forecast_values[b] ?? 0;
     return bCenter - aCenter;
   });
 
-  return options.map((choice, index) => {
+  return options?.map((choice, index) => {
     const userForecasts = question.my_forecasts?.history;
     const values: (number | null)[] = [];
     const timestamps: number[] = [];
@@ -290,10 +291,10 @@ export const generateUserForecastsForMultipleQuestion = (
         timestamps[timestamps.length - 1] === forecast.start_time
       ) {
         // new forecast starts at the end of the previous, so overwrite values
-        values[values.length - 1] = forecast.forecast_values[index];
+        values[values.length - 1] = forecast.forecast_values[index] ?? null;
       } else {
         // just add the forecast
-        values.push(forecast.forecast_values[index]);
+        values.push(forecast.forecast_values[index] ?? null);
         timestamps.push(forecast.start_time);
       }
 
@@ -323,22 +324,31 @@ export const generateUserForecasts = (
 
     return {
       choice: question.label,
-      values: userForecasts?.history.map((forecast) =>
-        question.type === "binary"
-          ? forecast.forecast_values[1]
-          : scaling
-            ? unscaleNominalLocation(
-                scaleInternalLocation(forecast.centers![0], question.scaling),
-                scaling
-              )
-            : forecast.centers![0]
-      ),
+      values: userForecasts?.history.map((forecast) => {
+        if (question.type === QuestionType.Binary) {
+          return forecast.forecast_values[1] ?? 0;
+        }
+
+        if (!forecast.centers || isNil(forecast.centers[0])) {
+          return 0;
+        }
+
+        const value = forecast.centers[0];
+        if (scaling) {
+          return unscaleNominalLocation(
+            scaleInternalLocation(value, question.scaling),
+            scaling
+          );
+        }
+
+        return value;
+      }),
       timestamps: userForecasts?.history.map((forecast) => forecast.start_time),
       color: MULTIPLE_CHOICE_COLOR_SCALE[index] ?? METAC_COLORS.gray["400"],
       unscaledValues: userForecasts?.history.map((forecast) =>
-        question.type === "binary"
-          ? forecast.forecast_values[1]
-          : forecast.centers![0]
+        question.type === QuestionType.Binary
+          ? forecast.forecast_values[1] ?? 0
+          : forecast.centers?.[0] ?? 0
       ),
     };
   });
@@ -348,8 +358,8 @@ export function sortGroupPredictionOptions(
   questions: QuestionWithNumericForecasts[]
 ) {
   return [...questions].sort((a, b) => {
-    const aMean = a.aggregations.recency_weighted.latest?.centers![0] ?? 0;
-    const bMean = b.aggregations.recency_weighted.latest?.centers![0] ?? 0;
+    const aMean = a.aggregations.recency_weighted.latest?.centers?.[0] ?? 0;
+    const bMean = b.aggregations.recency_weighted.latest?.centers?.[0] ?? 0;
     return bMean - aMean;
   });
 }

--- a/front_end/tsconfig.json
+++ b/front_end/tsconfig.json
@@ -12,6 +12,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "noUncheckedIndexedAccess": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
Resolves #1469

This PR introduces an initial set of enhancements aimed at improving the maintainability of the front-end codebase.

Changes:
- Enabled the `noUncheckedIndexedAccess` rule to enforce stricter type safety when accessing values by index.
- Configured `typescript-eslint` and enabled a rule to block non-null assertions, promoting safer handling of nullable values.
- Addressed existing TypeScript errors and resolved no-non-null-assertion violations resulting from the above changes.

Benefits:

These updates improve the application’s stability by encouraging proper handling of nullable states and reducing the risk of crashes during refactoring.

Note:

In scenarios where handling empty states adds unnecessary complexity, non-null assertions can still be used. For such cases, the ESLint rule can be disabled selectively for specific lines to balance safety and simplicity.