### PR TITLE
reaffirm button on feed

### DIFF
--- a/front_end/src/app/(main)/(home)/components/research_and_updates.tsx
+++ b/front_end/src/app/(main)/(home)/components/research_and_updates.tsx
@@ -8,12 +8,12 @@ import { FC } from "react";
 
 import imagePlaceholder from "@/app/assets/images/tournament.webp";
 import WithServerComponentErrorBoundary from "@/components/server_component_error_boundary";
-import { PostWithNotebook } from "@/types/post";
+import { NotebookPost } from "@/types/post";
 import { getPostLink } from "@/utils/navigation";
 import { getMarkdownSummary } from "@/utils/questions";
 
 type Props = {
-  posts: PostWithNotebook[];
+  posts: NotebookPost[];
 };
 
 const ResearchAndUpdatesBlock: FC<Props> = async ({ posts }) => {

--- a/front_end/src/app/(main)/(home)/page.tsx
+++ b/front_end/src/app/(main)/(home)/page.tsx
@@ -5,7 +5,7 @@ import OnboardingCheck from "@/components/onboarding/onboarding_check";
 import { POST_TOPIC_FILTER } from "@/constants/posts_feed";
 import PostsApi from "@/services/posts";
 import ProjectsApi from "@/services/projects";
-import { PostWithForecasts, PostWithNotebook } from "@/types/post";
+import { PostWithForecasts, NotebookPost } from "@/types/post";
 import { encodeQueryParams } from "@/utils/navigation";
 
 import EmailConfirmation from "./components/email_confirmation";
@@ -63,7 +63,7 @@ export default async function Home() {
   ) as unknown as PostWithForecasts[];
   const postNotebooks = homepagePosts.filter(
     (post) => !!post.notebook
-  ) as unknown as PostWithNotebook[];
+  ) as unknown as NotebookPost[];
 
   return (
     <main className="bg-gradient-to-b from-blue-100 from-20% to-blue-200 to-50% pt-16 dark:from-blue-100-dark dark:to-blue-200-dark sm:pt-28">

--- a/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/constants/posts_feed";
 import PostsApi from "@/services/posts";
 import ProjectsApi from "@/services/projects";
-import { PostStatus, PostWithNotebook } from "@/types/post";
+import { PostStatus, NotebookPost } from "@/types/post";
 import { TournamentType } from "@/types/projects";
 import { formatDate } from "@/utils/date_formatters";
 import { estimateReadingTime, getQuestionTitle } from "@/utils/questions";
@@ -186,7 +186,7 @@ export default async function IndividualNotebook({ params }: Props) {
           </div>
           <div className="w-full">
             <NotebookEditor
-              postData={postData as PostWithNotebook}
+              postData={postData as NotebookPost}
               contentId={NOTEBOOK_CONTENT_SECTION}
             />
             {!!postData.projects.category?.length && (

--- a/front_end/src/app/(main)/notebooks/components/index_notebook/index.tsx
+++ b/front_end/src/app/(main)/notebooks/components/index_notebook/index.tsx
@@ -10,7 +10,7 @@ import PostsApi from "@/services/posts";
 import {
   PostWithForecasts,
   PostWithForecastsAndWeight,
-  PostWithNotebook,
+  NotebookPost,
 } from "@/types/post";
 import { QuestionType } from "@/types/question";
 import { scaleInternalLocation } from "@/utils/charts";
@@ -61,7 +61,7 @@ const IndexNotebook: FC<Props> = async ({
           {postData.title}
         </h1>
         {postData.notebook && (
-          <NotebookEditor postData={postData as PostWithNotebook} />
+          <NotebookEditor postData={postData as NotebookPost} />
         )}
 
         <IndexQuestionsTable

--- a/front_end/src/app/(main)/notebooks/components/notebook_editor.tsx
+++ b/front_end/src/app/(main)/notebooks/components/notebook_editor.tsx
@@ -9,10 +9,10 @@ import { useContentTranslatedBannerProvider } from "@/app/providers";
 import MarkdownEditor from "@/components/markdown_editor";
 import PostDefaultProject from "@/components/post_default_project";
 import Button from "@/components/ui/button";
-import { PostStatus, PostWithNotebook, ProjectPermissions } from "@/types/post";
+import { PostStatus, NotebookPost, ProjectPermissions } from "@/types/post";
 
 interface NotebookEditorProps {
-  postData: PostWithNotebook;
+  postData: NotebookPost;
   contentId?: string;
 }
 

--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
@@ -13,11 +13,15 @@ import PostsApi from "@/services/posts";
 import ProjectsApi from "@/services/projects";
 import questions from "@/services/questions";
 import { SearchParams } from "@/types/navigation";
-import { PostConditional, PostStatus, ProjectPermissions } from "@/types/post";
+import { PostStatus, ProjectPermissions } from "@/types/post";
 import { TournamentType } from "@/types/projects";
-import { QuestionWithNumericForecasts } from "@/types/question";
 import { getPostLink } from "@/utils/navigation";
-import { getQuestionTitle } from "@/utils/questions";
+import {
+  getQuestionTitle,
+  isConditionalPost,
+  isGroupOfQuestionsPost,
+  isQuestionPost,
+} from "@/utils/questions";
 
 import BackgroundInfo from "../components/background_info";
 import HideCPProvider from "../components/cp_provider";
@@ -148,7 +152,6 @@ export default async function IndividualQuestion({
       postData.curation_status !== PostStatus.APPROVED);
 
   const questionTitle = getQuestionTitle(postData);
-  const isClosed = postData.status === PostStatus.CLOSED;
   return (
     <EmbedModalContextProvider>
       <HideCPProvider post={postData}>
@@ -173,48 +176,29 @@ export default async function IndividualQuestion({
                   </div>
                 )}
 
-                {!!postData.conditional && (
+                {isConditionalPost(postData) && (
                   <ConditionalTile
-                    postTitle={postData.title}
-                    conditional={postData.conditional}
-                    nrForecasters={postData.nr_forecasters}
+                    post={postData}
                     withNavigation
                     withCPRevealBtn
-                    forecasters={postData.nr_forecasters}
                   />
                 )}
                 <QuestionHeaderInfo post={postData} />
 
-                {!!postData.question && (
-                  <DetailedQuestionCard
-                    postStatus={postData.status}
-                    question={postData.question}
-                    nrForecasters={postData.nr_forecasters}
-                  />
+                {isQuestionPost(postData) && (
+                  <DetailedQuestionCard post={postData} />
                 )}
-                {!!postData.group_of_questions && (
+                {isGroupOfQuestionsPost(postData) && (
                   <DetailedGroupCard
-                    actualCloseTime={
-                      postData.actual_close_time ??
-                      postData.scheduled_close_time
-                    }
-                    openTime={postData.open_time}
-                    questions={postData.group_of_questions.questions}
+                    post={postData}
                     preselectedQuestionId={preselectedGroupQuestionId}
-                    isClosed={isClosed}
-                    graphType={postData.group_of_questions.graph_type}
-                    postStatus={postData.status}
                   />
                 )}
 
                 <ForecastMaker post={postData} />
-                {!!postData.conditional && (
-                  <ConditionalTimeline
-                    conditional={
-                      postData.conditional as PostConditional<QuestionWithNumericForecasts>
-                    }
-                    isClosed={isClosed}
-                  />
+
+                {isConditionalPost(postData) && (
+                  <ConditionalTimeline post={postData} />
                 )}
 
                 {!!postData.group_of_questions && (

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_group_card/index.tsx
@@ -8,7 +8,7 @@ import FanGraphGroupChart from "@/app/(main)/questions/[id]/components/detailed_
 import MultipleChoiceGroupChart from "@/app/(main)/questions/[id]/components/multiple_choice_group_chart";
 import RevealCPButton from "@/app/(main)/questions/[id]/components/reveal_cp_button";
 import { GroupOfQuestionsGraphType } from "@/types/charts";
-import { PostStatus } from "@/types/post";
+import { GroupOfQuestionsPost, PostStatus } from "@/types/post";
 import {
   QuestionWithForecasts,
   QuestionWithNumericForecasts,
@@ -23,25 +23,22 @@ import {
 import { useHideCP } from "../cp_provider";
 
 type Props = {
-  questions: QuestionWithForecasts[];
-  graphType: string;
+  post: GroupOfQuestionsPost<QuestionWithForecasts>;
   preselectedQuestionId?: number;
-  isClosed?: boolean;
-  actualCloseTime: string | null;
-  openTime: string | null;
-  postStatus: PostStatus;
 };
 
-const DetailedGroupCard: FC<Props> = ({
-  questions,
-  preselectedQuestionId,
-  isClosed,
-  graphType,
-  actualCloseTime,
-  openTime,
-  postStatus,
-}) => {
+const DetailedGroupCard: FC<Props> = ({ post, preselectedQuestionId }) => {
   const t = useTranslations();
+
+  const {
+    open_time,
+    actual_close_time,
+    scheduled_close_time,
+    group_of_questions: { questions, graph_type },
+    status,
+  } = post;
+  const refCloseTime = actual_close_time ?? scheduled_close_time;
+
   const groupType = questions.at(0)?.type;
   const { hideCP } = useHideCP();
 
@@ -64,12 +61,12 @@ const DetailedGroupCard: FC<Props> = ({
   if (
     forecastAvailability.isEmpty &&
     forecastAvailability.cpRevealsOn &&
-    postStatus !== PostStatus.OPEN
+    status !== PostStatus.OPEN
   ) {
     return null;
   }
 
-  switch (graphType) {
+  switch (graph_type) {
     case GroupOfQuestionsGraphType.MultipleChoiceGraph: {
       const sortedQuestions = sortGroupPredictionOptions(
         questions as QuestionWithNumericForecasts[]
@@ -90,10 +87,10 @@ const DetailedGroupCard: FC<Props> = ({
             timestamps={timestamps}
             type={type}
             actualCloseTime={
-              actualCloseTime ? new Date(actualCloseTime).getTime() : null
+              refCloseTime ? new Date(refCloseTime).getTime() : null
             }
-            openTime={openTime ? new Date(openTime).getTime() : undefined}
-            isClosed={isClosed}
+            openTime={open_time ? new Date(open_time).getTime() : undefined}
+            isClosed={status === PostStatus.CLOSED}
             preselectedQuestionId={preselectedQuestionId}
             hideCP={hideCP}
             forecastAvailability={forecastAvailability}

--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/index.tsx
@@ -2,7 +2,7 @@
 import { sendGAEvent } from "@next/third-parties/google";
 import React, { FC, useEffect } from "react";
 
-import { PostStatus } from "@/types/post";
+import { PostStatus, QuestionPost } from "@/types/post";
 import { QuestionType, QuestionWithForecasts } from "@/types/question";
 import { getQuestionForecastAvailability } from "@/utils/questions";
 
@@ -13,16 +13,11 @@ import { useHideCP } from "../cp_provider";
 import RevealCPButton from "../reveal_cp_button";
 
 type Props = {
-  postStatus: PostStatus;
-  question: QuestionWithForecasts;
-  nrForecasters: number;
+  post: QuestionPost<QuestionWithForecasts>;
 };
 
-const DetailedQuestionCard: FC<Props> = ({
-  postStatus,
-  question,
-  nrForecasters,
-}) => {
+const DetailedQuestionCard: FC<Props> = ({ post }) => {
+  const { question, status, nr_forecasters } = post;
   const forecastAvailability = getQuestionForecastAvailability(question);
 
   const { hideCP } = useHideCP();
@@ -35,7 +30,7 @@ const DetailedQuestionCard: FC<Props> = ({
     }
   }, [question.my_forecasts?.history.length, question.type]);
 
-  if (forecastAvailability.isEmpty && postStatus !== PostStatus.OPEN) {
+  if (forecastAvailability.isEmpty && status !== PostStatus.OPEN) {
     return null;
   }
 
@@ -49,7 +44,7 @@ const DetailedQuestionCard: FC<Props> = ({
             question={question}
             hideCP={hideCP}
             forecastAvailability={forecastAvailability}
-            nrForecasters={nrForecasters}
+            nrForecasters={nr_forecasters}
           />
           {hideCP && <RevealCPButton />}
         </DetailsQuestionCardErrorBoundary>

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_conditional/index.tsx
@@ -33,13 +33,6 @@ const ForecastMakerConditional: FC<Props> = ({
   if (question_yes.type !== question_no.type) {
     return null;
   }
-  const parentSuccessfullyResolved =
-    condition.resolution === "yes" || condition.resolution === "no";
-  const parentIsClosed = condition.actual_close_time
-    ? new Date(condition.actual_close_time).getTime() < Date.now()
-    : false;
-  const conditionClosedOrResolved =
-    parentSuccessfullyResolved || parentIsClosed;
 
   return (
     <ForecastMakerContainer
@@ -65,12 +58,7 @@ const ForecastMakerConditional: FC<Props> = ({
           conditional={
             conditional as PostConditional<QuestionWithNumericForecasts>
           }
-          canPredict={
-            canPredict &&
-            !conditionClosedOrResolved &&
-            conditional.condition_child.open_time !== undefined &&
-            new Date(conditional.condition_child.open_time) <= new Date()
-          }
+          canPredict={canPredict}
           predictionMessage={predictionMessage}
           projects={projects}
         />
@@ -83,12 +71,7 @@ const ForecastMakerConditional: FC<Props> = ({
           conditional={
             conditional as PostConditional<QuestionWithNumericForecasts>
           }
-          canPredict={
-            canPredict &&
-            !conditionClosedOrResolved &&
-            conditional.condition_child.open_time !== undefined &&
-            new Date(conditional.condition_child.open_time) <= new Date()
-          }
+          canPredict={canPredict}
           predictionMessage={predictionMessage}
           projects={projects}
         />

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
@@ -31,6 +31,8 @@ import { getCdfBounds } from "@/utils/charts";
 import cn from "@/utils/cn";
 import {
   extractPrevNumericForecastValue,
+  getNormalizedContinuousForecast,
+  getNormalizedContinuousWeight,
   getNumericForecastDataset,
 } from "@/utils/forecasts";
 import { computeQuartilesFromCDF } from "@/utils/math";
@@ -173,7 +175,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
       prev.map((prevChoice) => {
         if (prevChoice.id === optionId) {
           const newUserForecast = [
-            ...getNormalizedUserForecast(prevChoice.userForecast),
+            ...getNormalizedContinuousForecast(prevChoice.userForecast),
             { left: 0.4, center: 0.5, right: 0.6 },
           ];
           const newWeights = [...prevChoice.userWeights, 1];
@@ -212,7 +214,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
               prevOption.question.open_upper_bound
             ),
             userForecast: getSliderValue(prevForecast),
-            userWeights: getWeightsValue(prevWeights),
+            userWeights: getNormalizedContinuousWeight(prevWeights),
             isDirty: false,
           };
         }
@@ -237,7 +239,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
           questionId: question.id,
           forecastData: {
             continuousCdf: getNumericForecastDataset(
-              getNormalizedUserForecast(userForecast),
+              getNormalizedContinuousForecast(userForecast),
               userWeights,
               question.open_lower_bound,
               question.open_upper_bound
@@ -246,7 +248,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
             probabilityYes: null,
           },
           sliderValues: {
-            forecast: getNormalizedUserForecast(userForecast),
+            forecast: getNormalizedContinuousForecast(userForecast),
             weights: userWeights,
           },
         };
@@ -271,7 +273,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
   const userCdf: number[] | undefined =
     activeGroupOption &&
     getNumericForecastDataset(
-      getNormalizedUserForecast(activeGroupOption.userForecast),
+      getNormalizedContinuousForecast(activeGroupOption.userForecast),
       activeGroupOption?.userWeights,
       activeGroupOption?.question.open_lower_bound,
       activeGroupOption?.question.open_upper_bound
@@ -295,7 +297,7 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
         showCP={!user || !hideCP}
       />
       {groupOptions.map((option) => {
-        const normalizedUserForecast = getNormalizedUserForecast(
+        const normalizedUserForecast = getNormalizedContinuousForecast(
           option.userForecast
         );
 
@@ -461,7 +463,7 @@ function generateGroupOptions(
           q.open_upper_bound
         ),
         userForecast: getSliderValue(prevForecast),
-        userWeights: getWeightsValue(prevWeights),
+        userWeights: getNormalizedContinuousWeight(prevWeights),
         communityQuartiles: q.aggregations.recency_weighted.latest
           ? computeQuartilesFromCDF(
               q.aggregations.recency_weighted.latest.forecast_values
@@ -511,22 +513,6 @@ function getUserQuartiles(
 
 function getSliderValue(forecast?: MultiSliderValue[]) {
   return forecast ?? null;
-}
-
-function getNormalizedUserForecast(forecast: MultiSliderValue[] | null) {
-  return (
-    forecast ?? [
-      {
-        left: 0.4,
-        center: 0.5,
-        right: 0.6,
-      },
-    ]
-  );
-}
-
-function getWeightsValue(weights?: number[]) {
-  return weights ?? [1];
 }
 
 export default ForecastMakerGroupContinuous;

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
@@ -19,6 +19,8 @@ import { QuestionWithNumericForecasts } from "@/types/question";
 import { getCdfBounds } from "@/utils/charts";
 import {
   extractPrevNumericForecastValue,
+  getNormalizedContinuousForecast,
+  getNormalizedContinuousWeight,
   getNumericForecastDataset,
 } from "@/utils/forecasts";
 import { computeQuartilesFromCDF } from "@/utils/math";
@@ -64,16 +66,10 @@ const ForecastMakerContinuous: FC<Props> = ({
   const hasUserForecast = !!activeForecastSliderValues.forecast;
   const t = useTranslations();
   const [forecast, setForecast] = useState<MultiSliderValue[]>(
-    activeForecastSliderValues?.forecast ?? [
-      {
-        left: 0.4,
-        center: 0.5,
-        right: 0.6,
-      },
-    ]
+    getNormalizedContinuousForecast(activeForecastSliderValues.forecast)
   );
   const [weights, setWeights] = useState<number[]>(
-    activeForecastSliderValues?.weights ?? [1]
+    getNormalizedContinuousWeight(activeForecastSliderValues.weights)
   );
   const [overlayPreviousForecast, setOverlayPreviousForecast] =
     useState<boolean>(

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_question/index.tsx
@@ -1,4 +1,3 @@
-import { parseISO } from "date-fns";
 import { useLocale, useTranslations } from "next-intl";
 import { FC, ReactNode } from "react";
 
@@ -55,11 +54,7 @@ const QuestionForecastMaker: FC<Props> = ({
             post={post}
             question={question}
             permission={permission}
-            canPredict={
-              canPredict &&
-              question.open_time !== undefined &&
-              parseISO(question.open_time) < new Date()
-            }
+            canPredict={canPredict}
             canResolve={canResolve}
             predictionMessage={predictionMessage}
           />
@@ -73,11 +68,7 @@ const QuestionForecastMaker: FC<Props> = ({
             question={question}
             permission={permission}
             prevForecast={activeUserForecast?.forecast_values[1]}
-            canPredict={
-              canPredict &&
-              question.open_time !== undefined &&
-              parseISO(question.open_time) < new Date()
-            }
+            canPredict={canPredict}
             canResolve={canResolve}
             predictionMessage={predictionMessage}
           />
@@ -90,11 +81,7 @@ const QuestionForecastMaker: FC<Props> = ({
             post={post}
             question={question}
             permission={permission}
-            canPredict={
-              canPredict &&
-              question.open_time !== undefined &&
-              parseISO(question.open_time) < new Date()
-            }
+            canPredict={canPredict}
             canResolve={canResolve}
             predictionMessage={predictionMessage}
           />

--- a/front_end/src/app/(main)/questions/actions.ts
+++ b/front_end/src/app/(main)/questions/actions.ts
@@ -19,7 +19,7 @@ import QuestionsApi, {
   WithdrawalPayload,
 } from "@/services/questions";
 import { FetchError } from "@/types/fetch";
-import { PostSubscription, PostWithNotebook } from "@/types/post";
+import { PostSubscription, NotebookPost } from "@/types/post";
 import { Tournament, TournamentType } from "@/types/projects";
 import { DeepPartial } from "@/types/utils";
 import { VoteDirection } from "@/types/votes";
@@ -185,8 +185,8 @@ export async function updateNotebook(
   title: string
 ) {
   const response = await PostsApi.updatePost<
-    PostWithNotebook,
-    DeepPartial<PostWithNotebook>
+    NotebookPost,
+    DeepPartial<NotebookPost>
   >(postId, {
     title: title,
     notebook: {

--- a/front_end/src/components/conditional_tile/index.tsx
+++ b/front_end/src/components/conditional_tile/index.tsx
@@ -10,7 +10,7 @@ import RevealCPButton from "@/app/(main)/questions/[id]/components/reveal_cp_but
 import { SLUG_POST_SUB_QUESTION_ID } from "@/app/(main)/questions/[id]/search_params";
 import ForecastersCounter from "@/app/(main)/questions/components/forecaster_counter";
 import PredictionChip from "@/components/prediction_chip";
-import { PostConditional, PostStatus } from "@/types/post";
+import { ConditionalPost, PostStatus } from "@/types/post";
 import { QuestionWithForecasts } from "@/types/question";
 import cn from "@/utils/cn";
 import {
@@ -25,26 +25,24 @@ import Arrow from "./icons/Arrow";
 import DisabledArrow from "./icons/DisabledArrow";
 
 type Props = {
-  postTitle: string;
-  conditional: PostConditional<QuestionWithForecasts>;
+  post: ConditionalPost<QuestionWithForecasts>;
   withNavigation?: boolean;
   chartTheme?: VictoryThemeDefinition;
-  nrForecasters?: number;
   withCPRevealBtn?: boolean;
-  forecasters?: number;
 };
 
 const ConditionalTile: FC<Props> = ({
-  postTitle,
-  conditional,
+  post,
   withNavigation,
   chartTheme,
   withCPRevealBtn,
-  forecasters,
 }) => {
   const t = useTranslations();
   const { hideCP } = useHideCP();
+
+  const { conditional, title, nr_forecasters } = post;
   const { condition, condition_child, question_yes, question_no } = conditional;
+
   const isEmbedded = !!chartTheme;
 
   const conditionHref =
@@ -94,7 +92,7 @@ const ConditionalTile: FC<Props> = ({
         >
           <ConditionalCard
             label={t("condition")}
-            title={getConditionTitle(postTitle, condition)}
+            title={getConditionTitle(title, condition)}
             resolved={parentSuccessfullyResolved}
             href={withNavigation ? conditionHref : undefined}
           >
@@ -110,7 +108,7 @@ const ConditionalTile: FC<Props> = ({
                 hideCP={hideCP}
               />
             )}
-            <ForecastersCounter forecasters={forecasters} />
+            <ForecastersCounter forecasters={nr_forecasters} />
           </ConditionalCard>
         </div>
         <div

--- a/front_end/src/components/conditional_timeline.tsx
+++ b/front_end/src/components/conditional_timeline.tsx
@@ -6,8 +6,11 @@ import React, { FC } from "react";
 import { useHideCP } from "@/app/(main)/questions/[id]/components/cp_provider";
 import MultipleChoiceGroupChart from "@/app/(main)/questions/[id]/components/multiple_choice_group_chart";
 import RevealCPButton from "@/app/(main)/questions/[id]/components/reveal_cp_button";
-import { PostConditional } from "@/types/post";
-import { QuestionWithNumericForecasts } from "@/types/question";
+import { ConditionalPost, PostConditional, PostStatus } from "@/types/post";
+import {
+  QuestionWithForecasts,
+  QuestionWithNumericForecasts,
+} from "@/types/question";
 import { getGroupQuestionsTimestamps } from "@/utils/charts";
 import {
   getGroupForecastAvailability,
@@ -15,14 +18,15 @@ import {
 } from "@/utils/questions";
 
 type Props = {
-  conditional: PostConditional<QuestionWithNumericForecasts>;
-  isClosed?: boolean;
+  post: ConditionalPost<QuestionWithForecasts>;
 };
 
-const ConditionalTimeline: FC<Props> = ({ conditional, isClosed }) => {
+const ConditionalTimeline: FC<Props> = ({ post }) => {
   const t = useTranslations();
 
   const { hideCP } = useHideCP();
+
+  const { conditional, status } = post;
 
   const groupType = conditional.question_no.type;
   const type = getQuestionLinearChartType(groupType);
@@ -30,7 +34,10 @@ const ConditionalTimeline: FC<Props> = ({ conditional, isClosed }) => {
     return null;
   }
 
-  const questions = generateQuestions(t, conditional);
+  const questions = generateQuestions(
+    t,
+    conditional as PostConditional<QuestionWithNumericForecasts>
+  );
   const forecastAvailability = getGroupForecastAvailability(questions);
   const timestamps = getGroupQuestionsTimestamps(questions, {
     withUserTimestamps: !!forecastAvailability.cpRevealsOn,
@@ -54,7 +61,7 @@ const ConditionalTimeline: FC<Props> = ({ conditional, isClosed }) => {
         }
         hideCP={hideCP}
         forecastAvailability={forecastAvailability}
-        isClosed={isClosed}
+        isClosed={status === PostStatus.CLOSED}
       />
       {hideCP && <RevealCPButton className="mb-3" />}
     </>

--- a/front_end/src/components/forecast_card.tsx
+++ b/front_end/src/components/forecast_card.tsx
@@ -29,6 +29,7 @@ import {
   getGroupForecastAvailability,
   getQuestionForecastAvailability,
   getQuestionLinearChartType,
+  isConditionalPost,
   sortGroupPredictionOptions,
 } from "@/utils/questions";
 
@@ -141,14 +142,8 @@ const ForecastCard: FC<Props> = ({
       }
     }
 
-    if (post.conditional) {
-      return (
-        <ConditionalTile
-          postTitle={post.title}
-          conditional={post.conditional}
-          chartTheme={embedTheme?.chart}
-        />
-      );
+    if (isConditionalPost(post)) {
+      return <ConditionalTile post={post} chartTheme={embedTheme?.chart} />;
     }
 
     if (post.question) {

--- a/front_end/src/components/multiple_choice_tile/index.tsx
+++ b/front_end/src/components/multiple_choice_tile/index.tsx
@@ -8,6 +8,7 @@ import FanGraphGroupChart from "@/app/(main)/questions/[id]/components/detailed_
 import { BINARY_FORECAST_PRECISION } from "@/app/(main)/questions/[id]/components/forecast_maker/binary_slider";
 import MultipleChoiceChart from "@/components/charts/multiple_choice_chart";
 import ForecastAvailabilityChartOverflow from "@/components/post_card/chart_overflow";
+import useCardReaffirmContext from "@/components/post_card/reaffirm_context";
 import PredictionChip from "@/components/prediction_chip";
 import { MultiSliderValue } from "@/components/sliders/multi_slider";
 import { ForecastPayload } from "@/services/questions";
@@ -37,7 +38,6 @@ type BaseProps = {
   hideCP?: boolean;
   forecastAvailability?: ForecastAvailability;
   chartHeight?: number;
-  onReaffirm?: (userForecast: ForecastPayload[]) => void;
   canPredict?: boolean;
 };
 
@@ -85,9 +85,10 @@ export const ContinuousMultipleChoiceTile: FC<
   scaling,
   hideCP,
   forecastAvailability,
-  onReaffirm,
   canPredict,
 }) => {
+  const { onReaffirm } = useCardReaffirmContext();
+
   // when resolution chip is shown we want to hide the chart and display the chip
   // (e.g. multiple-choice question on questions feed)
   // otherwise, resolution status will be populated near the every choice
@@ -164,9 +165,10 @@ export const FanGraphMultipleChoiceTile: FC<
   forecastAvailability,
   chartHeight,
   groupType,
-  onReaffirm,
   canPredict,
 }) => {
+  const { onReaffirm } = useCardReaffirmContext();
+
   const { canReaffirm, forecast } = useMemo(
     () => generateReaffirmData({ groupQuestions, groupType }),
     [groupQuestions, groupType]

--- a/front_end/src/components/multiple_choice_tile/multiple_choice_tile_legend.tsx
+++ b/front_end/src/components/multiple_choice_tile/multiple_choice_tile_legend.tsx
@@ -5,6 +5,7 @@ import React, { FC } from "react";
 
 import { ChoiceItem } from "@/types/choices";
 import { QuestionType } from "@/types/question";
+import cn from "@/utils/cn";
 
 import ChoiceOption from "./choice_option";
 
@@ -15,6 +16,8 @@ type Props = {
   hideCP?: boolean;
   hideChoiceIcon?: boolean;
   optionLabelClassName?: string;
+  onReaffirm?: () => void;
+  canPredict?: boolean;
 };
 
 const MultipleChoiceTileLegend: FC<Props> = ({
@@ -24,6 +27,8 @@ const MultipleChoiceTileLegend: FC<Props> = ({
   questionType,
   hideChoiceIcon,
   optionLabelClassName,
+  onReaffirm,
+  canPredict = false,
 }) => {
   const t = useTranslations();
 
@@ -67,9 +72,41 @@ const MultipleChoiceTileLegend: FC<Props> = ({
           <div className="resize-label whitespace-nowrap px-1.5 py-0.5 text-left text-sm font-medium leading-4">
             {t("otherWithCount", { count: otherItemsCount })}
           </div>
+          {canPredict && !!onReaffirm && (
+            <ReaffirmButton onReaffirm={onReaffirm} combined />
+          )}
         </div>
       )}
+      {!otherItemsCount && canPredict && !!onReaffirm && (
+        <ReaffirmButton onReaffirm={onReaffirm} />
+      )}
     </div>
+  );
+};
+
+const ReaffirmButton: FC<{ onReaffirm: () => void; combined?: boolean }> = ({
+  onReaffirm,
+  combined = false,
+}) => {
+  const t = useTranslations();
+
+  return (
+    <button
+      className={cn(
+        "resize-label flex py-0.5 text-left text-sm font-medium leading-4 text-orange-700 underline hover:text-orange-600 dark:text-orange-700 dark:hover:text-orange-600-dark",
+        { lowercase: combined }
+      )}
+      onClick={(e) => {
+        // prevent navigation, e.g. when rendered inside Next.js Link
+        e.stopPropagation();
+        e.nativeEvent.preventDefault();
+        e.nativeEvent.stopImmediatePropagation();
+
+        onReaffirm();
+      }}
+    >
+      {combined ? `(${t("reaffirm")})` : t("reaffirm")}
+    </button>
   );
 };
 

--- a/front_end/src/components/multiple_choice_tile/multiple_choice_tile_legend.tsx
+++ b/front_end/src/components/multiple_choice_tile/multiple_choice_tile_legend.tsx
@@ -3,9 +3,9 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslations } from "next-intl";
 import React, { FC } from "react";
 
+import ReaffirmButton from "@/components/post_card/reaffirm_button";
 import { ChoiceItem } from "@/types/choices";
 import { QuestionType } from "@/types/question";
-import cn from "@/utils/cn";
 
 import ChoiceOption from "./choice_option";
 
@@ -73,40 +73,21 @@ const MultipleChoiceTileLegend: FC<Props> = ({
             {t("otherWithCount", { count: otherItemsCount })}
           </div>
           {canPredict && !!onReaffirm && (
-            <ReaffirmButton onReaffirm={onReaffirm} combined />
+            <ReaffirmButton
+              onClick={onReaffirm}
+              combined
+              className="resize-label flex py-0.5 text-left text-sm font-medium leading-4"
+            />
           )}
         </div>
       )}
       {!otherItemsCount && canPredict && !!onReaffirm && (
-        <ReaffirmButton onReaffirm={onReaffirm} />
+        <ReaffirmButton
+          onClick={onReaffirm}
+          className="resize-label flex py-0.5 text-left text-sm font-medium leading-4"
+        />
       )}
     </div>
-  );
-};
-
-const ReaffirmButton: FC<{ onReaffirm: () => void; combined?: boolean }> = ({
-  onReaffirm,
-  combined = false,
-}) => {
-  const t = useTranslations();
-
-  return (
-    <button
-      className={cn(
-        "resize-label flex py-0.5 text-left text-sm font-medium leading-4 text-orange-700 underline hover:text-orange-600 dark:text-orange-700 dark:hover:text-orange-600-dark",
-        { lowercase: combined }
-      )}
-      onClick={(e) => {
-        // prevent navigation, e.g. when rendered inside Next.js Link
-        e.stopPropagation();
-        e.nativeEvent.preventDefault();
-        e.nativeEvent.stopImmediatePropagation();
-
-        onReaffirm();
-      }}
-    >
-      {combined ? `(${t("reaffirm")})` : t("reaffirm")}
-    </button>
   );
 };
 

--- a/front_end/src/components/news_card.tsx
+++ b/front_end/src/components/news_card.tsx
@@ -7,13 +7,13 @@ import { FC } from "react";
 import MarkdownEditor from "@/components/markdown_editor";
 import CircleDivider from "@/components/ui/circle_divider";
 import useContainerSize from "@/hooks/use_container_size";
-import { PostWithNotebook } from "@/types/post";
+import { NotebookPost } from "@/types/post";
 import { formatDate } from "@/utils/date_formatters";
 import { getPostLink } from "@/utils/navigation";
 import { estimateReadingTime, getMarkdownSummary } from "@/utils/questions";
 
 type Props = {
-  post: PostWithNotebook;
+  post: NotebookPost;
 };
 
 const NewsCard: FC<Props> = ({ post }) => {

--- a/front_end/src/components/post_card/group_of_questions_tile/group_continuous_tile.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/group_continuous_tile.tsx
@@ -7,11 +7,12 @@ import {
   FanGraphMultipleChoiceTile,
 } from "@/components/multiple_choice_tile";
 import { useAuth } from "@/contexts/auth_context";
+import { ForecastPayload } from "@/services/questions";
 import {
   GroupOfQuestionsGraphType,
   TimelineChartZoomOption,
 } from "@/types/charts";
-import { PostWithForecasts } from "@/types/post";
+import { GroupOfQuestionsPost } from "@/types/post";
 import { QuestionType, QuestionWithNumericForecasts } from "@/types/question";
 import {
   generateChoiceItemsFromGroupQuestions,
@@ -19,6 +20,7 @@ import {
   getGroupQuestionsTimestamps,
 } from "@/utils/charts";
 import {
+  canPredictQuestion,
   getGroupForecastAvailability,
   sortGroupPredictionOptions,
 } from "@/utils/questions";
@@ -27,14 +29,19 @@ const CHART_HEIGHT = 100;
 const VISIBLE_CHOICES_COUNT = 3;
 
 type Props = {
-  questions: QuestionWithNumericForecasts[];
-  post: PostWithForecasts;
+  post: GroupOfQuestionsPost<QuestionWithNumericForecasts>;
   hideCP?: boolean;
+  onReaffirm?: (userForecast: ForecastPayload[]) => void;
 };
 
-const GroupContinuousTile: FC<Props> = ({ questions, post, hideCP }) => {
+const GroupContinuousTile: FC<Props> = ({ post, hideCP, onReaffirm }) => {
   const { user } = useAuth();
   const locale = useLocale();
+
+  const {
+    group_of_questions: { questions, graph_type },
+  } = post;
+  const canPredict = canPredictQuestion(post);
 
   const questionType = questions[0]?.type;
   const isBinaryGroup = questionType === QuestionType.Binary;
@@ -44,9 +51,7 @@ const GroupContinuousTile: FC<Props> = ({ questions, post, hideCP }) => {
   );
   const forecastAvailability = getGroupForecastAvailability(questions);
 
-  const groupGraphType = post.group_of_questions?.graph_type;
-
-  switch (groupGraphType) {
+  switch (graph_type) {
     case GroupOfQuestionsGraphType.FanGraph: {
       const sortedFanGraphQuestions = [...questions].sort((a, b) =>
         differenceInMilliseconds(
@@ -67,11 +72,13 @@ const GroupContinuousTile: FC<Props> = ({ questions, post, hideCP }) => {
         <FanGraphMultipleChoiceTile
           choices={choices}
           visibleChoicesCount={VISIBLE_CHOICES_COUNT}
-          questions={questions}
-          questionType={questionType}
+          groupQuestions={questions}
+          groupType={questionType}
           hideCP={hideCP}
           forecastAvailability={forecastAvailability}
           chartHeight={CHART_HEIGHT}
+          onReaffirm={onReaffirm}
+          canPredict={canPredict}
         />
       );
     }
@@ -103,9 +110,12 @@ const GroupContinuousTile: FC<Props> = ({ questions, post, hideCP }) => {
               : TimelineChartZoomOption.TwoMonths
           }
           scaling={scaling}
-          questionType={questionType}
+          groupQuestions={questions}
+          groupType={questionType}
           hideCP={hideCP}
           forecastAvailability={forecastAvailability}
+          onReaffirm={onReaffirm}
+          canPredict={canPredict}
         />
       );
     }

--- a/front_end/src/components/post_card/group_of_questions_tile/group_continuous_tile.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/group_continuous_tile.tsx
@@ -7,7 +7,6 @@ import {
   FanGraphMultipleChoiceTile,
 } from "@/components/multiple_choice_tile";
 import { useAuth } from "@/contexts/auth_context";
-import { ForecastPayload } from "@/services/questions";
 import {
   GroupOfQuestionsGraphType,
   TimelineChartZoomOption,
@@ -31,10 +30,9 @@ const VISIBLE_CHOICES_COUNT = 3;
 type Props = {
   post: GroupOfQuestionsPost<QuestionWithNumericForecasts>;
   hideCP?: boolean;
-  onReaffirm?: (userForecast: ForecastPayload[]) => void;
 };
 
-const GroupContinuousTile: FC<Props> = ({ post, hideCP, onReaffirm }) => {
+const GroupContinuousTile: FC<Props> = ({ post, hideCP }) => {
   const { user } = useAuth();
   const locale = useLocale();
 
@@ -77,7 +75,6 @@ const GroupContinuousTile: FC<Props> = ({ post, hideCP, onReaffirm }) => {
           hideCP={hideCP}
           forecastAvailability={forecastAvailability}
           chartHeight={CHART_HEIGHT}
-          onReaffirm={onReaffirm}
           canPredict={canPredict}
         />
       );
@@ -114,7 +111,6 @@ const GroupContinuousTile: FC<Props> = ({ post, hideCP, onReaffirm }) => {
           groupType={questionType}
           hideCP={hideCP}
           forecastAvailability={forecastAvailability}
-          onReaffirm={onReaffirm}
           canPredict={canPredict}
         />
       );

--- a/front_end/src/components/post_card/group_of_questions_tile/index.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/index.tsx
@@ -2,7 +2,8 @@
 import { useTranslations } from "next-intl";
 import { FC } from "react";
 
-import { PostWithForecasts } from "@/types/post";
+import { ForecastPayload } from "@/services/questions";
+import { GroupOfQuestionsPost } from "@/types/post";
 import {
   QuestionWithForecasts,
   QuestionWithNumericForecasts,
@@ -11,13 +12,16 @@ import {
 import GroupContinuousTile from "./group_continuous_tile";
 
 type Props = {
-  questions: QuestionWithForecasts[];
-  post: PostWithForecasts;
+  post: GroupOfQuestionsPost<QuestionWithForecasts>;
   hideCP?: boolean;
+  onReaffirm?: (userForecast: ForecastPayload[]) => void;
 };
 
-const GroupOfQuestionsTile: FC<Props> = ({ questions, post, hideCP }) => {
+const GroupOfQuestionsTile: FC<Props> = ({ post, hideCP, onReaffirm }) => {
   const t = useTranslations();
+  const {
+    group_of_questions: { questions },
+  } = post;
   const groupType = questions.at(0)?.type;
 
   if (!groupType) {
@@ -26,9 +30,9 @@ const GroupOfQuestionsTile: FC<Props> = ({ questions, post, hideCP }) => {
 
   return (
     <GroupContinuousTile
-      questions={questions as QuestionWithNumericForecasts[]}
-      post={post}
+      post={post as GroupOfQuestionsPost<QuestionWithNumericForecasts>}
       hideCP={hideCP}
+      onReaffirm={onReaffirm}
     />
   );
 };

--- a/front_end/src/components/post_card/group_of_questions_tile/index.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/index.tsx
@@ -2,7 +2,6 @@
 import { useTranslations } from "next-intl";
 import { FC } from "react";
 
-import { ForecastPayload } from "@/services/questions";
 import { GroupOfQuestionsPost } from "@/types/post";
 import {
   QuestionWithForecasts,
@@ -14,10 +13,9 @@ import GroupContinuousTile from "./group_continuous_tile";
 type Props = {
   post: GroupOfQuestionsPost<QuestionWithForecasts>;
   hideCP?: boolean;
-  onReaffirm?: (userForecast: ForecastPayload[]) => void;
 };
 
-const GroupOfQuestionsTile: FC<Props> = ({ post, hideCP, onReaffirm }) => {
+const GroupOfQuestionsTile: FC<Props> = ({ post, hideCP }) => {
   const t = useTranslations();
   const {
     group_of_questions: { questions },
@@ -32,7 +30,6 @@ const GroupOfQuestionsTile: FC<Props> = ({ post, hideCP, onReaffirm }) => {
     <GroupContinuousTile
       post={post as GroupOfQuestionsPost<QuestionWithNumericForecasts>}
       hideCP={hideCP}
-      onReaffirm={onReaffirm}
     />
   );
 };

--- a/front_end/src/components/post_card/index.tsx
+++ b/front_end/src/components/post_card/index.tsx
@@ -1,12 +1,11 @@
 "use client";
-import { FC, useCallback, useState } from "react";
+import { FC, useState } from "react";
 
 import HideCPProvider from "@/app/(main)/questions/[id]/components/cp_provider";
-import { createForecasts, getPost } from "@/app/(main)/questions/actions";
 import ConditionalTile from "@/components/conditional_tile";
 import NotebookTile from "@/components/post_card/notebook_tile";
+import { CardReaffirmContextProvider } from "@/components/post_card/reaffirm_context";
 import { useAuth } from "@/contexts/auth_context";
-import { ForecastPayload } from "@/services/questions";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import {
   canPredictQuestion,
@@ -35,54 +34,42 @@ const PostCard: FC<Props> = ({ post }) => {
 
   const canPredict = canPredictQuestion(internalPost);
 
-  // submit reaffirmed forecast and update the post
-  const handleReaffirm = useCallback(
-    async (userForecast: ForecastPayload[]) => {
-      if (!userForecast.length) {
-        return;
-      }
-
-      await createForecasts(internalPost.id, userForecast, false);
-      const postResponse = await getPost(internalPost.id);
-      setInternalPost(postResponse);
-    },
-    [internalPost.id]
-  );
-
   return (
-    <PostCardErrorBoundary>
-      <BasicPostCard
-        post={internalPost}
-        hideTitle={!!internalPost.conditional}
-        borderVariant={internalPost.notebook ? "highlighted" : "regular"}
-        borderColor={internalPost.notebook ? "purple" : "blue"}
-      >
-        <HideCPProvider post={internalPost}>
-          {isQuestionPost(internalPost) && (
-            <QuestionChartTile
-              question={internalPost.question}
-              authorUsername={post.author_username}
-              curationStatus={post.status}
-              hideCP={hideCP}
-              forecasters={post.nr_forecasters}
-              onReaffirm={handleReaffirm}
-              canPredict={canPredict}
-            />
-          )}
-          {isGroupOfQuestionsPost(internalPost) && (
-            <GroupOfQuestionsTile
-              post={internalPost}
-              hideCP={hideCP}
-              onReaffirm={handleReaffirm}
-            />
-          )}
-          {isConditionalPost(internalPost) && (
-            <ConditionalTile post={internalPost} />
-          )}
-          {isNotebookPost(internalPost) && <NotebookTile post={internalPost} />}
-        </HideCPProvider>
-      </BasicPostCard>
-    </PostCardErrorBoundary>
+    <CardReaffirmContextProvider
+      post={internalPost}
+      onPostChanged={setInternalPost}
+    >
+      <PostCardErrorBoundary>
+        <BasicPostCard
+          post={internalPost}
+          hideTitle={!!internalPost.conditional}
+          borderVariant={internalPost.notebook ? "highlighted" : "regular"}
+          borderColor={internalPost.notebook ? "purple" : "blue"}
+        >
+          <HideCPProvider post={internalPost}>
+            {isQuestionPost(internalPost) && (
+              <QuestionChartTile
+                question={internalPost.question}
+                authorUsername={post.author_username}
+                curationStatus={post.status}
+                hideCP={hideCP}
+                forecasters={post.nr_forecasters}
+                canPredict={canPredict}
+              />
+            )}
+            {isGroupOfQuestionsPost(internalPost) && (
+              <GroupOfQuestionsTile post={internalPost} hideCP={hideCP} />
+            )}
+            {isConditionalPost(internalPost) && (
+              <ConditionalTile post={internalPost} />
+            )}
+            {isNotebookPost(internalPost) && (
+              <NotebookTile post={internalPost} />
+            )}
+          </HideCPProvider>
+        </BasicPostCard>
+      </PostCardErrorBoundary>
+    </CardReaffirmContextProvider>
   );
 };
 

--- a/front_end/src/components/post_card/notebook_tile.tsx
+++ b/front_end/src/components/post_card/notebook_tile.tsx
@@ -4,15 +4,17 @@ import { FC } from "react";
 
 import MarkdownEditor from "@/components/markdown_editor";
 import useContainerSize from "@/hooks/use_container_size";
-import { Notebook } from "@/types/post";
+import { NotebookPost } from "@/types/post";
 import { getMarkdownSummary } from "@/utils/questions";
 
 type Props = {
-  notebook: Notebook;
+  post: NotebookPost;
 };
 
-const NotebookTile: FC<Props> = ({ notebook }) => {
+const NotebookTile: FC<Props> = ({ post }) => {
   const { ref, width } = useContainerSize<HTMLDivElement>();
+
+  const { notebook } = post;
 
   return (
     <div ref={ref} className="flex gap-4">

--- a/front_end/src/components/post_card/question_chart_tile/index.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/index.tsx
@@ -5,6 +5,7 @@ import { FC } from "react";
 
 import { ContinuousMultipleChoiceTile } from "@/components/multiple_choice_tile";
 import { useAuth } from "@/contexts/auth_context";
+import { ForecastPayload } from "@/services/questions";
 import { TimelineChartZoomOption } from "@/types/charts";
 import { PostStatus, QuestionStatus } from "@/types/post";
 import { QuestionType, QuestionWithForecasts } from "@/types/question";
@@ -16,23 +17,30 @@ import {
 
 import QuestionNumericTile from "./question_numeric_tile";
 
+// TODO: refactor this component to expect QuestionPost
+// requires refactoring conditional form
 type Props = {
   question: QuestionWithForecasts;
   authorUsername: string;
   curationStatus: PostStatus | QuestionStatus;
   hideCP?: boolean;
   forecasters?: number;
+  canPredict?: boolean;
+  onReaffirm?: (userForecast: ForecastPayload[]) => void;
 };
 
 const QuestionChartTile: FC<Props> = ({
   question,
-  authorUsername,
   curationStatus,
+  authorUsername,
   hideCP,
   forecasters,
+  canPredict,
+  onReaffirm,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
+
   const forecastAvailability = getQuestionForecastAvailability(question);
 
   if (curationStatus === PostStatus.PENDING) {
@@ -68,6 +76,8 @@ const QuestionChartTile: FC<Props> = ({
           hideCP={hideCP}
           forecastAvailability={forecastAvailability}
           forecasters={forecasters}
+          onReaffirm={onReaffirm}
+          canPredict={canPredict}
         />
       );
     case QuestionType.MultipleChoice: {
@@ -101,6 +111,8 @@ const QuestionChartTile: FC<Props> = ({
           actualCloseTime={actualCloseTime}
           openTime={openTime}
           forecastAvailability={forecastAvailability}
+          onReaffirm={onReaffirm}
+          canPredict={canPredict}
         />
       );
     }

--- a/front_end/src/components/post_card/question_chart_tile/index.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/index.tsx
@@ -5,7 +5,6 @@ import { FC } from "react";
 
 import { ContinuousMultipleChoiceTile } from "@/components/multiple_choice_tile";
 import { useAuth } from "@/contexts/auth_context";
-import { ForecastPayload } from "@/services/questions";
 import { TimelineChartZoomOption } from "@/types/charts";
 import { PostStatus, QuestionStatus } from "@/types/post";
 import { QuestionType, QuestionWithForecasts } from "@/types/question";
@@ -26,7 +25,6 @@ type Props = {
   hideCP?: boolean;
   forecasters?: number;
   canPredict?: boolean;
-  onReaffirm?: (userForecast: ForecastPayload[]) => void;
 };
 
 const QuestionChartTile: FC<Props> = ({
@@ -36,7 +34,6 @@ const QuestionChartTile: FC<Props> = ({
   hideCP,
   forecasters,
   canPredict,
-  onReaffirm,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -76,7 +73,6 @@ const QuestionChartTile: FC<Props> = ({
           hideCP={hideCP}
           forecastAvailability={forecastAvailability}
           forecasters={forecasters}
-          onReaffirm={onReaffirm}
           canPredict={canPredict}
         />
       );
@@ -111,7 +107,6 @@ const QuestionChartTile: FC<Props> = ({
           actualCloseTime={actualCloseTime}
           openTime={openTime}
           forecastAvailability={forecastAvailability}
-          onReaffirm={onReaffirm}
           canPredict={canPredict}
         />
       );

--- a/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
@@ -6,8 +6,8 @@ import ForecastersCounter from "@/app/(main)/questions/components/forecaster_cou
 import ContinuousAreaChart from "@/components/charts/continuous_area_chart";
 import NumericChart from "@/components/charts/numeric_chart";
 import ForecastAvailabilityChartOverflow from "@/components/post_card/chart_overflow";
+import useCardReaffirmContext from "@/components/post_card/reaffirm_context";
 import PredictionChip from "@/components/prediction_chip";
-import { ForecastPayload } from "@/services/questions";
 import { ContinuousAreaType, TimelineChartZoomOption } from "@/types/charts";
 import { PostStatus, QuestionStatus } from "@/types/post";
 import {
@@ -34,7 +34,6 @@ type Props = {
   hideCP?: boolean;
   forecasters?: number;
   forecastAvailability: ForecastAvailability;
-  onReaffirm?: (userForecast: ForecastPayload[]) => void;
   canPredict?: boolean;
 };
 
@@ -45,9 +44,10 @@ const QuestionNumericTile: FC<Props> = ({
   hideCP,
   forecasters,
   forecastAvailability,
-  onReaffirm,
   canPredict,
 }) => {
+  const { onReaffirm } = useCardReaffirmContext();
+
   const latest = question.aggregations.recency_weighted.latest;
   const prediction = latest?.centers?.[0];
 

--- a/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
@@ -1,18 +1,28 @@
-import React, { FC } from "react";
+import { isNil, round } from "lodash";
+import React, { FC, useCallback } from "react";
 
+import { BINARY_FORECAST_PRECISION } from "@/app/(main)/questions/[id]/components/forecast_maker/binary_slider";
 import ForecastersCounter from "@/app/(main)/questions/components/forecaster_counter";
 import ContinuousAreaChart from "@/components/charts/continuous_area_chart";
 import NumericChart from "@/components/charts/numeric_chart";
 import ForecastAvailabilityChartOverflow from "@/components/post_card/chart_overflow";
 import PredictionChip from "@/components/prediction_chip";
+import { ForecastPayload } from "@/services/questions";
 import { ContinuousAreaType, TimelineChartZoomOption } from "@/types/charts";
 import { PostStatus, QuestionStatus } from "@/types/post";
 import {
-  QuestionWithNumericForecasts,
-  QuestionType,
   ForecastAvailability,
+  QuestionType,
+  QuestionWithNumericForecasts,
+  UserForecast,
 } from "@/types/question";
 import { getContinuousChartTypeFromQuestion } from "@/utils/charts";
+import {
+  extractPrevBinaryForecastValue,
+  extractPrevNumericForecastValue,
+  getNormalizedContinuousWeight,
+  getNumericForecastDataset,
+} from "@/utils/forecasts";
 import { cdfToPmf } from "@/utils/math";
 
 const HEIGHT = 100;
@@ -24,6 +34,8 @@ type Props = {
   hideCP?: boolean;
   forecasters?: number;
   forecastAvailability: ForecastAvailability;
+  onReaffirm?: (userForecast: ForecastPayload[]) => void;
+  canPredict?: boolean;
 };
 
 const QuestionNumericTile: FC<Props> = ({
@@ -33,6 +45,8 @@ const QuestionNumericTile: FC<Props> = ({
   hideCP,
   forecasters,
   forecastAvailability,
+  onReaffirm,
+  canPredict,
 }) => {
   const latest = question.aggregations.recency_weighted.latest;
   const prediction = latest?.centers?.[0];
@@ -55,6 +69,88 @@ const QuestionNumericTile: FC<Props> = ({
     });
   }
 
+  // generate data to submit based on user forecast and question type
+  const handleReaffirmClick = useCallback(
+    (userForecast: UserForecast) => {
+      if (!onReaffirm) return;
+
+      switch (question.type) {
+        case QuestionType.Binary: {
+          const prevForecastValue = extractPrevBinaryForecastValue(
+            userForecast.forecast_values[1]
+          );
+          if (isNil(prevForecastValue)) {
+            return;
+          }
+
+          const forecastValue = round(
+            prevForecastValue / 100,
+            BINARY_FORECAST_PRECISION
+          );
+
+          onReaffirm([
+            {
+              questionId: question.id,
+              forecastData: {
+                continuousCdf: null,
+                probabilityYes: forecastValue,
+                probabilityYesPerCategory: null,
+              },
+            },
+          ]);
+          break;
+        }
+        case QuestionType.Numeric:
+        case QuestionType.Date: {
+          const activeForecast = isNil(userForecast.end_time)
+            ? userForecast
+            : undefined;
+          const activeForecastSliderValues = activeForecast
+            ? extractPrevNumericForecastValue(activeForecast.slider_values)
+            : {};
+          const forecast = activeForecastSliderValues?.forecast;
+          const weights = getNormalizedContinuousWeight(
+            activeForecastSliderValues?.weights
+          );
+          if (!forecast) {
+            return;
+          }
+
+          const dataset = getNumericForecastDataset(
+            forecast,
+            weights ?? [1],
+            question.open_lower_bound,
+            question.open_upper_bound
+          );
+          const userCdf = dataset.cdf;
+
+          onReaffirm([
+            {
+              questionId: question.id,
+              forecastData: {
+                continuousCdf: userCdf,
+                probabilityYes: null,
+                probabilityYesPerCategory: null,
+              },
+              sliderValues: {
+                forecast: forecast,
+                weights: weights,
+              },
+            },
+          ]);
+          break;
+        }
+      }
+    },
+    [
+      onReaffirm,
+      question.id,
+      question.open_lower_bound,
+      question.open_upper_bound,
+      question.type,
+    ]
+  );
+
   return (
     <div className="flex justify-between">
       <div className="mr-3 inline-flex flex-col justify-center gap-0.5 text-xs font-semibold text-gray-600 dark:text-gray-600-dark xs:max-w-[650px]">
@@ -64,6 +160,8 @@ const QuestionNumericTile: FC<Props> = ({
           status={curationStatus as PostStatus}
           showUserForecast
           hideCP={hideCP}
+          onReaffirm={onReaffirm ? handleReaffirmClick : undefined}
+          canPredict={canPredict}
         />
 
         <ForecastersCounter forecasters={forecasters} className="p-1" />

--- a/front_end/src/components/post_card/reaffirm_button.tsx
+++ b/front_end/src/components/post_card/reaffirm_button.tsx
@@ -1,0 +1,54 @@
+import { faCircleCheck } from "@fortawesome/free-regular-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useTranslations } from "next-intl";
+import { FC, MouseEventHandler } from "react";
+
+import useCardReaffirmContext from "@/components/post_card/reaffirm_context";
+import LoadingSpinner from "@/components/ui/loading_spiner";
+import cn from "@/utils/cn";
+
+type Props = {
+  onClick: MouseEventHandler<HTMLButtonElement>;
+  combined?: boolean;
+  className?: string;
+};
+
+const ReaffirmButton: FC<Props> = ({ onClick, combined, className }) => {
+  const t = useTranslations();
+  const { reaffirmStatus } = useCardReaffirmContext();
+
+  const ReaffirmElement = (
+    <span
+      className={cn("inline-flex items-center gap-1 underline", {
+        lowercase: combined,
+      })}
+    >
+      {t("reaffirm")}
+      {reaffirmStatus === "loading" && <LoadingSpinner size="sm" />}
+      {reaffirmStatus === "completed" && (
+        <FontAwesomeIcon icon={faCircleCheck} size="sm" />
+      )}
+    </span>
+  );
+
+  return (
+    <button
+      className={cn(
+        "text-orange-800 hover:text-orange-600 dark:text-orange-800-dark dark:hover:text-orange-600-dark",
+        className
+      )}
+      onClick={(e) => {
+        // prevent navigation, e.g. when rendered inside Next.js Link
+        e.stopPropagation();
+        e.nativeEvent.preventDefault();
+        e.nativeEvent.stopImmediatePropagation();
+
+        onClick(e);
+      }}
+    >
+      {combined ? <>({ReaffirmElement})</> : ReaffirmElement}
+    </button>
+  );
+};
+
+export default ReaffirmButton;

--- a/front_end/src/components/post_card/reaffirm_context.tsx
+++ b/front_end/src/components/post_card/reaffirm_context.tsx
@@ -1,0 +1,62 @@
+"use client";
+import {
+  createContext,
+  FC,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+
+import { createForecasts, getPost } from "@/app/(main)/questions/actions";
+import { ForecastPayload } from "@/services/questions";
+import { PostWithForecasts } from "@/types/post";
+
+export type ReaffirmStatus = "idle" | "loading" | "completed";
+
+type CardReaffirmContext = {
+  reaffirmStatus?: ReaffirmStatus;
+  onReaffirm?: (userForecast: ForecastPayload[]) => void;
+};
+
+const CardReaffirmContext = createContext({} as CardReaffirmContext);
+
+type ProviderProps = {
+  post: PostWithForecasts;
+  onPostChanged: (post: PostWithForecasts) => void;
+};
+
+export const CardReaffirmContextProvider: FC<
+  PropsWithChildren<ProviderProps>
+> = ({ post, onPostChanged, children }) => {
+  const [status, setStatus] = useState<ReaffirmStatus>("idle");
+
+  // submit reaffirmed forecast and update the post
+  const handleReaffirm = useCallback(
+    async (userForecast: ForecastPayload[]) => {
+      setStatus("idle");
+      if (!userForecast.length) {
+        return;
+      }
+
+      setStatus("loading");
+      await createForecasts(post.id, userForecast, false);
+      const postResponse = await getPost(post.id);
+      onPostChanged(postResponse);
+      setStatus("completed");
+    },
+    [onPostChanged, post.id]
+  );
+
+  return (
+    <CardReaffirmContext.Provider
+      value={{ reaffirmStatus: status, onReaffirm: handleReaffirm }}
+    >
+      {children}
+    </CardReaffirmContext.Provider>
+  );
+};
+
+export default function useCardReaffirmContext(): CardReaffirmContext {
+  return useContext(CardReaffirmContext);
+}

--- a/front_end/src/components/posts_feed/paginated_feed.tsx
+++ b/front_end/src/components/posts_feed/paginated_feed.tsx
@@ -14,7 +14,7 @@ import LoadingIndicator from "@/components/ui/loading_indicator";
 import { POSTS_PER_PAGE, POST_PAGE_FILTER } from "@/constants/posts_feed";
 import useSearchParams from "@/hooks/use_search_params";
 import { PostsParams } from "@/services/posts";
-import { PostWithForecasts, PostWithNotebook } from "@/types/post";
+import { PostWithForecasts, NotebookPost } from "@/types/post";
 import { logError } from "@/utils/errors";
 
 import { SCROLL_CACHE_KEY } from "./constants";
@@ -127,7 +127,7 @@ const PaginatedPostsFeed: FC<Props> = ({
 
   const renderPost = (post: PostWithForecasts) => {
     if (type === "news" && post.notebook) {
-      return <NewsCard post={post as PostWithNotebook} />;
+      return <NewsCard post={post as NotebookPost} />;
     }
 
     return <PostCard post={post} />;

--- a/front_end/src/components/prediction_chip.tsx
+++ b/front_end/src/components/prediction_chip.tsx
@@ -6,7 +6,7 @@ import { CSSProperties, FC, PropsWithChildren } from "react";
 
 import CPWeeklyMovement from "@/components/cp_weekly_movement";
 import { PostStatus } from "@/types/post";
-import { QuestionWithForecasts } from "@/types/question";
+import { QuestionWithForecasts, UserForecast } from "@/types/question";
 import { getDisplayValue } from "@/utils/charts";
 import cn from "@/utils/cn";
 import { formatResolution, isUnsuccessfullyResolved } from "@/utils/questions";
@@ -22,6 +22,8 @@ type Props = {
   chipClassName?: string;
   unresovledChipStyle?: CSSProperties;
   showUserForecast?: boolean;
+  onReaffirm?: (userForecast: UserForecast) => void;
+  canPredict?: boolean;
   hideCP?: boolean;
   compact?: boolean;
 };
@@ -35,6 +37,8 @@ const PredictionChip: FC<Props> = ({
   unresovledChipStyle,
   size,
   showUserForecast,
+  onReaffirm,
+  canPredict = false,
   hideCP,
   compact,
 }) => {
@@ -62,7 +66,22 @@ const PredictionChip: FC<Props> = ({
       return (
         <p className="m-2 text-orange-800 dark:text-orange-800-dark">
           <FontAwesomeIcon icon={faUser} className="mr-1" />
-          {displayValue}
+          {displayValue}{" "}
+          {!!onReaffirm && canPredict && (
+            <button
+              className="lowercase underline hover:text-orange-600 dark:hover:text-orange-600-dark"
+              onClick={(e) => {
+                // prevent navigation, e.g. when rendered inside Next.js Link
+                e.stopPropagation();
+                e.nativeEvent.preventDefault();
+                e.nativeEvent.stopImmediatePropagation();
+
+                onReaffirm(latest);
+              }}
+            >
+              ({t("reaffirm")})
+            </button>
+          )}
         </p>
       );
     }

--- a/front_end/src/components/prediction_chip.tsx
+++ b/front_end/src/components/prediction_chip.tsx
@@ -5,6 +5,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { CSSProperties, FC, PropsWithChildren } from "react";
 
 import CPWeeklyMovement from "@/components/cp_weekly_movement";
+import ReaffirmButton from "@/components/post_card/reaffirm_button";
 import { PostStatus } from "@/types/post";
 import { QuestionWithForecasts, UserForecast } from "@/types/question";
 import { getDisplayValue } from "@/utils/charts";
@@ -68,19 +69,12 @@ const PredictionChip: FC<Props> = ({
           <FontAwesomeIcon icon={faUser} className="mr-1" />
           {displayValue}{" "}
           {!!onReaffirm && canPredict && (
-            <button
-              className="lowercase underline hover:text-orange-600 dark:hover:text-orange-600-dark"
-              onClick={(e) => {
-                // prevent navigation, e.g. when rendered inside Next.js Link
-                e.stopPropagation();
-                e.nativeEvent.preventDefault();
-                e.nativeEvent.stopImmediatePropagation();
-
+            <ReaffirmButton
+              onClick={() => {
                 onReaffirm(latest);
               }}
-            >
-              ({t("reaffirm")})
-            </button>
+              combined
+            />
           )}
         </p>
       );

--- a/front_end/src/services/posts.ts
+++ b/front_end/src/services/posts.ts
@@ -10,7 +10,7 @@ import {
   Post,
   PostSubscription,
   PostWithForecasts,
-  PostWithNotebook,
+  NotebookPost,
 } from "@/types/post";
 import { QuestionWithForecasts } from "@/types/question";
 import { Require } from "@/types/utils";
@@ -127,7 +127,7 @@ class PostsApi {
   }
 
   static async getPostsForHomepage(): Promise<
-    (PostWithForecasts | PostWithNotebook)[]
+    (PostWithForecasts | NotebookPost)[]
   > {
     return await get(`/posts/homepage/`, {
       next: {
@@ -137,13 +137,13 @@ class PostsApi {
   }
 
   static async createQuestionPost<
-    T extends PostWithForecasts | PostWithNotebook,
+    T extends PostWithForecasts | NotebookPost,
     B,
   >(body: B): Promise<T> {
     return await post(`/posts/create/`, body);
   }
 
-  static async updatePost<T extends PostWithForecasts | PostWithNotebook, B>(
+  static async updatePost<T extends PostWithForecasts | NotebookPost, B>(
     id: number,
     body: B
   ): Promise<T> {

--- a/front_end/src/types/post.ts
+++ b/front_end/src/types/post.ts
@@ -154,7 +154,16 @@ export type Post<QT = Question> = {
   key_factors?: KeyFactor[];
 };
 
-export type PostWithNotebook = Omit<Post, "notebook"> & {
+export type QuestionPost<QT = Question> = Post<QT> & {
+  question: QT;
+};
+export type ConditionalPost<QT = Question> = Post<QT> & {
+  conditional: PostConditional<QT>;
+};
+export type GroupOfQuestionsPost<QT = Question> = Post<QT> & {
+  group_of_questions: PostGroupOfQuestions<QT>;
+};
+export type NotebookPost = Omit<Post, "notebook"> & {
   notebook: Notebook;
 };
 

--- a/front_end/src/utils/forecasts.ts
+++ b/front_end/src/utils/forecasts.ts
@@ -140,3 +140,18 @@ export function generateCurveChoiceOptions(
       return 0;
     });
 }
+
+export const getNormalizedContinuousForecast = (
+  forecast: MultiSliderValue[] | null | undefined
+): MultiSliderValue[] =>
+  forecast ?? [
+    {
+      left: 0.4,
+      center: 0.5,
+      right: 0.6,
+    },
+  ];
+
+export const getNormalizedContinuousWeight = (
+  weights: number[] | null | undefined
+): number[] => weights ?? [1];


### PR DESCRIPTION
Related to #1348

Done:
- reaffirm binary, numeric, date questions
- reaffirm MC questions
- reaffirm group questions
- unified the logic for allowing predictions based on post type
- added a basic setup for more unified props managing based on post type

TODO

- ~~reaffirm conditional questions (requires design)~~
  - we decided not to add reaffirm button to conditionals: https://github.com/Metaculus/metaculus/pull/1845#issuecomment-2577308525