### PR TITLE
adds site-wide-password-protection

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -63,3 +63,7 @@ class LoginSerializer(serializers.Serializer):
     # username or email
     login = serializers.CharField()
     password = serializers.CharField()
+
+
+class PasswordSerializer(serializers.Serializer):
+    password = serializers.CharField()

--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -14,4 +14,9 @@ urlpatterns = [
     # Password Reset
     path("auth/password-reset/", common.password_reset_api_view),
     path("auth/password-reset/change/", common.password_reset_confirm_api_view),
+    path(
+        "auth/private-site-password-submit/",
+        common.private_site_submit_password_view,
+        name="private-site-password-submit",
+    ),
 ]

--- a/front_end/src/app/(main)/private-site-login/actions.ts
+++ b/front_end/src/app/(main)/private-site-login/actions.ts
@@ -1,0 +1,21 @@
+"use server";
+
+import { setPrivateSiteSession } from "@/services/session";
+import { post } from "@/utils/fetch";
+
+type PrivateSiteLoginResponse = {
+  token?: string;
+  errors?: string[];
+};
+
+export async function sumbitPrivateSiteLogin(
+  password: string
+): Promise<PrivateSiteLoginResponse> {
+  return await post("/auth/private-site-password-submit/", {
+    password,
+  });
+}
+
+export async function setPrivateSiteToken(token: string) {
+  setPrivateSiteSession(token);
+}

--- a/front_end/src/app/(main)/private-site-login/page.tsx
+++ b/front_end/src/app/(main)/private-site-login/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { setPrivateSiteToken, sumbitPrivateSiteLogin } from "./actions";
+
+export default function PrivateSiteLogin() {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const router = useRouter();
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setErrorMessage(null);
+    setIsSubmitting(true);
+    const password = (
+      event.currentTarget.elements.namedItem("password") as HTMLInputElement
+    )?.value;
+
+    try {
+      const response = await sumbitPrivateSiteLogin(password);
+      console.log({ response });
+
+      if (response && response.errors?.length) {
+        setErrorMessage(response.errors.at(0) || "");
+      } else {
+        // If no errors, set the private site token
+        const token = response.token;
+        if (!token) {
+          setErrorMessage("No token received from the server");
+          return;
+        }
+        console.log({ token });
+        setPrivateSiteToken(token);
+        console.log("Token set");
+        // then redirect to the questions page
+        router.push("/questions/"); // NOTE: doesn't always work
+      }
+    } catch (e) {
+      if (e instanceof Error) {
+        setErrorMessage(e.message);
+      } else {
+        // Fallback for network or unexpected errors
+        setErrorMessage("An unexpected error occurred.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto mt-4 min-h-min w-full max-w-5xl flex-auto px-0 sm:px-2 md:px-3">
+      <h1 className="mb-5 mt-20 text-balance text-center text-4xl text-blue-800 dark:text-blue-800-dark sm:text-5xl sm:tracking-tight md:text-6xl">
+        {"Private Site Sign In - password is 'password'"}
+      </h1>
+      <form onSubmit={handleSubmit}>
+        {errorMessage && (
+          <div className="mb-3 text-red-700 dark:text-red-500-dark">
+            {errorMessage}
+          </div>
+        )}
+
+        <label htmlFor="password">Password:</label>
+        <input
+          disabled={isSubmitting}
+          type="password"
+          id="password"
+          name="password"
+          className="mb-4"
+        />
+
+        <div className="mt-4">
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="inline-block rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:bg-blue-300"
+          >
+            {isSubmitting ? "Submitting..." : "Submit"}
+          </button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/front_end/src/services/session.ts
+++ b/front_end/src/services/session.ts
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 
 export const COOKIE_NAME_TOKEN = "auth_token";
 export const COOKIE_NAME_DEV_TOKEN = "alpha_token";
+export const COOKIE_NAME_PRIVATE_SITE_TOKEN = "private_site_token";
 
 export function setServerCookie(name: string, value: string) {
   cookies().set(name, value, {
@@ -34,4 +35,14 @@ export function getAlphaTokenSession() {
 
 export function setAlphaTokenSession(token: string) {
   return setServerCookie(COOKIE_NAME_DEV_TOKEN, token);
+}
+
+export function setPrivateSiteSession(token: string) {
+  return setServerCookie(COOKIE_NAME_PRIVATE_SITE_TOKEN, token);
+}
+
+export function getPrivateSiteSession() {
+  const cookie = cookies().get(COOKIE_NAME_PRIVATE_SITE_TOKEN);
+
+  return cookie?.value || null;
 }

--- a/front_end/src/utils/fetch.ts
+++ b/front_end/src/utils/fetch.ts
@@ -1,7 +1,11 @@
 import { notFound } from "next/navigation";
 import { getLocale } from "next-intl/server";
 
-import { getAlphaTokenSession, getServerSession } from "@/services/session";
+import {
+  getAlphaTokenSession,
+  getPrivateSiteSession,
+  getServerSession,
+} from "@/services/session";
 import {
   ApiErrorResponse,
   ErrorResponse,
@@ -115,6 +119,7 @@ const appFetch = async <T>(
 
   const authToken = passAuthHeader ? getServerSession() : null;
   const alphaToken = getAlphaTokenSession();
+  const privateSiteToken = getPrivateSiteSession();
   const locale = await getLocale();
 
   // Default values are configured in the next.config.mjs
@@ -138,6 +143,12 @@ const appFetch = async <T>(
           }
         : {}),
       "Accept-Language": locale,
+      // Propagate private site token
+      ...(privateSiteToken
+        ? {
+            "private-site-token": privateSiteToken,
+          }
+        : {}),
     },
   };
   if (

--- a/metaculus_web/settings.py
+++ b/metaculus_web/settings.py
@@ -92,6 +92,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "utils.middlewares.middleware_alpha_access_check",
+    "utils.middlewares.PrivateSiteMiddleware",
 ]
 
 if DEBUG:

--- a/users/models.py
+++ b/users/models.py
@@ -8,6 +8,7 @@ from django.db import models
 from django.db.models import QuerySet
 from django.utils import timezone
 from utils.models import TimeStampedModel
+from rest_framework.authtoken.models import Token
 
 if TYPE_CHECKING:
     from comments.models import Comment

--- a/users/models.py
+++ b/users/models.py
@@ -8,7 +8,6 @@ from django.db import models
 from django.db.models import QuerySet
 from django.utils import timezone
 from utils.models import TimeStampedModel
-from rest_framework.authtoken.models import Token
 
 if TYPE_CHECKING:
     from comments.models import Comment

--- a/utils/middlewares.py
+++ b/utils/middlewares.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.http import JsonResponse
 from django.utils.translation import activate
 from django.urls import reverse
-from django.shortcuts import redirect
 
 from users.models import User
 


### PR DESCRIPTION
Implements a basic site wide password block for non-signed in users.

adds three new optional environmental variables:
`PRIVATE_SITE_MODE=True` (defaults to false)
`PRIVATE_SITE_PASSWORD="password"` (defaults to "")
`PRIVATE_SITE_TOKEN="01234"` (defaults to "")

If `PRIVATE_SITE_MODE` is on, middleware on the back end always blocks content return unless user is authenticated or has the `PRIVATE_SITE_TOKEN` as a cookie.
The server side front end middleware also always pushes a reroute to the new page `/private-site-login/` under similar conditions

There are 2 places in code where I could use some help. I've added comments accordingly.

Something else worth noting - though it's not a big deal - is that even on the `/private-site-login/` page, we still get a bunch of calls to the bulletin endpoint. Probably not worth circumnavigating, but thought I'd mention it here.


UPDATE:
after deploying to play I've noticed a few bugs
- The log in endpoint is also blocked without first having the private site cookie - log in attempts should be allowed
- admin and api are blocked completely without manually adding the right cookie to the browser - have to figure out a way to make that work... @hlibowski ideas?
- if you delete the private_site_token, but have your crsf_token in tact from logging in you don't get redirected to the password page (good), but the backend still rejects your requests (bad). I think this is connected to one of my comments on the backend middleware bit.