### PR TITLE
add 30s grace period for showing comment 'edited at'

### DIFF
--- a/front_end/src/components/comment_feed/comment_date.tsx
+++ b/front_end/src/components/comment_feed/comment_date.tsx
@@ -1,4 +1,5 @@
 import "@github/relative-time-element";
+import { differenceInSeconds } from "date-fns";
 import { useLocale, useTranslations } from "next-intl";
 import { FC, useMemo } from "react";
 
@@ -11,8 +12,7 @@ export const CommentDate: FC<{ comment: CommentType }> = ({ comment }) => {
   const wasEdited = useMemo(
     () =>
       comment.edited_at &&
-      new Date(comment.created_at).getTime() !=
-        new Date(comment.edited_at).getTime(),
+      differenceInSeconds(comment.edited_at, comment.created_at) > 30,
     [comment.edited_at, comment.created_at]
   );
 


### PR DESCRIPTION
this is for two reasons:
1. the comment `edited_at` field is set for all/most comments and is often very slightly different from `created_at`, even for comments that have not in fact been edited by a person. This leads to the 'edit time' showing up confusingly for comments that were literally just posted. #1766

2. having a longish grace period is an accepted convention for this pattern: e.g. hackernews or reddit comments let you edit them for a bit without displaying as 'edited'; this is presumably because it's pretty normal to notice you made some typo right after posting. (we might actually want a slightly longer grace period for this reason)