### PR TITLE
Updated BW sidebar link, fixed Notice page spacing

### DIFF
--- a/front_end/src/app/(campaigns-registration)/bridgewater/notice-at-collection/page.tsx
+++ b/front_end/src/app/(campaigns-registration)/bridgewater/notice-at-collection/page.tsx
@@ -13,7 +13,7 @@ export default function NoticeAtCollection() {
   return (
     <>
       <Header />
-      <div className="mx-auto flex w-full justify-center pb-0 pt-10">
+      <div className="mx-auto mt-12 flex w-full justify-center pb-0 pt-10">
         {" "}
         <Button
           variant="secondary"

--- a/front_end/src/app/(main)/questions/components/question_topics.tsx
+++ b/front_end/src/app/(main)/questions/components/question_topics.tsx
@@ -174,7 +174,7 @@ const QuestionTopics: FC<Props> = ({ topics }) => {
             isActive={false}
             emoji="🔭"
             text="Bridgewater 2025"
-            href="/bridgewater/register/"
+            href="/bridgewater/"
             onClick={() =>
               sendGAEvent("event", "sidebarClick", {
                 event_category: "Bridgewater 2025",


### PR DESCRIPTION
Quick fix for:

- Updating sidebar link from "/bridgewater/register/" to "/bridgewater/"
- Adding a spacer to the Notice at Collection page so the button does not get cut off