### PR TITLE
Empty instances state: auth screen

### DIFF
--- a/authentication/views/social.py
+++ b/authentication/views/social.py
@@ -26,6 +26,10 @@ def social_providers_api_view(request):
 
         backend = cls(redirect_uri=f"{redirect_uri}/{cls.name}", strategy=None)
 
+        # Check whether backend is configured with secrets
+        if not all(backend.get_key_and_secret()):
+            continue
+
         response.append(
             {
                 "name": backend.name,

--- a/front_end/src/components/auth/signup.tsx
+++ b/front_end/src/components/auth/signup.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import React, { FC, useRef, useState } from "react";
-import { useForm, useFormContext, FormProvider } from "react-hook-form";
+import { FormProvider, useForm, useFormContext } from "react-hook-form";
 
 import { signUpAction, SignUpActionState } from "@/app/(main)/accounts/actions";
 import { SignUpSchema, signUpSchema } from "@/app/(main)/accounts/schemas";
@@ -34,7 +34,9 @@ export const SignupForm: FC<{
   addToProject?: number;
 }> = ({ forceIsBot, addToProject }) => {
   const t = useTranslations();
-  const [isTurnstileValidated, setIsTurnstileValidate] = useState(false);
+  const [isTurnstileValidated, setIsTurnstileValidate] =
+    // Treat as validated if project is not configured with Turnstile key
+    useState(!TURNSTILE_SITE_KEY);
   const { setCurrentModal } = useModal();
   const turnstileRef = useRef<TurnstileInstance | undefined>();
 


### PR DESCRIPTION
- Removed unconfigured social providers from auth screen
<img width="420" alt="image" src="https://github.com/user-attachments/assets/5f631b14-51dc-4a72-a280-2d73916b58c7" />
- Fixed signup behaviour with deactivated turnstile
