### PR TITLE
Custom embed themes

### DIFF
--- a/front_end/src/app/(embed)/questions/constants/embed_theme.ts
+++ b/front_end/src/app/(embed)/questions/constants/embed_theme.ts
@@ -28,7 +28,7 @@ export const EMBED_THEME: Record<string, EmbedTheme> = {
       area: { style: { data: { fill: "#89BFD1" } } },
     },
     card: {
-      backgroundColor: "#F0F0F0",
+      backgroundColor: "#19191C",
       fontFamily: "serif",
     },
     predictionChip: {


### PR DESCRIPTION
Related to #731

Fixed wrong card bg color being used in `verity-dark` theme:

<img width="1498" alt="image" src="https://github.com/user-attachments/assets/2d119d59-5444-4758-914e-ea3e7c01bc8f" />


**Note**: This change will not immediately affect how embeds are rendered on Verity, as they currently rely on legacy customization using CSS variables, which is functioning correctly. This PR is simply an update to align the new theming system to match the appearance of the legacy system.