### PR TITLE
TypeError: Body has already been consumed

### DIFF
--- a/front_end/package-lock.json
+++ b/front_end/package-lock.json
@@ -43,7 +43,7 @@
         "lodash": "^4.17.21",
         "mathjs": "^12.4.2",
         "negotiator": "^0.6.3",
-        "next": "^14.2.15",
+        "next": "^14.2.22",
         "next-intl": "^3.14.1",
         "next-themes": "^0.3.0",
         "nextjs-toploader": "^1.6.12",
@@ -2252,9 +2252,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.15.tgz",
-      "integrity": "sha512-S1qaj25Wru2dUpcIZMjxeMVSwkt8BK4dmWHHiBuRstcIyOsMapqT4A4jSB6onvqeygkSSmOkyny9VVx8JIGamQ==",
+      "version": "14.2.22",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.22.tgz",
+      "integrity": "sha512-EQ6y1QeNQglNmNIXvwP/Bb+lf7n9WtgcWvtoFsHquVLCJUuxRs+6SfZ5EK0/EqkkLex4RrDySvKgKNN7PXip7Q==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2267,9 +2267,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.15.tgz",
-      "integrity": "sha512-Rvh7KU9hOUBnZ9TJ28n2Oa7dD9cvDBKua9IKx7cfQQ0GoYUwg9ig31O2oMwH3wm+pE3IkAQ67ZobPfEgurPZIA==",
+      "version": "14.2.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.22.tgz",
+      "integrity": "sha512-HUaLiehovgnqY4TMBZJ3pDaOsTE1spIXeR10pWgdQVPYqDGQmHJBj3h3V6yC0uuo/RoY2GC0YBFRkOX3dI9WVQ==",
       "cpu": [
         "arm64"
       ],
@@ -2283,9 +2283,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.15.tgz",
-      "integrity": "sha512-5TGyjFcf8ampZP3e+FyCax5zFVHi+Oe7sZyaKOngsqyaNEpOgkKB3sqmymkZfowy3ufGA/tUgDPPxpQx931lHg==",
+      "version": "14.2.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.22.tgz",
+      "integrity": "sha512-ApVDANousaAGrosWvxoGdLT0uvLBUC+srqOcpXuyfglA40cP2LBFaGmBjhgpxYk5z4xmunzqQvcIgXawTzo2uQ==",
       "cpu": [
         "x64"
       ],
@@ -2299,9 +2299,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.15.tgz",
-      "integrity": "sha512-3Bwv4oc08ONiQ3FiOLKT72Q+ndEMyLNsc/D3qnLMbtUYTQAmkx9E/JRu0DBpHxNddBmNT5hxz1mYBphJ3mfrrw==",
+      "version": "14.2.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.22.tgz",
+      "integrity": "sha512-3O2J99Bk9aM+d4CGn9eEayJXHuH9QLx0BctvWyuUGtJ3/mH6lkfAPRI4FidmHMBQBB4UcvLMfNf8vF0NZT7iKw==",
       "cpu": [
         "arm64"
       ],
@@ -2315,9 +2315,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.15.tgz",
-      "integrity": "sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==",
+      "version": "14.2.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.22.tgz",
+      "integrity": "sha512-H/hqfRz75yy60y5Eg7DxYfbmHMjv60Dsa6IWHzpJSz4MRkZNy5eDnEW9wyts9bkxwbOVZNPHeb3NkqanP+nGPg==",
       "cpu": [
         "arm64"
       ],
@@ -2331,9 +2331,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.15.tgz",
-      "integrity": "sha512-kE6q38hbrRbKEkkVn62reLXhThLRh6/TvgSP56GkFNhU22TbIrQDEMrO7j0IcQHcew2wfykq8lZyHFabz0oBrA==",
+      "version": "14.2.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.22.tgz",
+      "integrity": "sha512-LckLwlCLcGR1hlI5eiJymR8zSHPsuruuwaZ3H2uudr25+Dpzo6cRFjp/3OR5UYJt8LSwlXv9mmY4oI2QynwpqQ==",
       "cpu": [
         "x64"
       ],
@@ -2347,9 +2347,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.15.tgz",
-      "integrity": "sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==",
+      "version": "14.2.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.22.tgz",
+      "integrity": "sha512-qGUutzmh0PoFU0fCSu0XYpOfT7ydBZgDfcETIeft46abPqP+dmePhwRGLhFKwZWxNWQCPprH26TjaTxM0Nv8mw==",
       "cpu": [
         "x64"
       ],
@@ -2363,9 +2363,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.15.tgz",
-      "integrity": "sha512-2raR16703kBvYEQD9HNLyb0/394yfqzmIeyp2nDzcPV4yPjqNUG3ohX6jX00WryXz6s1FXpVhsCo3i+g4RUX+g==",
+      "version": "14.2.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.22.tgz",
+      "integrity": "sha512-K6MwucMWmIvMb9GlvT0haYsfIPxfQD8yXqxwFy4uLFMeXIb2TcVYQimxkaFZv86I7sn1NOZnpOaVk5eaxThGIw==",
       "cpu": [
         "arm64"
       ],
@@ -2379,9 +2379,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.15.tgz",
-      "integrity": "sha512-fyTE8cklgkyR1p03kJa5zXEaZ9El+kDNM5A+66+8evQS5e/6v0Gk28LqA0Jet8gKSOyP+OTm/tJHzMlGdQerdQ==",
+      "version": "14.2.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.22.tgz",
+      "integrity": "sha512-5IhDDTPEbzPR31ZzqHe90LnNe7BlJUZvC4sA1thPJV6oN5WmtWjZ0bOYfNsyZx00FJt7gggNs6SrsX0UEIcIpA==",
       "cpu": [
         "ia32"
       ],
@@ -2395,9 +2395,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.15.tgz",
-      "integrity": "sha512-SzqGbsLsP9OwKNUG9nekShTwhj6JSB9ZLMWQ8g1gG6hdE5gQLncbnbymrwy2yVmH9nikSLYRYxYMFu78Ggp7/g==",
+      "version": "14.2.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.22.tgz",
+      "integrity": "sha512-nvRaB1PyG4scn9/qNzlkwEwLzuoPH3Gjp7Q/pLuwUgOTt1oPMlnCI3A3rgkt+eZnU71emOiEv/mR201HoURPGg==",
       "cpu": [
         "x64"
       ],
@@ -11542,12 +11542,12 @@
       }
     },
     "node_modules/next": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.15.tgz",
-      "integrity": "sha512-h9ctmOokpoDphRvMGnwOJAedT6zKhwqyZML9mDtspgf4Rh3Pn7UTYKqePNoDvhsWBAO5GoPNYshnAUGIazVGmw==",
+      "version": "14.2.22",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.22.tgz",
+      "integrity": "sha512-Ps2caobQ9hlEhscLPiPm3J3SYhfwfpMqzsoCMZGWxt9jBRK9hoBZj2A37i8joKhsyth2EuVKDVJCTF5/H4iEDw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.15",
+        "@next/env": "14.2.22",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -11562,15 +11562,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.15",
-        "@next/swc-darwin-x64": "14.2.15",
-        "@next/swc-linux-arm64-gnu": "14.2.15",
-        "@next/swc-linux-arm64-musl": "14.2.15",
-        "@next/swc-linux-x64-gnu": "14.2.15",
-        "@next/swc-linux-x64-musl": "14.2.15",
-        "@next/swc-win32-arm64-msvc": "14.2.15",
-        "@next/swc-win32-ia32-msvc": "14.2.15",
-        "@next/swc-win32-x64-msvc": "14.2.15"
+        "@next/swc-darwin-arm64": "14.2.22",
+        "@next/swc-darwin-x64": "14.2.22",
+        "@next/swc-linux-arm64-gnu": "14.2.22",
+        "@next/swc-linux-arm64-musl": "14.2.22",
+        "@next/swc-linux-x64-gnu": "14.2.22",
+        "@next/swc-linux-x64-musl": "14.2.22",
+        "@next/swc-win32-arm64-msvc": "14.2.22",
+        "@next/swc-win32-ia32-msvc": "14.2.22",
+        "@next/swc-win32-x64-msvc": "14.2.22"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/front_end/package.json
+++ b/front_end/package.json
@@ -48,7 +48,7 @@
     "lodash": "^4.17.21",
     "mathjs": "^12.4.2",
     "negotiator": "^0.6.3",
-    "next": "^14.2.15",
+    "next": "^14.2.22",
     "next-intl": "^3.14.1",
     "next-themes": "^0.3.0",
     "nextjs-toploader": "^1.6.12",

--- a/front_end/src/utils/fetch.ts
+++ b/front_end/src/utils/fetch.ts
@@ -149,10 +149,7 @@ const appFetch = async <T>(
   }
 
   const response = await fetch(finalUrl, finalOptions);
-  // consume response in order to fix SocketError: other side is closed
-  // https://stackoverflow.com/questions/76931498/typeerror-terminated-cause-socketerror-other-side-closed-in-fetch-nodejs
-  const clonedRes = response.clone();
-  return await handleResponse<T>(clonedRes);
+  return await handleResponse<T>(response);
 };
 
 const get = async <T>(


### PR DESCRIPTION
Fixes #1806

- updated to the latest Next.js v14 release. According to [this](https://github.com/vercel/next.js/discussions/69635) discussion, the issue was fixed in `14.2.20`
- removed redundant workaround for socket error
  - the issue was fixed BE-side and we don't need redundant response cloning. The workaround didn't work anyway