### PR TITLE
LATEX formatting is applied to regular comments

### DIFF
--- a/front_end/src/components/markdown_editor/helpers.ts
+++ b/front_end/src/components/markdown_editor/helpers.ts
@@ -103,14 +103,11 @@ export const escapeRawDollarSigns = (markdown: string): string => {
   });
 
   // replace valid inline math with placeholders
-  processedMarkdown = processedMarkdown.replace(
-    inlineMathRegex,
-    (match, contentInside) => {
-      const placeholder = `{{MATH_INLINE_${placeholderIndex++}}}`;
-      placeholders.set(placeholder, match); // Save the valid inline math as is
-      return placeholder;
-    }
-  );
+  processedMarkdown = processedMarkdown.replace(inlineMathRegex, (match) => {
+    const placeholder = `{{MATH_INLINE_${placeholderIndex++}}}`;
+    placeholders.set(placeholder, match); // Save the valid inline math as is
+    return placeholder;
+  });
 
   // escape remaining dollar signs that are not part of valid math
   processedMarkdown = processedMarkdown.replace(/(?<!\\)\$/g, "\\$");

--- a/front_end/src/components/markdown_editor/plugins/equation/components/equation_component.tsx
+++ b/front_end/src/components/markdown_editor/plugins/equation/components/equation_component.tsx
@@ -55,6 +55,7 @@ const EquationComponent: FC<EquationComponentProps> = ({
   const onHide = useCallback(
     (restoreSelection?: boolean) => {
       setShowEquationEditor(false);
+      setEquationValue((prev) => prev.trim());
       parentEditor.update(() => {
         const node = $getNodeByKey(nodeKey);
         if ($isEquationNode(node)) {
@@ -69,8 +70,12 @@ const EquationComponent: FC<EquationComponentProps> = ({
   );
 
   useEffect(() => {
-    if (!showEquationEditor && equationValue !== equation) {
-      setEquationValue(equation);
+    const normalizedEquationValue = equationValue.trim();
+    const normalizedEquation = equation.trim();
+    const didChange = normalizedEquationValue !== normalizedEquation;
+
+    if (!showEquationEditor && didChange) {
+      setEquationValue(normalizedEquation);
     }
   }, [showEquationEditor, equation, equationValue]);
 


### PR DESCRIPTION
Related to #1933

- applied a workaround to manually escape dollar signs when they are not part of the math expression

**Note:** 

This is only a workaround and I assume it may not handle all the edge cases. I’ve implemented a solution that should cover most scenarios. However, to properly resolve this issue, we need to implement escaping for the dollar sign whenever new content is created. This is already handled by the FE application (specifically, the editor). The issue arises when content is created outside of the app, such as when bots create comments via the API or when comments are created through the Django admin. In these cases, unescaped special characters can lead to problems. This issue isn’t limited to embedded math; any special character needs to be properly escaped. For example, this comment has broken markdown formatting (which is why it’s disabled) because it contains unescaped curly brackets.

Additionally, it would be beneficial to create a migration to escape special characters in existing markdown content. I’m not sure how difficult this would be to implement, but the alternative would be to manually correct the content whenever an issue is identified via the FE editor.