### PR TITLE
User tags are working unreliabily

### DIFF
--- a/comments/utils.py
+++ b/comments/utils.py
@@ -8,7 +8,7 @@ from comments.models import Comment
 from users.models import User
 
 # Regex pattern to find all @<username> mentions
-USERNAME_PATTERN = r"@\(?([\w.+-_'~#%]+)\)?"
+USERNAME_PATTERN = r"@\(?([\w+\-_'~#%@]+(?:\.[\w+\-_'~#%@]+)*)\)?"
 
 
 def comment_extract_user_mentions(

--- a/front_end/src/utils/comments.ts
+++ b/front_end/src/utils/comments.ts
@@ -31,7 +31,8 @@ export function parseUserMentions(
   markdown: string,
   mentionedUsers?: AuthorType[]
 ): string {
-  const userTagPattern = /@(\(([^)]+)\)|([\w.+-_'~#%]+))/gu;
+  const userTagPattern =
+    /@(\(([^)]+)\)|([\w+\-_'~#%@]+(?:\.[\w+\-_'~#%@]+)*))/gu;
 
   function isInsideSquareBrackets(index: number) {
     let insideBrackets = false;


### PR DESCRIPTION
Related to #1658

- updated regex to properly handle mention matches when punctuation is used (e.g. ",", ".", "!", etc.)
- note: for period, we'll match it as part of mention only when it is not the end of string, otherwise we consider it as punctuation symbol and ignore it:

<img width="213" alt="image" src="https://github.com/user-attachments/assets/1c023f2f-1819-4598-8e50-1d6d53a27183" />

<img width="752" alt="image" src="https://github.com/user-attachments/assets/f6c25c13-2598-4bbf-8e1e-44a5f612f380" />

<img width="759" alt="image" src="https://github.com/user-attachments/assets/d1d67921-dde9-4fff-a25b-ad9745be524b" />
