### PR TITLE
Fixed question resolution empty string values

### DIFF
--- a/questions/models.py
+++ b/questions/models.py
@@ -122,6 +122,13 @@ class Question(TimeStampedModel, TranslatedModel):  # type: ignore
     def __str__(self):
         return f"{self.type} {self.title}"
 
+    def save(self, **kwargs):
+        # Ensure resolution is always null or non-empty string
+        if self.resolution is not None and self.resolution.strip() == "":
+            self.resolution = None
+
+        return super().save(**kwargs)
+
     def get_post(self) -> "Post | None":
         posts = [x.post for x in self.related_posts.all()]
 


### PR DESCRIPTION
### Issue

Our backend uses a strict `resolution is None` check to determine if a post is resolved. However, in some cases, while editing questions in the admin panel, the nullable `resolution` field was being set to an empty string (`""`) instead of `None`. This caused the `resolved = resolution is not None` condition to incorrectly mark some posts as resolved.

### Fix

This PR introduces an extra step in the `Question.save` method to convert empty strings (`""`) in the `resolution` field back to `None`.
