### PR TITLE
fix(mdx-editor): extra long math formulas overflowing parent container

### DIFF
--- a/front_end/src/components/math_jax_content/index.tsx
+++ b/front_end/src/components/math_jax_content/index.tsx
@@ -1,4 +1,5 @@
 "use client";
+import "./styles.css";
 import { MathJax, MathJaxContext } from "better-react-mathjax";
 import dynamic from "next/dynamic";
 import React, { FC } from "react";

--- a/front_end/src/components/math_jax_content/styles.css
+++ b/front_end/src/components/math_jax_content/styles.css
@@ -1,0 +1,3 @@
+mjx-math {
+    @apply !whitespace-normal;
+}


### PR DESCRIPTION
Related to #1797

* adjusted `MathJaxContent` to properly render extra-long formulas

<img width="889" alt="image" src="https://github.com/user-attachments/assets/3451be36-3d68-45cc-8651-b053e7c874a7" />
