### PR TITLE
Navbar search missing from question pages

### DIFF
--- a/front_end/src/contexts/global_search_context.tsx
+++ b/front_end/src/contexts/global_search_context.tsx
@@ -13,6 +13,8 @@ import {
 import { POST_TEXT_SEARCH_FILTER } from "@/constants/posts_feed";
 import useSearchInputState from "@/hooks/use_search_input_state";
 
+import { useNavigation } from "./navigation_context";
+
 interface GlobalSearchContextProps {
   isVisible: boolean;
   setIsVisible: (a: boolean) => void;
@@ -39,7 +41,12 @@ export const GlobalSearchProvider: FC<PropsWithChildren> = ({ children }) => {
       modifySearchParams,
     }
   );
-
+  const { previousPath, currentPath } = useNavigation();
+  useEffect(() => {
+    if (previousPath !== currentPath && previousPath !== null) {
+      setIsVisible(false);
+    }
+  }, [previousPath, currentPath]);
   const [delayedIsVisible, setDelayedIsVisible] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
Related to #1985

- investigated the source of the bug – it can be reproduced on any page if the page you navigate from doesn’t render the global search in the header (question feed page, at the top of home page, etc)
- adjusted search state update on page navigation