### PR TITLE
add remake aggregations to admin actions for posts and questions, als…

### DIFF
--- a/questions/admin.py
+++ b/questions/admin.py
@@ -12,6 +12,7 @@ from questions.models import (
     GroupOfQuestions,
     Forecast,
 )
+from questions.services import build_question_forecasts
 from utils.csv_utils import export_data_for_questions
 from utils.models import CustomTranslationAdmin
 
@@ -29,7 +30,7 @@ class QuestionAdmin(CustomTranslationAdmin, DynamicArrayMixin):
     ]
     readonly_fields = ["post_link"]
     search_fields = ["title_original", "description_original"]
-    actions = ["export_selected_questions_data"]
+    actions = ["export_selected_questions_data", "rebuild_aggregation_history"]
     list_filter = [
         "type",
         "related_posts__post__curation_status",
@@ -93,6 +94,10 @@ class QuestionAdmin(CustomTranslationAdmin, DynamicArrayMixin):
         response["Content-Disposition"] = 'attachment; filename="metaculus_data.zip"'
 
         return response
+
+    def rebuild_aggregation_history(self, request, queryset: QuerySet[Question]):
+        for question in queryset:
+            build_question_forecasts(question)
 
 
 @admin.register(Conditional)


### PR DESCRIPTION
Hopeful fix to #1870

This creates a manual solution to an erroneous aggregation summary state by adding a "recalcualte aggregations" for both questions and posts in the admin panel.

This also hopefully solves what I suspect to be the culprit by adding the entire aggregation history overwriting to the updating atomic transaction in `build_question_forecasts`.