### PR TITLE
Embedded question has wrong color when embedded in dark mode

### DIFF
--- a/front_end/src/app/(embed)/questions/embed/[id]/page.tsx
+++ b/front_end/src/app/(embed)/questions/embed/[id]/page.tsx
@@ -55,7 +55,7 @@ export default async function GenerateQuestionPreview({
     >
       <ForecastCard
         post={post}
-        className="size-full flex-1 bg-transparent hover:shadow-none"
+        className="size-full flex-1 bg-transparent hover:shadow-none dark:bg-transparent"
         embedTheme={embedTheme}
         nonInteractive={!!nonInteractiveParam && nonInteractiveParam === "true"}
         defaultChartZoom={chartZoom}


### PR DESCRIPTION
Related to a regression noticed by ITN team. 

Before:

<img width="1476" alt="image" src="https://github.com/user-attachments/assets/65e4921e-65e4-467f-9062-a843b8834057" />


After:

<img width="1465" alt="image" src="https://github.com/user-attachments/assets/d3de386d-5e80-469e-98dd-6abbd714e044" />
