### PR TITLE
Tagging broken for certain username

### DIFF
--- a/comments/utils.py
+++ b/comments/utils.py
@@ -8,7 +8,7 @@ from comments.models import Comment
 from users.models import User
 
 # Regex pattern to find all @<username> mentions
-USERNAME_PATTERN = r"@(?:\(([^)]+)\)|(\w[\w\-_.]+\w))"
+USERNAME_PATTERN = r"@(\([^)]+\)|\w[\w\-_.]+\w)"
 
 
 def comment_extract_user_mentions(
@@ -18,7 +18,10 @@ def comment_extract_user_mentions(
     Extracts mentioned users query
     """
 
-    unique_mentions = {(m[0] or m[1]).lower() for m in re.findall(USERNAME_PATTERN, comment.text, re.UNICODE)}
+    unique_mentions = {
+        m.strip("()").lower()
+        for m in re.findall(USERNAME_PATTERN, comment.text, re.UNICODE)
+    }
 
     if not unique_mentions:
         return User.objects.none(), {}

--- a/comments/utils.py
+++ b/comments/utils.py
@@ -8,7 +8,7 @@ from comments.models import Comment
 from users.models import User
 
 # Regex pattern to find all @<username> mentions
-USERNAME_PATTERN = r"@\(?([\w+\-_.'~#%@]+)\)?"
+USERNAME_PATTERN = r"@(?:\(([^)]+)\)|(\w[\w\-_.]+\w))"
 
 
 def comment_extract_user_mentions(
@@ -18,7 +18,7 @@ def comment_extract_user_mentions(
     Extracts mentioned users query
     """
 
-    unique_mentions = {m.lower() for m in re.findall(USERNAME_PATTERN, comment.text, re.UNICODE)}
+    unique_mentions = {(m[0] or m[1]).lower() for m in re.findall(USERNAME_PATTERN, comment.text, re.UNICODE)}
 
     if not unique_mentions:
         return User.objects.none(), {}

--- a/comments/utils.py
+++ b/comments/utils.py
@@ -8,7 +8,7 @@ from comments.models import Comment
 from users.models import User
 
 # Regex pattern to find all @<username> mentions
-USERNAME_PATTERN = r"@\(?([\w+\-_'~#%@]+(?:\.[\w+\-_'~#%@]+)*)\)?"
+USERNAME_PATTERN = r"@\(?([\w+\-_.'~#%@]+)\)?"
 
 
 def comment_extract_user_mentions(

--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -27,6 +27,7 @@ import { Moderator } from "@/components/icons/moderator";
 import MarkdownEditor from "@/components/markdown_editor";
 import Button from "@/components/ui/button";
 import DropdownMenu, { MenuItemProps } from "@/components/ui/dropdown_menu";
+import { userTagPattern } from "@/constants/comments";
 import { useAuth } from "@/contexts/auth_context";
 import useScrollTo from "@/hooks/use_scroll_to";
 import { CommentType } from "@/types/comment";
@@ -477,10 +478,14 @@ const Comment: FC<CommentProps> = ({
                   // usually, don't expect this, as action is available only for logged-in users
                   return;
                 }
+                const parsedMarkdown = commentMarkdown.replace(
+                  userTagPattern,
+                  (match) => match.replace(/[\\]/g, "")
+                );
 
                 const response = await editComment({
                   id: comment.id,
-                  text: commentMarkdown,
+                  text: parsedMarkdown,
                   author: user.id,
                 });
                 if (response && "errors" in response) {
@@ -499,7 +504,7 @@ const Comment: FC<CommentProps> = ({
                       newCommentDataResponse.errors
                     );
                   } else {
-                    setCommentMarkdown(commentMarkdown);
+                    setCommentMarkdown(parsedMarkdown);
                   }
                   setIsEditing(false);
                 }

--- a/front_end/src/components/comment_feed/comment_editor.tsx
+++ b/front_end/src/components/comment_feed/comment_editor.tsx
@@ -9,6 +9,7 @@ import MarkdownEditor from "@/components/markdown_editor";
 import Button from "@/components/ui/button";
 import Checkbox from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/form_field";
+import { userTagPattern } from "@/constants/comments";
 import { useAuth } from "@/contexts/auth_context";
 import { useModal } from "@/contexts/modal_context";
 import { CommentType } from "@/types/comment";
@@ -69,9 +70,8 @@ const CommentEditor: FC<CommentEditorProps> = ({
     });
 
     try {
-      const userTagPattern = /@(?!\[)(?:\(([^)]+)\)|([^\s(]+)(?!\]))/g;
       const parsedMarkdown = markdown.replace(userTagPattern, (match) =>
-        match.replace(/[()\\]/g, "")
+        match.replace(/[\\]/g, "")
       );
 
       const newComment = await createComment({
@@ -87,6 +87,7 @@ const CommentEditor: FC<CommentEditorProps> = ({
         setErrorMessage(newComment.errors?.message);
         return;
       }
+
       setIsEditing(true);
       setHasIncludedForecast(false);
       setMarkdown("");

--- a/front_end/src/components/markdown_editor/plugins/mentions/LexicalBeautifulMentionVisitor.ts
+++ b/front_end/src/components/markdown_editor/plugins/mentions/LexicalBeautifulMentionVisitor.ts
@@ -14,7 +14,7 @@ export const LexicalBeautifulMentionVisitor: LexicalExportVisitor<
     const value = lexicalNode.getValue();
 
     actions.addAndStepInto("text", {
-      value: `@${value}`,
+      value: `@(${value})`,
     });
   },
 };

--- a/front_end/src/components/markdown_editor/plugins/mentions/components/mention.tsx
+++ b/front_end/src/components/markdown_editor/plugins/mentions/components/mention.tsx
@@ -12,7 +12,7 @@ const CustomMentionComponent = forwardRef<
   return (
     <span className="inline-block">
       <span {...other} ref={ref} className="block">
-        {trigger + value}
+        {trigger}({value})
       </span>
     </span>
   );

--- a/front_end/src/constants/comments.ts
+++ b/front_end/src/constants/comments.ts
@@ -1,0 +1,1 @@
+export const userTagPattern = /@(?!\[)(?:\(([^)]+)\)|([^\s(]+)(?!\]))/g;

--- a/front_end/src/utils/comments.ts
+++ b/front_end/src/utils/comments.ts
@@ -1,3 +1,4 @@
+import { userTagPattern } from "@/constants/comments";
 import { AuthorType, BECommentType, CommentType } from "@/types/comment";
 
 export function parseComment(
@@ -31,9 +32,6 @@ export function parseUserMentions(
   markdown: string,
   mentionedUsers?: AuthorType[]
 ): string {
-  const userTagPattern =
-    /@(\(([^)]+)\)|([\w+\-_'~#%@]+(?:\.[\w+\-_'~#%@]+)*))/gu;
-
   function isInsideSquareBrackets(index: number) {
     let insideBrackets = false;
     for (let i = 0; i < index; i++) {
@@ -49,9 +47,8 @@ export function parseUserMentions(
       if (isInsideSquareBrackets(offset)) {
         return match;
       }
-
       // remove only the leading "@" and clean parentheses around the username
-      let cleanedUsername = (group2 || group3).replace(/^@/, "");
+      let cleanedUsername = match.replace(/^@/, "");
       cleanedUsername = cleanedUsername.replace(/^\(([^)]+)\)$/, "$1");
 
       switch (cleanedUsername.toLowerCase()) {

--- a/tests/unit/test_comments/test_utils.py
+++ b/tests/unit/test_comments/test_utils.py
@@ -1,12 +1,17 @@
 import re
-import pytest
 
 from comments.utils import USERNAME_PATTERN, get_mention_for_user
 from tests.unit.fixtures import *  # noqa
 
 
 @pytest.mark.parametrize(
-    "mention,actual_username", [["@username", "username"], ["@(username)", "username"]]
+    "mention,actual_username",
+    [
+        ["@username", "username"],
+        ["@(username)", "(username)"],
+        ["@username.", "username"],
+        ["@(user name)", "(user name)"],
+    ],
 )
 def test_username_pattern(mention, actual_username):
     assert re.findall(USERNAME_PATTERN, mention)[0] == actual_username

--- a/tests/unit/test_comments/test_utils.py
+++ b/tests/unit/test_comments/test_utils.py
@@ -1,5 +1,7 @@
 import re
 
+import pytest
+
 from comments.utils import USERNAME_PATTERN, get_mention_for_user
 from tests.unit.fixtures import *  # noqa
 

--- a/tests/unit/test_notifications/test_utils.py
+++ b/tests/unit/test_notifications/test_utils.py
@@ -59,7 +59,7 @@ from notifications.utils import generate_email_comment_preview_text
             ),
             "username",
             (
-                "There are many variations of passages @username2 of Lorem Ipsum available, but t..."
+                "There are many variations of passages @username2 of Lorem Ipsum available, but..."
             ),
             False,
         ],


### PR DESCRIPTION
Related to #1604

- wrap user tagging into parentheses
- tested mentions with different user names patterns

**Note:** we'll still need to run BE migration for existing comments and transform mentions into `@()` format. This fix will be applied only for new mentions. 



https://github.com/user-attachments/assets/6ff4d232-a436-4fdb-8c32-e47065715baa

