### PR TITLE
don't compute divergence if cp is hidden

### DIFF
--- a/posts/services/common.py
+++ b/posts/services/common.py
@@ -338,6 +338,8 @@ def compute_sorting_divergence(post: Post) -> dict[int, float]:
     questions = post.get_questions()
     now = timezone.now()
     for question in questions:
+        if question.cp_reveal_time and question.cp_reveal_time > now:
+            continue
         cp = get_aggregations_at_time(
             question, now, [AggregationMethod.RECENCY_WEIGHTED]
         ).get(AggregationMethod.RECENCY_WEIGHTED, None)


### PR DESCRIPTION
closes #1995

Instead of filtering out questions where the cp is hidden, just don't calculate divergence on questions where the CP is hidden in the first place.

Once this is merged, I'll go in and remove divergences from all PostUserSnapshots that have a Question whose CP reveal time isn't passed.