### PR TITLE
Resend the activation email when inactive users try to login

### DIFF
--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1042,5 +1042,8 @@
   "insertEquation": "Insert Equation",
   "choseEquationType": "Choose the type of equation you want to add. To edit it, simply click on it within the editor.",
   "inline": "Inline",
-  "block": "Block"
+  "block": "Block",
+  "accountInactiveModalTitle": "You've got mail!",
+  "accountInactiveModalBody": "Please confirm your email associated with your <bold>{login}</bold> account to be able to log in.",
+  "accountInactiveModalResendButton": "Resend activation email"
 }

--- a/front_end/src/app/(main)/accounts/actions.ts
+++ b/front_end/src/app/(main)/accounts/actions.ts
@@ -116,3 +116,18 @@ export async function registerUserCampaignAction(
     };
   }
 }
+
+export async function resendActivationEmailAction(
+  login: string,
+  redirectUrl: string
+): Promise<{ errors?: any }> {
+  try {
+    await AuthApi.resendActivationEmail(login, redirectUrl);
+    return { errors: null };
+  } catch (err) {
+    const error = err as FetchError;
+    return {
+      errors: error.data,
+    };
+  }
+}

--- a/front_end/src/components/auth/signin.tsx
+++ b/front_end/src/components/auth/signin.tsx
@@ -30,7 +30,7 @@ const SignInModal: FC<SignInModalType> = ({
   const [isPending, startTransition] = useTransition();
   const { setUser } = useAuth();
   const { setCurrentModal } = useModal();
-  const { register } = useForm<SignInSchema>({
+  const { register, watch } = useForm<SignInSchema>({
     resolver: zodResolver(signInSchema),
   });
   const [state, formAction] = useFormState<LoginActionState, FormData>(
@@ -46,6 +46,18 @@ const SignInModal: FC<SignInModalType> = ({
       sendGAEvent("event", "login");
       setUser(state.user);
       setCurrentModal(null);
+    }
+
+    if (
+      state.errors &&
+      state.errors.user_state &&
+      state.errors.user_state == "inactive"
+    ) {
+      setCurrentModal(null);
+      setCurrentModal({
+        type: "accountInactive",
+        data: { login: watch("login") },
+      });
     }
   }, [setCurrentModal, setUser, state]);
 

--- a/front_end/src/components/auth/signup.tsx
+++ b/front_end/src/components/auth/signup.tsx
@@ -162,6 +162,32 @@ export const SignUpModalSuccess: FC<SignUpModalSuccessProps> = ({
   );
 };
 
+type AccountInactiveModalProps = SignInModalType & {
+  login: string;
+};
+
+export const AccountInactive: FC<AccountInactiveModalProps> = ({
+  isOpen,
+  onClose,
+  login,
+}: AccountInactiveModalProps) => {
+  const t = useTranslations();
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} className="max-w-xs">
+      <h2 className="mb-4	mr-3 mt-0 text-2xl text-blue-900 dark:text-blue-900-dark">
+        {t("accountInactiveModalTitle")}
+      </h2>
+      <p>
+        {t.rich("accountInactiveModalBody", {
+          login,
+          bold: (chunks) => <b>{chunks}</b>,
+        })}
+      </p>
+    </BaseModal>
+  );
+};
+
 const SignUpModal: FC<SignInModalType> = ({
   isOpen,
   onClose,

--- a/front_end/src/components/global_modals.tsx
+++ b/front_end/src/components/global_modals.tsx
@@ -5,7 +5,10 @@ import ResetPasswordModal, {
   ResetPasswordConfirmModal,
 } from "@/components/auth/password_reset";
 import SignInModal from "@/components/auth/signin";
-import SignUpModal, { SignUpModalSuccess } from "@/components/auth/signup";
+import SignUpModal, {
+  AccountInactive,
+  SignUpModalSuccess,
+} from "@/components/auth/signup";
 import OnboardingModal from "@/components/onboarding/onboarding_modal";
 import { useModal } from "@/contexts/modal_context";
 
@@ -25,6 +28,11 @@ const GlobalModals: FC = () => {
         onClose={onClose}
         username={currentModal?.data?.username}
         email={currentModal?.data?.email}
+      />
+      <AccountInactive
+        isOpen={currentModal?.type === "accountInactive"}
+        onClose={onClose}
+        login={currentModal?.data?.login}
       />
       <ResetPasswordModal
         isOpen={currentModal?.type === "resetPassword"}

--- a/front_end/src/contexts/modal_context.tsx
+++ b/front_end/src/contexts/modal_context.tsx
@@ -16,7 +16,8 @@ export type ModalType =
   | "resetPasswordConfirm"
   | "contactUs"
   | "onboarding"
-  | "confirm";
+  | "confirm"
+  | "accountInactive";
 
 export type CurrentModal = {
   type: ModalType;

--- a/front_end/src/services/auth.ts
+++ b/front_end/src/services/auth.ts
@@ -44,6 +44,16 @@ class AuthApi {
     );
   }
 
+  static async resendActivationEmail(login: string, redirect_url: string) {
+    return post<AuthResponse, { login: string; redirect_url: string }>(
+      "/auth/signup/resend/",
+      {
+        login,
+        redirect_url,
+      }
+    );
+  }
+
   static async signIn(login: string, password: string) {
     return post<AuthResponse, { login: string; password: string }>(
       "/auth/login/token/",


### PR DESCRIPTION
This is a somewhat temporary solution to two issues:
- users who didn't activate their account (didn't verify their email by clicking the activation URL) do not get a proper error message from the platform when they try to login.
- if the activation URL expires, users have no way to get another one.

So this shows a proper message to the user when attempting to login before the email has been verified, and also re-sends a new verification email.