### PR TITLE
ExpandableContent uses incorrect arrow directions

### DIFF
--- a/front_end/src/components/ui/section_toggle.tsx
+++ b/front_end/src/components/ui/section_toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { faChevronUp } from "@fortawesome/free-solid-svg-icons";
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   Disclosure,
@@ -78,7 +78,7 @@ const SectionToggle: FC<PropsWithChildren<Props>> = ({
               )}
             >
               <FontAwesomeIcon
-                icon={faChevronUp}
+                icon={faChevronDown}
                 className={cn(
                   "h-4 duration-75 ease-linear",
                   open && "rotate-180",


### PR DESCRIPTION
Related to #2042

- adjust chevron direction in SectionToggle component