### PR TITLE
Continuous closed questions don't show height of user distribution on hover

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_prediction_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_prediction_chart.tsx
@@ -54,13 +54,11 @@ const ContinuousPredictionChart: FC<Props> = ({
     });
     return {
       xLabel,
-      yUserLabel: readOnly
+      yUserLabel: !hoverState.yData.user
         ? null
-        : !hoverState.yData.user
-          ? null
-          : graphType === "pmf"
-            ? (hoverState.yData.user * 200).toFixed(3)
-            : getForecastPctDisplayValue(hoverState.yData.user),
+        : graphType === "pmf"
+          ? (hoverState.yData.user * 200).toFixed(3)
+          : getForecastPctDisplayValue(hoverState.yData.user),
       yUserPreviousLabel: readOnly
         ? null
         : !hoverState.yData.user_previous


### PR DESCRIPTION
Related to #1317

Show user distribution at closed continuous question on hover