### PR TITLE
Index "change this week" showing 0 when CP on components has moved

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -1024,6 +1024,7 @@
   "indexWeight": "Váha",
   "indexCP": "CP",
   "weeklyMovementChange": "{value} tento týden",
+  "noChange": "Beze změny",
   "percentagePoints": "procentní body",
   "proForecastersTitle": "O profesionálních předpovídačích Metaculus",
   "proForecastersDescription": "Pro určité projekty Metaculus zaměstnává profesionální předpovědníky, kteří prokázali vynikající schopnosti předpovídání a mají historii jasného popisu své argumentace. Profesionálové předpovídají na soukromých a veřejných sadách otázek, aby poskytli dobře kalibrované předpovědi a popisné argumentace pro naše partnery.<br></br><br></br>Pokud máte zájem o zaměstnání profesionálních předpovídačů Metaculus pro projekt, kontaktujte nás na <email>support@metaculus.com</email> s předmětem <strong>\"Požadavek na projekt\"</strong>.",

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1023,6 +1023,7 @@
   "indexWeight": "Weight",
   "indexCP": "CP",
   "weeklyMovementChange": "{value} this week",
+  "noChange": "No change",
   "percentagePoints": "percentage points",
   "proForecastersTitle": "About Metaculus Pro Forecasters",
   "proForecastersDescription": "For certain projects Metaculus employs Pro Forecasters who have demonstrated excellent forecasting ability and who have a history of clearly describing their rationales. Pros forecast on private and public sets of questions to produce well-calibrated forecasts and descriptive rationales for our partners.<br></br><br></br>If you’re interested in hiring Metaculus Pro Forecasters for a project, contact us at <email>support@metaculus.com</email> with the subject <strong>\"Project Inquiry\"</strong>.",

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -1024,6 +1024,7 @@
   "indexWeight": "Peso",
   "indexCP": "CP",
   "weeklyMovementChange": "{value} esta semana",
+  "noChange": "Sin cambios",
   "percentagePoints": "puntos porcentuales",
   "proForecastersTitle": "Sobre los Pronosticadores Profesionales de Metaculus",
   "proForecastersDescription": "Para ciertos proyectos, Metaculus emplea Pronosticadores Profesionales que han demostrado una excelente capacidad de previsión y que tienen un historial de describir claramente sus razonamientos. Los profesionales predicen en conjuntos de preguntas públicos y privados para producir previsiones bien calibradas y razonamientos descriptivos para nuestros socios.<br></br><br></br>Si estás interesado en contratar a Pronosticadores Profesionales de Metaculus para un proyecto, contáctanos en <email>support@metaculus.com</email> con el asunto <strong>\"Consulta de Proyecto\"</strong>.",

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -1022,6 +1022,7 @@
   "indexWeight": "Peso",
   "indexCP": "CP",
   "weeklyMovementChange": "{value} nesta semana",
+  "noChange": "Sem alteração",
   "percentagePoints": "pontos percentuais",
   "proForecastersTitle": "Sobre os Pro Previsores da Metaculus",
   "proForecastersDescription": "Para certos projetos, a Metaculus emprega Pro Previsores que demonstraram excelente capacidade de previsão e têm um histórico de descrever claramente suas motivações. Os profissionais preveem em conjuntos de perguntas privadas e públicas para produzir previsões bem calibradas e motivações descritivas para nossos parceiros.<br></br><br></br>Se você estiver interessado em contratar Pro Previsores da Metaculus para um projeto, entre em contato conosco em <email>support@metaculus.com</email> com o assunto <strong>\"Inquérito de Projeto\"</strong>.",

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -1026,6 +1026,7 @@
   "indexWeight": "权重",
   "indexCP": "CP",
   "weeklyMovementChange": "本周变化{value}",
+  "noChange": "无变化",
   "percentagePoints": "百分点",
   "proForecastersTitle": "关于Metaculus专业预测者",
   "proForecastersDescription": "对于某些项目，Metaculus雇佣已展示出卓越预测能力且具备清晰描述其推理历史的专业预测者。专业预测者在私人和公共问题集上进行预测，为我们的合作伙伴提供良好的校准预测和描述性推理。<br></br><br></br>如果您有兴趣为项目聘用Metaculus专业预测者，请通过邮件<email>support@metaculus.com</email>，主题为<strong>\"项目咨询\"</strong>与我们联系。",

--- a/front_end/src/app/(main)/notebooks/components/index_notebook/index.tsx
+++ b/front_end/src/app/(main)/notebooks/components/index_notebook/index.tsx
@@ -44,7 +44,7 @@ const IndexNotebook: FC<Props> = async ({
   }));
 
   const { index: indexValue, indexWeekAgo } = calculateIndex(indexQuestions);
-  const indexWeeklyMovement = Math.round(indexValue - indexWeekAgo);
+  const indexWeeklyMovement = Number((indexValue - indexWeekAgo).toFixed(1));
 
   return (
     <main className="mx-auto mb-24 mt-12 flex w-full max-w-3xl flex-1 flex-col  text-base text-gray-800  dark:text-gray-800-dark">
@@ -73,14 +73,17 @@ const IndexNotebook: FC<Props> = async ({
               <div className="flex flex-col items-center border-b border-gray-300 bg-blue-100 px-4 py-4 text-center leading-4 dark:border-gray-300-dark dark:bg-blue-100-dark">
                 <p className="m-0 mb-2 text-3xl capitalize leading-9">
                   {t.rich("indexScore", {
-                    value: Math.round(indexValue),
+                    value: Number(indexValue.toFixed(1)),
                     bold: (chunks) => <b>{chunks}</b>,
                   })}
                 </p>
                 <WeeklyMovement
                   weeklyMovement={indexWeeklyMovement}
                   message={t("weeklyMovementChange", {
-                    value: Math.abs(indexWeeklyMovement),
+                    value:
+                      indexWeeklyMovement === 0
+                        ? t("noChange")
+                        : Math.abs(indexWeeklyMovement),
                   })}
                   className="text-base"
                   iconClassName="text-base"

--- a/front_end/src/app/(main)/notebooks/constants/indexes.ts
+++ b/front_end/src/app/(main)/notebooks/constants/indexes.ts
@@ -7,7 +7,7 @@ export const NOTEBOOK_INDEXES: NotebookIndex = {
     { questionId: 31688, weight: -12 },
     { questionId: 31689, weight: 12 },
     { questionId: 31707, weight: 10 },
-    { questionId: 31709, weight: 9 },
+    { questionId: 34453, weight: 9 },
     // { postId: 27797, weight: 9 }, // currently missing on prod
     { questionId: 31710, weight: 11 },
     { questionId: 31711, weight: -8 },

--- a/front_end/src/components/weekly_movement.tsx
+++ b/front_end/src/components/weekly_movement.tsx
@@ -18,7 +18,7 @@ const WeeklyMovement: FC<Props> = ({
   iconClassName,
 }) => {
   const isNegative = weeklyMovement < 0;
-
+  const noChange = weeklyMovement === 0;
   return (
     <div className={cn("flex gap-1", className)}>
       <span
@@ -26,18 +26,21 @@ const WeeklyMovement: FC<Props> = ({
           "font-medium leading-4",
           isNegative
             ? "text-salmon-600 dark:text-salmon-600-dark"
-            : "text-olive-700 dark:text-olive-700-dark"
+            : "text-olive-700 dark:text-olive-700-dark",
+          noChange && "text-gray-500 dark:text-gray-500-dark"
         )}
       >
-        <FontAwesomeIcon
-          className={cn(
-            isNegative
-              ? "text-salmon-600 dark:text-salmon-600-dark"
-              : "text-olive-700 dark:text-olive-700-dark",
-            iconClassName
-          )}
-          icon={isNegative ? faCaretDown : faCaretUp}
-        />{" "}
+        {!noChange && (
+          <FontAwesomeIcon
+            className={cn(
+              isNegative
+                ? "text-salmon-600 dark:text-salmon-600-dark"
+                : "text-olive-700 dark:text-olive-700-dark",
+              iconClassName
+            )}
+            icon={isNegative ? faCaretDown : faCaretUp}
+          />
+        )}
         {message}
       </span>
     </div>


### PR DESCRIPTION
Related to #2078

- fixed movement message and styles when there is no change
- adjusted rounding for weekly movement to one decimal place
- updated reopened question in notebook indexes array