### PR TITLE
New commenters get very visible warning for first five comments

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -1058,7 +1058,6 @@
   "reviewCommunityGuidelines": "Před odesláním komentáře si prosím udělejte chvilku na zhodnocení našich <link>Pokynů pro komunitu</link>. Oceňujeme promyšlené, respektující a konstruktivní příspěvky, které pomáhají podporovat významné diskuze.",
   "keepCivilStayOnTopic": "Udržujte diskuzi slušnou, zůstaňte u tématu a vyhýbejte se nepodloženým komentářům. Odůvodnění přímo zkopírovaná z nástrojů AI nejsou povolena. Odstraníme komentáře, které porušují naše Pokyny pro komunitu.",
   "understand": "Rozumím",
-  "closeThisMessage": "Zavřít tuto zprávu",
   "editProfile": "Upravit profil",
   "forecastingPerformance": "Výkon předpovědí",
   "totalPrizes": "Celkem cen",

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1055,7 +1055,6 @@
   "reviewCommunityGuidelines": "Before posting a comment, please take a moment to review our <link>Community Guidelines</link>. We value thoughtful, respectful, and constructive contributions that help foster meaningful discussions.",
   "keepCivilStayOnTopic": "Keep it civil, stay on topic, and avoid low-effort comments. Reasoning copied directly from AI tools is not allowed. We will delete comments that violate our Community Guidelines.",
   "understand": "I understand",
-  "closeThisMessage": "Close this message",
   "editProfile": "Edit Profile",
   "forecastingPerformance": "Forecasting Performance",
   "totalPrizes": "Total Prizes",

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -1058,7 +1058,6 @@
   "reviewCommunityGuidelines": "Antes de publicar un comentario, por favor tómese un momento para revisar nuestras <link>Normas de la Comunidad</link>. Valoramos las contribuciones reflexivas, respetuosas y constructivas que ayudan a fomentar discusiones significativas.",
   "keepCivilStayOnTopic": "Mantén la civilidad, permanece en el tema y evita comentarios poco trabajados. No se permite el razonamiento copiado directamente de herramientas de IA. Eliminaremos los comentarios que violen nuestras Normas de la Comunidad.",
   "understand": "Entiendo",
-  "closeThisMessage": "Cerrar este mensaje",
   "editProfile": "Editar perfil",
   "forecastingPerformance": "Desempeño de Pronóstico",
   "totalPrizes": "Premios Totales",

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -1056,7 +1056,6 @@
   "reviewCommunityGuidelines": "Antes de postar um comentário, por favor, reserve um momento para revisar nossas <link>Diretrizes da Comunidade</link>. Valorizamos contribuições reflexivas, respeitosas e construtivas que ajudam a promover discussões significativas.",
   "keepCivilStayOnTopic": "Mantenha a civilidade, permaneça no tópico e evite comentários de baixo esforço. O raciocínio copiado diretamente de ferramentas de IA não é permitido. Eliminaremos comentários que violem nossas Diretrizes da Comunidade.",
   "understand": "Eu entendo",
-  "closeThisMessage": "Fechar esta mensagem",
   "editProfile": "Editar Perfil",
   "forecastingPerformance": "Desempenho de Previsões",
   "totalPrizes": "Total de Prêmios",

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -1060,7 +1060,6 @@
   "reviewCommunityGuidelines": "在发表评论之前，请花一点时间查看我们的 <link>社区指南</link>。我们重视深思熟虑、尊重和建设性的贡献，这有助于促进有意义的讨论。",
   "keepCivilStayOnTopic": "保持礼貌，言之有据，避免低效的评论。不允许直接从 AI 工具复制的推理。我们将删除违反社区指南的评论。",
   "understand": "我明白",
-  "closeThisMessage": "关闭此消息",
   "editProfile": "编辑个人资料",
   "forecastingPerformance": "预测表现",
   "totalPrizes": "总奖项",

--- a/front_end/src/components/comment_feed/comment_welcome_message.tsx
+++ b/front_end/src/components/comment_feed/comment_welcome_message.tsx
@@ -5,11 +5,12 @@ import { FC } from "react";
 import Button from "@/components/ui/button";
 
 type Props = {
-  commentCount: number;
   onClick: () => void;
 };
 
-const CommentWelcomeMessage: FC<Props> = ({ commentCount, onClick }) => {
+const STORAGE_KEY = "welcome_message_closed";
+
+const CommentWelcomeMessage: FC<Props> = ({ onClick }) => {
   const t = useTranslations();
   return (
     <div className="rounded border border-orange-500 bg-orange-100 p-6 text-sm font-normal leading-5 text-gray-800 dark:border-orange-500-dark dark:bg-orange-100-dark dark:text-gray-800-dark">
@@ -29,11 +30,25 @@ const CommentWelcomeMessage: FC<Props> = ({ commentCount, onClick }) => {
         })}
       </p>
       <p className="m-0 mt-3">{t("keepCivilStayOnTopic")}</p>
-      <Button className="mt-4" onClick={onClick}>
-        {t(commentCount > 0 ? "closeThisMessage" : "understand")}
-      </Button>
+      {!getIsMessagePreviouslyClosed() && (
+        <Button
+          className="mt-4"
+          onClick={() => {
+            localStorage.setItem(STORAGE_KEY, "true");
+            onClick();
+          }}
+        >
+          {t("understand")}
+        </Button>
+      )}
     </div>
   );
 };
+
+export function getIsMessagePreviouslyClosed(): boolean {
+  const alreadyClosed = localStorage.getItem(STORAGE_KEY);
+
+  return Boolean(alreadyClosed);
+}
 
 export default CommentWelcomeMessage;

--- a/front_end/src/components/comment_feed/index.tsx
+++ b/front_end/src/components/comment_feed/index.tsx
@@ -26,7 +26,9 @@ import cn from "@/utils/cn";
 import { parseComment } from "@/utils/comments";
 import { logError } from "@/utils/errors";
 
-import CommentWelcomeMessage from "./comment_welcome_message";
+import CommentWelcomeMessage, {
+  getIsMessagePreviouslyClosed,
+} from "./comment_welcome_message";
 import Button from "../ui/button";
 import { FormErrorMessage } from "../ui/form_field";
 
@@ -391,7 +393,7 @@ const CommentFeed: FC<Props> = ({
             </h2>
             {!profileId &&
               user &&
-              (!showWelcomeMessage || userCommentsAmount > 0) && (
+              (!showWelcomeMessage || getIsMessagePreviouslyClosed()) && (
                 <ButtonGroup
                   value={feedFilters.is_private ? "private" : "public"}
                   buttons={feedOptions}
@@ -404,7 +406,6 @@ const CommentFeed: FC<Props> = ({
           </div>
           {postId && showWelcomeMessage && (
             <CommentWelcomeMessage
-              commentCount={userCommentsAmount}
               onClick={() => {
                 setUserCommentsAmount(NEW_USER_COMMENT_LIMIT);
               }}
@@ -413,7 +414,7 @@ const CommentFeed: FC<Props> = ({
         </div>
         {postId && (
           <>
-            {showWelcomeMessage && userCommentsAmount === 0 ? null : (
+            {showWelcomeMessage && !getIsMessagePreviouslyClosed() ? null : (
               <CommentEditor
                 shouldIncludeForecast={includeUserForecast}
                 postId={postId}


### PR DESCRIPTION
Addresses feedback on #2097

- adjusted logic for the welcome block in the comments feed
- added flag in local storage to keep the info about user interaction with it