### PR TITLE
leaderboard contributions: link with post_id not question_id

### DIFF
--- a/front_end/src/app/(main)/(leaderboards)/contributions/components/contributions_table.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/contributions/components/contributions_table.tsx
@@ -230,7 +230,7 @@ const ContributionsTable: FC<Props> = ({
               {["peer", "baseline"].includes(category) && (
                 <Link
                   className="no-underline"
-                  href={`/questions/${contribution?.question_id}`}
+                  href={`/questions/${contribution?.post_id}`}
                 >
                   {contribution?.question_title}
                 </Link>


### PR DESCRIPTION
for questions created since the new app rewrite, question_id != post_id and any link to one such question in the leaderboard would 404 (as the url structure takes a post_id)

as far as I can tell, this is all the fix that is needed to resolve #1916, but I'm not sure how to generate leaderboard data to test it.

It looks like this is sufficient because the Contribution type includes post_id (optionally):

https://github.com/Metaculus/metaculus/blob/main/front_end/src/types/scoring.ts#L118

and because the view looks like it is returning it already:

https://github.com/Metaculus/metaculus/blob/878de5f628f4ff273acae9e6efd994180831d220/scoring/views.py#L189
https://github.com/Metaculus/metaculus/blob/878de5f628f4ff273acae9e6efd994180831d220/scoring/utils.py#L634-L638
https://github.com/Metaculus/metaculus/blob/878de5f628f4ff273acae9e6efd994180831d220/scoring/utils.py#L678
https://github.com/Metaculus/metaculus/blob/main/scoring/serializers.py#L78