### PR TITLE
Display active tournaments with zero questions

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournaments/page.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/page.tsx
@@ -79,10 +79,6 @@ function extractTournamentLists(tournaments: TournamentPreview[]) {
   );
 
   for (const tournament of sortedTournaments) {
-    if (!tournament.questions_count) {
-      continue;
-    }
-
     if (tournament.is_ongoing) {
       if (tournament.type === TournamentType.QuestionSeries) {
         questionSeries.push(tournament);


### PR DESCRIPTION
We want to display tournaments with zero questions if their visibility is not "unlisted". With this mechanism, we can create placeholder tournaments and add a redirect to the appropriate community, ensuring that this community "alias" is visible on the tournaments page.

<img width="360" alt="image" src="https://github.com/user-attachments/assets/82dde1d7-c9ad-45cd-ba79-b965cff0dad9" />
