### PR TITLE
User predictions are missing on MC tiles when CP is hidden

### DIFF
--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -32,7 +32,7 @@ import {
   TickFormat,
   TimelineChartZoomOption,
 } from "@/types/charts";
-import { ChoiceItem, UserChoiceItem } from "@/types/choices";
+import { ChoiceItem } from "@/types/choices";
 import { QuestionType, Scaling } from "@/types/question";
 import { ThemeColor } from "@/types/theme";
 import {
@@ -62,7 +62,6 @@ type Props = {
   onCursorChange?: (value: number, format: TickFormat) => void;
   onChartReady?: () => void;
   extraTheme?: VictoryThemeDefinition;
-  userForecasts?: UserChoiceItem[];
   questionType?: QuestionType;
   scaling?: Scaling;
   isClosed?: boolean;

--- a/front_end/src/components/multiple_choice_tile/index.tsx
+++ b/front_end/src/components/multiple_choice_tile/index.tsx
@@ -9,7 +9,7 @@ import MultipleChoiceChart from "@/components/charts/multiple_choice_chart";
 import ForecastAvailabilityChartOverflow from "@/components/post_card/chart_overflow";
 import PredictionChip from "@/components/prediction_chip";
 import { TimelineChartZoomOption } from "@/types/charts";
-import { ChoiceItem, UserChoiceItem } from "@/types/choices";
+import { ChoiceItem } from "@/types/choices";
 import { PostStatus } from "@/types/post";
 import {
   ForecastAvailability,
@@ -37,7 +37,6 @@ type ContinuousMultipleChoiceTileProps = BaseProps & {
   defaultChartZoom?: TimelineChartZoomOption;
   withZoomPicker?: boolean;
   chartTheme?: VictoryThemeDefinition;
-  userForecasts?: UserChoiceItem[];
   question?: QuestionWithForecasts;
   scaling?: Scaling | undefined;
 };
@@ -54,7 +53,6 @@ export const ContinuousMultipleChoiceTile: FC<
   withZoomPicker,
   chartHeight = 100,
   chartTheme,
-  userForecasts,
   question,
   questionType,
   scaling,
@@ -88,12 +86,11 @@ export const ContinuousMultipleChoiceTile: FC<
           <MultipleChoiceChart
             timestamps={timestamps}
             actualCloseTime={actualCloseTime}
-            choiceItems={hideCP ? [] : choices}
+            choiceItems={choices}
             height={chartHeight}
             extraTheme={chartTheme}
             defaultZoom={defaultChartZoom}
             withZoomPicker={withZoomPicker}
-            userForecasts={userForecasts}
             questionType={questionType}
             scaling={scaling}
             isEmptyDomain={
@@ -101,6 +98,7 @@ export const ContinuousMultipleChoiceTile: FC<
               !!forecastAvailability?.cpRevealsOn
             }
             openTime={openTime}
+            hideCP={hideCP}
           />
           <ForecastAvailabilityChartOverflow
             forecastAvailability={forecastAvailability}

--- a/front_end/src/components/post_card/group_of_questions_tile/group_continuous_tile.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/group_continuous_tile.tsx
@@ -19,7 +19,6 @@ import {
   getGroupQuestionsTimestamps,
 } from "@/utils/charts";
 import {
-  generateUserForecasts,
   getGroupForecastAvailability,
   sortGroupPredictionOptions,
 } from "@/utils/questions";
@@ -104,14 +103,6 @@ const GroupContinuousTile: FC<Props> = ({ questions, post, hideCP }) => {
               : TimelineChartZoomOption.TwoMonths
           }
           scaling={scaling}
-          userForecasts={
-            user
-              ? generateUserForecasts(
-                  sortedQuestions as QuestionWithNumericForecasts[],
-                  scaling
-                )
-              : undefined
-          }
           questionType={questionType}
           hideCP={hideCP}
           forecastAvailability={forecastAvailability}

--- a/front_end/src/components/post_card/question_chart_tile/index.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/index.tsx
@@ -97,7 +97,6 @@ const QuestionChartTile: FC<Props> = ({
           visibleChoicesCount={visibleChoicesCount}
           defaultChartZoom={defaultChartZoom}
           question={question}
-          userForecasts={userForecasts}
           hideCP={hideCP}
           actualCloseTime={actualCloseTime}
           openTime={openTime}


### PR DESCRIPTION
Fixed an issue reported in Slack when user predictions were not displayed in feed tiles if CP is hidden:

<img width="749" alt="image" src="https://github.com/user-attachments/assets/240b1232-a62d-4069-9b83-2e730264b7ab" />
