### PR TITLE
"Add Forecast" modal should recognize post ids/full urls

### DIFF
--- a/front_end/src/components/markdown_editor/embedded_question/embed_question_modal.tsx
+++ b/front_end/src/components/markdown_editor/embedded_question/embed_question_modal.tsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslations } from "next-intl";
 import { FC, useEffect, useState } from "react";
 
-import { fetchEmbedPosts } from "@/app/(main)/questions/actions";
+import { fetchEmbedPosts, getPost } from "@/app/(main)/questions/actions";
 import BaseModal from "@/components/base_modal";
 import PostStatus from "@/components/post_status";
 import SearchInput from "@/components/search_input";
@@ -12,6 +12,7 @@ import LoadingIndicator from "@/components/ui/loading_indicator";
 import { useDebouncedValue } from "@/hooks/use_debounce";
 import { Post, PostWithForecasts } from "@/types/post";
 import { QuestionType, QuestionWithNumericForecasts } from "@/types/question";
+import { logError } from "@/utils/errors";
 import { formatPrediction } from "@/utils/forecasts";
 import { extractPostResolution } from "@/utils/questions";
 
@@ -37,7 +38,22 @@ const EmbedQuestionModal: FC<Props> = ({
     if (isOpen) {
       const fetchPosts = async () => {
         setIsLoading(true);
-        const posts = await fetchEmbedPosts(debouncedSearch);
+        const match = debouncedSearch.match(/(?:\/questions\/|^)(\d+)(?:\/|$)/);
+        let posts: PostWithForecasts[] = [];
+
+        if (match?.[1]) {
+          try {
+            const questionId = Number(match?.[1]);
+            const question = await getPost(questionId);
+            posts = [question];
+          } catch (e) {
+            logError(e);
+          }
+        }
+        if (!posts.length) {
+          posts = await fetchEmbedPosts(debouncedSearch);
+        }
+
         setPosts(posts);
         setIsLoading(false);
       };


### PR DESCRIPTION
Related to #338

- update modal search, recognize post ids from urls