### PR TITLE
Split auto translations by chunks

### DIFF
--- a/front_end/package-lock.json
+++ b/front_end/package-lock.json
@@ -8,6 +8,7 @@
       "name": "front_end",
       "version": "0.1.0",
       "dependencies": {
+        "@dqbd/tiktoken": "^1.0.18",
         "@floating-ui/react": "^0.26.16",
         "@formatjs/intl-localematcher": "^0.5.4",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
@@ -880,6 +881,12 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/@dqbd/tiktoken": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@dqbd/tiktoken/-/tiktoken-1.0.18.tgz",
+      "integrity": "sha512-18xwsIO9UStlCCrumyjmJ8r2bM0EeLS6KqlnyZA718qsQxWCH0WR7iK/njszFPhhY14dnqLMMmRPvJ1ZhVTN6A==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.3.1",

--- a/front_end/package.json
+++ b/front_end/package.json
@@ -14,6 +14,7 @@
     "translations:generate": "node ./scripts/add_missing_translations.mjs"
   },
   "dependencies": {
+    "@dqbd/tiktoken": "^1.0.18",
     "@floating-ui/react": "^0.26.16",
     "@formatjs/intl-localematcher": "^0.5.4",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",

--- a/front_end/scripts/add_missing_translations.mjs
+++ b/front_end/scripts/add_missing_translations.mjs
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import { encoding_for_model } from "@dqbd/tiktoken";
 import fs from "fs";
 import OpenAI from "openai";
 import path from "path";
@@ -7,38 +8,95 @@ const MESSAGES_DIR = path.join(process.cwd(), "messages");
 const BASE_FILE = "en.json";
 const FILES_TO_SKIP = new Set(["original.json", BASE_FILE]);
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const GPT_MODEL = "gpt-4o";
 
-async function getMissingTranslations(missingKeys, baseTranslations, language) {
-  const client = new OpenAI({
-    apiKey: OPENAI_API_KEY,
-  });
+const MAX_TOKENS_PER_CHUNK = 3000;
 
-  const toBeTranslated = Object.fromEntries(
-    missingKeys
-      .filter((key) => key in baseTranslations)
-      .map((key) => [key, baseTranslations[key]])
-  );
+const client = new OpenAI({
+  apiKey: OPENAI_API_KEY,
+});
 
+const enc = encoding_for_model(GPT_MODEL);
+
+function estimateTokensForChunk(chunkObj) {
+  const tokens = enc.encode(JSON.stringify(chunkObj, null, 2)).length;
+  return tokens + 50;
+}
+
+/**
+ * Break `missingKeys` into multiple chunks so each chunk's
+ * prompt is under MAX_TOKENS_PER_CHUNK.
+ */
+function chunkMissingTranslations(missingKeys, baseTranslations, language) {
+  const chunks = [];
+  let currentChunk = {};
+
+  for (const key of missingKeys) {
+    const updatedChunk = { ...currentChunk, [key]: baseTranslations[key] };
+
+    // Estimate tokens
+    const tokens = estimateTokensForChunk(updatedChunk, language);
+
+    if (tokens > MAX_TOKENS_PER_CHUNK) {
+      // If the current chunk is empty, that means
+      // a single key-value alone exceeds the limit.
+      // We have no choice but to push it alone anyway.
+      if (Object.keys(currentChunk).length === 0) {
+        chunks.push(updatedChunk);
+        // Reset current chunk
+        currentChunk = {};
+      } else {
+        // Otherwise finalize the current chunk
+        chunks.push(currentChunk);
+
+        // Start a fresh chunk with the new key
+        currentChunk = { [key]: baseTranslations[key] };
+      }
+    } else {
+      // Accept the new key in the current chunk
+      currentChunk = updatedChunk;
+    }
+  }
+
+  // Push the last chunk if not empty
+  if (Object.keys(currentChunk).length > 0) {
+    chunks.push(currentChunk);
+  }
+
+  return chunks;
+}
+
+/**
+ * Make a single call to GPT for the given chunk of key-value pairs.
+ */
+async function translateChunk(chunkObj, language) {
   const systemPrompt = `
 You are a professional translator. Translate the following strings from English to ${language} and return only a JSON object with the same keys.
 
 Strings:
-${JSON.stringify(toBeTranslated, undefined, 2)}
+${JSON.stringify(chunkObj, null, 2)}
 `;
 
-  console.log(
-    `Generating ${missingKeys.length} missing translations for ${language}`
-  );
-
   const response = await client.chat.completions.create({
-    model: "gpt-4o",
+    model: GPT_MODEL,
     messages: [{ role: "system", content: systemPrompt.trim() }],
     response_format: { type: "json_object" },
   });
 
-  return JSON.parse(response.choices?.[0]?.message?.content || "{}");
+  const rawContent = response.choices?.[0]?.message?.content || "{}";
+  try {
+    return JSON.parse(rawContent);
+  } catch (err) {
+    console.error("Error parsing JSON from GPT response:", err);
+    console.error("Raw content was:", rawContent);
+    return {};
+  }
 }
 
+/**
+ * Main: read the base file, find missing keys in each language,
+ *       chunk them, request translations chunk by chunk.
+ */
 async function main() {
   const basePath = path.join(MESSAGES_DIR, BASE_FILE);
   const baseTranslations = JSON.parse(fs.readFileSync(basePath, "utf8"));
@@ -53,19 +111,38 @@ async function main() {
     const filePath = path.join(MESSAGES_DIR, langFile);
     const language = path.basename(langFile, ".json");
     const existingTranslations = JSON.parse(fs.readFileSync(filePath, "utf8"));
-    const missingKeys = baseKeys.filter(
-      (key) => !existingTranslations.hasOwnProperty(key)
-    );
-    if (!missingKeys.length) continue;
 
-    const newTranslations = await getMissingTranslations(
+    // Identify missing keys
+    const missingKeys = baseKeys.filter(
+      (k) => !Object.prototype.hasOwnProperty.call(existingTranslations, k)
+    );
+    if (missingKeys.length === 0) continue;
+
+    // 1. Split missing keys into token-friendly chunks
+    const chunks = chunkMissingTranslations(
       missingKeys,
       baseTranslations,
       language
     );
-    for (const [key, value] of Object.entries(newTranslations)) {
-      existingTranslations[key] = value;
+
+    console.log(
+      `Language: ${language}, missing ${missingKeys.length} keys. ` +
+        `Splitting into ${chunks.length} chunk(s).`
+    );
+
+    // 2. Translate each chunk
+    for (let i = 0; i < chunks.length; i++) {
+      console.log(`  Translating chunk ${i + 1} of ${chunks.length}`);
+      const chunkObj = chunks[i];
+      const chunkResult = await translateChunk(chunkObj, language);
+
+      // 3. Merge partial results
+      for (const [k, v] of Object.entries(chunkResult)) {
+        existingTranslations[k] = v;
+      }
     }
+
+    // 4. Save file
     fs.writeFileSync(
       filePath,
       JSON.stringify(existingTranslations, null, 2) + "\n",


### PR DESCRIPTION
Our current frontend auto-translations script can run into issues when translating large text blocks, because OpenAI enforces a limit on the number of output tokens. 

This PR fixes the issue by splitting requests into 3k-token chunks, ensuring that the translation process completes successfully within OpenAI’s limits
