### PR TITLE
Fan graphs show empty tick labels on vertical scale

### DIFF
--- a/front_end/src/components/charts/fan_chart.tsx
+++ b/front_end/src/components/charts/fan_chart.tsx
@@ -22,12 +22,12 @@ import useAppTheme from "@/hooks/use_app_theme";
 import useContainerSize from "@/hooks/use_container_size";
 import { Area, FanOption, Line } from "@/types/charts";
 import {
-  Scaling,
-  Quartiles,
-  QuestionWithNumericForecasts,
-  QuestionType,
-  Question,
   ForecastAvailability,
+  Quartiles,
+  Question,
+  QuestionType,
+  QuestionWithNumericForecasts,
+  Scaling,
 } from "@/types/question";
 import {
   generateScale,
@@ -276,8 +276,8 @@ function buildChartData(options: FanOption[]) {
   }
 
   const scaling: Scaling = {
-    range_max: Math.max(...rangeMaxValues),
-    range_min: Math.min(...rangeMinValues),
+    range_max: rangeMaxValues.length > 0 ? Math.max(...rangeMaxValues) : null,
+    range_min: rangeMinValues.length > 0 ? Math.min(...rangeMinValues) : null,
     zero_point: zeroPoints.length > 0 ? Math.min(...zeroPoints) : null,
   };
   if (scaling.range_max === scaling.range_min && scaling.range_max === 0) {

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -1165,8 +1165,8 @@ export function getContinuousGroupScaling(
     }
   });
   const scaling: Scaling = {
-    range_max: Math.max(...rangeMaxPoints),
-    range_min: Math.min(...rangeMinPoints),
+    range_max: rangeMaxPoints.length > 0 ? Math.max(...rangeMaxPoints) : null,
+    range_min: rangeMinPoints.length > 0 ? Math.min(...rangeMinPoints) : null,
     zero_point: zeroPoints.length > 0 ? Math.min(...zeroPoints) : null,
   };
   // we can have mixes of log and linear scaled options


### PR DESCRIPTION
Related to #1812

Fixed invalid `scale` being generated for binary group questions when rendering fan graph