### PR TITLE
Fixed header links misclicks

### DIFF
--- a/front_end/src/app/(main)/components/headers/community_header.tsx
+++ b/front_end/src/app/(main)/components/headers/community_header.tsx
@@ -27,7 +27,7 @@ const CommunityHeader: FC<Props> = ({ community, alwaysShowName = true }) => {
   const [localShowName, setLocalShowName] = useState(alwaysShowName);
 
   return (
-    <header className="fixed left-0 top-0 z-50 flex min-h-12 w-full flex-auto flex-wrap items-stretch justify-between border-b border-blue-200-dark bg-blue-900 text-gray-0">
+    <header className="fixed left-0 top-0 z-100 flex min-h-12 w-full flex-auto flex-wrap items-stretch justify-between border-b border-blue-200-dark bg-blue-900 text-gray-0">
       <div className="flex items-center">
         <Link
           href="/questions"

--- a/front_end/src/app/(main)/components/headers/header.tsx
+++ b/front_end/src/app/(main)/components/headers/header.tsx
@@ -42,7 +42,7 @@ const Header: FC = () => {
 
   return (
     <>
-      <header className="fixed left-0 top-0 z-50 flex min-h-12 w-full flex-auto flex-wrap items-stretch justify-between border-b border-blue-200-dark bg-blue-900 text-gray-0">
+      <header className="fixed left-0 top-0 z-100 flex min-h-12 w-full flex-auto flex-wrap items-stretch justify-between border-b border-blue-200-dark bg-blue-900 text-gray-0">
         <Link
           href="/"
           className="inline-flex max-w-60 flex-shrink-0 flex-grow-0 basis-auto flex-col justify-center text-center no-underline"


### PR DESCRIPTION
Fixed z-index of header to be > than graphs:
<img width="1512" alt="image" src#1483 ps://github.com/user-attachments/assets/4c8e3ba3-d616-41c4-b008-77f1ebca7e1d" />

fixes #1483