### PR TITLE
Multiple choice tiles look wrong on mobile

### DIFF
--- a/front_end/src/components/multiple_choice_tile/index.tsx
+++ b/front_end/src/components/multiple_choice_tile/index.tsx
@@ -82,7 +82,7 @@ export const ContinuousMultipleChoiceTile: FC<
         )}
       </div>
       {!isResolvedView && (
-        <div className="relative">
+        <div className="relative w-full">
           <MultipleChoiceChart
             timestamps={timestamps}
             actualCloseTime={actualCloseTime}
@@ -137,7 +137,7 @@ export const FanGraphMultipleChoiceTile: FC<
           optionLabelClassName="text-olive-800 dark:text-olive-800-dark"
         />
       </div>
-      <div>
+      <div className="w-full">
         <FanGraphGroupChart
           questions={questions}
           height={chartHeight}


### PR DESCRIPTION
Related to #1855

- fixed zero graph width for group tiles on mobile screens

<img width="383" alt="image" src="https://github.com/user-attachments/assets/6c7aeb1f-bf5b-4fdd-ac9e-2f25441f0459" />

<img width="374" alt="image" src="https://github.com/user-attachments/assets/dbf6b89b-98b7-4d84-b93b-df4bb3812973" />
