### PR TITLE
No information displayed below the graph in some questions

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/continuous_chart_card.tsx
@@ -55,7 +55,6 @@ const DetailedContinuousChartCard: FC<Props> = ({
     if (
       timestamp === null &&
       question.my_forecasts?.latest?.start_time &&
-      !question.my_forecasts?.latest?.end_time &&
       forecast &&
       forecast.start_time < question.my_forecasts.latest.start_time
     ) {

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -1300,7 +1300,7 @@ export function getCursorForecast(
         f.start_time <= cursorTimestamp &&
         (f.end_time === null || f.end_time > cursorTimestamp)
     );
-  } else if (cursorTimestamp === null && isNil(aggregation.latest?.end_time)) {
+  } else if (cursorTimestamp === null) {
     forecastIndex = aggregation.history.length - 1;
   }
   return forecastIndex === -1


### PR DESCRIPTION
Related to #1870

- fixed cursor data was missing for particular questions

<img width="782" alt="image" src="https://github.com/user-attachments/assets/75f93b05-f926-423f-b058-693d7364b2b1" />
