### PR TITLE
aggregation explorer missing from mobile menu

### DIFF
--- a/front_end/src/app/(main)/components/mobile_menu.tsx
+++ b/front_end/src/app/(main)/components/mobile_menu.tsx
@@ -237,6 +237,9 @@ const MobileMenu: FC<Props> = ({ community, onClick }) => {
                 {t("trackRecord")}
               </MenuLink>
               <MenuLink href={`/project/journal/`}>{t("theJournal")}</MenuLink>
+              <MenuLink href="/aggregation-explorer">
+                {t("aggregationExplorer")}
+              </MenuLink>
               <MenuLink href={`/questions/create/`}>+ {t("create")}</MenuLink>
               <SectionTitle>{t("account")}</SectionTitle>
               {user ? (


### PR DESCRIPTION
Related to #1897