### PR TITLE
Small fixes for global leaderboard contributions and tags

### DIFF
--- a/posts/services/common.py
+++ b/posts/services/common.py
@@ -71,8 +71,8 @@ def update_global_leaderboard_tags(post: Post):
     projects: QuerySet[Project] = post.projects.all()
 
     # Skip if post is not eligible for global leaderboards
-    if not post.default_project.type == Project.ProjectTypes.SITE_MAIN and not next(
-        (p for p in projects if p.type == Project.ProjectTypes.SITE_MAIN), None
+    if not post.default_project.visibility == Project.Visibility.NORMAL and not next(
+        (p for p in projects if p.visibility == Project.Visibility.NORMAL), None
     ):
         return
 
@@ -193,14 +193,24 @@ def trigger_update_post_translations(
     if post.conditional_id is not None:
         post.conditional.condition.update_and_maybe_translate(should_translate_if_dirty)
         if hasattr(post.conditional.condition, "post"):
-            post.conditional.condition.post.update_and_maybe_translate(should_translate_if_dirty)
+            post.conditional.condition.post.update_and_maybe_translate(
+                should_translate_if_dirty
+            )
 
-        post.conditional.condition_child.update_and_maybe_translate(should_translate_if_dirty)
+        post.conditional.condition_child.update_and_maybe_translate(
+            should_translate_if_dirty
+        )
         if hasattr(post.conditional.condition_child, "post"):
-            post.conditional.condition_child.post.update_and_maybe_translate(should_translate_if_dirty)
+            post.conditional.condition_child.post.update_and_maybe_translate(
+                should_translate_if_dirty
+            )
 
-        post.conditional.question_yes.update_and_maybe_translate(should_translate_if_dirty)
-        post.conditional.question_no.update_and_maybe_translate(should_translate_if_dirty)
+        post.conditional.question_yes.update_and_maybe_translate(
+            should_translate_if_dirty
+        )
+        post.conditional.question_no.update_and_maybe_translate(
+            should_translate_if_dirty
+        )
 
     batch_size = 10
     comments_qs = get_comments_feed(qs=Comment.objects.filter(), post=post)

--- a/scoring/models.py
+++ b/scoring/models.py
@@ -413,7 +413,9 @@ def global_leaderboard_dates() -> list[tuple[datetime, datetime]]:
     # Returns the start and end dates for each global leaderboard
     # reads directly from the set of global leaderboards
     leaderboards = Leaderboard.objects.filter(
-        start_time__isnull=False, end_time__isnull=False
+        project__type=Project.ProjectTypes.SITE_MAIN,
+        start_time__isnull=False,
+        end_time__isnull=False,
     )
     intervals = [(lb.start_time, lb.end_time) for lb in leaderboards]
     intervals.sort(key=lambda x: (x[1] - x[0], x[0]))

--- a/scoring/utils.py
+++ b/scoring/utils.py
@@ -799,11 +799,9 @@ def get_contributions(
     leaderboard: Leaderboard,
 ) -> list[Contribution]:
     if leaderboard.score_type == Leaderboard.ScoreTypes.COMMENT_INSIGHT:
-        public_posts = Post.objects.filter(
-            Q(projects=leaderboard.project) | Q(default_project=leaderboard.project)
-        )
+        main_feed_posts = Post.objects.filter_for_main_feed()
         comments = Comment.objects.filter(
-            on_post__in=public_posts,
+            on_post__in=main_feed_posts,
             author=user,
             created_at__lte=leaderboard.end_time,
             comment_votes__isnull=False,


### PR DESCRIPTION
In response to user [Zaldath's comment](https://www.metaculus.com/notebooks/28734/a-massive-rewrite-a-slate-of-improvements-and-going-open-source/#comment-251279):

> By the way, several of my comments don't seem to count for the Comments leaderboard at the moment, such as these...
https://www.metaculus.com/questions/31256/#comment-245237
https://www.metaculus.com/notebooks/31634/#comment-245144
Some questions also don't count for the peer/baseline leaderboards, such as...
https://www.metaculus.com/questions/31460/us-name-change-of-the-gulf-of-mexico-before-apr-1-2025/

global leaderboard dates only read from site main leaderboards
leaderboard tagging catches all visibility=normal posts
comment leaderboard reads comments on all visibility=normal posts