### PR TITLE
include closed posts by default

### DIFF
--- a/front_end/src/app/(main)/questions/helpers/filters.ts
+++ b/front_end/src/app/(main)/questions/helpers/filters.ts
@@ -152,7 +152,11 @@ export function generateFiltersFromSearchParams(
     filters.order_by = defaultOrderBy;
 
     if (!filters.statuses && !filters.search) {
-      filters.statuses = [PostStatus.OPEN, PostStatus.RESOLVED];
+      filters.statuses = [
+        PostStatus.OPEN,
+        PostStatus.CLOSED,
+        PostStatus.RESOLVED,
+      ];
     }
   }
 


### PR DESCRIPTION
closes #1846 

Turns out the default filters only included open and resolved posts