### PR TITLE
Disabled `ATOMIC_REQUESTS` for every api view

### DIFF
--- a/comments/services/key_factors.py
+++ b/comments/services/key_factors.py
@@ -1,7 +1,10 @@
+from django.db import transaction
+
 from comments.models import KeyFactor
 from users.models import User
 
 
+@transaction.atomic
 def key_factor_vote(
     key_factor: KeyFactor, user: User, vote: int = None
 ) -> dict[int, int]:

--- a/metaculus_web/settings.py
+++ b/metaculus_web/settings.py
@@ -148,9 +148,6 @@ if ENV != "testing":
         "OPTIONS": {"options": "-c default_transaction_read_only=on"},
     }
 
-# TODO: probably we should switch to the explicit transactions
-DATABASES["default"]["ATOMIC_REQUESTS"] = True
-
 # REST Framework
 # https://www.django-rest-framework.org/
 

--- a/posts/views.py
+++ b/posts/views.py
@@ -342,7 +342,6 @@ def post_delete_api_view(request, pk):
 
 
 @api_view(["POST"])
-@transaction.non_atomic_requests
 def post_vote_api_view(request: Request, pk: int):
     post = get_object_or_404(Post, pk=pk)
     direction = serializers.ChoiceField(

--- a/posts/views.py
+++ b/posts/views.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 
 from django.core.files.storage import default_storage
-from django.db import transaction
 from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404

--- a/projects/services/common.py
+++ b/projects/services/common.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from typing import Iterable
 
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.db.models import Q
 
 from notifications.constants import MailingTags
@@ -90,6 +90,7 @@ def invite_user_to_project(
         return
 
 
+@transaction.atomic
 def subscribe_project(project: Project, user: User) -> ProjectSubscription:
     obj = ProjectSubscription(
         project=project,
@@ -103,6 +104,7 @@ def subscribe_project(project: Project, user: User) -> ProjectSubscription:
     return obj
 
 
+@transaction.atomic
 def unsubscribe_project(project: Project, user: User) -> ProjectSubscription:
     ProjectSubscription.objects.filter(project=project, user=user).delete()
 

--- a/questions/views.py
+++ b/questions/views.py
@@ -1,4 +1,3 @@
-from django.db import transaction
 from django.http import Http404
 from django.utils import timezone
 from rest_framework import status

--- a/questions/views.py
+++ b/questions/views.py
@@ -84,7 +84,6 @@ def unresolve_api_view(request, pk: int):
 
 
 @api_view(["POST"])
-@transaction.non_atomic_requests
 def bulk_create_forecasts_api_view(request):
     now = timezone.now()
     serializer = ForecastWriteSerializer(data=request.data, many=True)
@@ -136,7 +135,6 @@ def bulk_create_forecasts_api_view(request):
 
 
 @api_view(["POST"])
-@transaction.non_atomic_requests
 def bulk_withdraw_forecasts_api_view(request):
     now = timezone.now()
     serializer = ForecastWithdrawSerializer(data=request.data, many=True)


### PR DESCRIPTION
Initially, we were running every Django API view request within a transaction block controlled by the `ATOMIC_REQUESTS: True` rule. This approach can introduce unnecessary overhead, as it wraps all endpoints in a transaction regardless of whether they need it. For endpoints that perform heavy operations or make multiple external API calls, managing transactions for every request can lead to performance degradation:
https://docs.djangoproject.com/en/5.1/topics/db/transactions/

> While the simplicity of this transaction model is appealing, it also makes it inefficient when traffic increases. Opening a transaction for every view has some overhead. The impact on performance depends on the query patterns of your application and on how well your database handles locking.

This PR disables global atomic requests and manually adds atomic blocks only where they're needed.
