### PR TITLE
Make bot comments collapsed by default

### DIFF
--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -7,6 +7,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { sendGAEvent } from "@next/third-parties/google";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { FC, useState, useEffect, useRef, ReactNode } from "react";
 
@@ -29,6 +30,7 @@ import Button from "@/components/ui/button";
 import DropdownMenu, { MenuItemProps } from "@/components/ui/dropdown_menu";
 import { userTagPattern } from "@/constants/comments";
 import { useAuth } from "@/contexts/auth_context";
+import useContainerSize from "@/hooks/use_container_size";
 import useScrollTo from "@/hooks/use_scroll_to";
 import { CommentType } from "@/types/comment";
 import { PostWithForecasts, ProjectPermissions } from "@/types/post";
@@ -197,13 +199,14 @@ const Comment: FC<CommentProps> = ({
   const [commentMarkdown, setCommentMarkdown] = useState(comment.text);
   const [tempCommentMarkdown, setTempCommentMarkdown] = useState("");
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
+  const { ref, width } = useContainerSize<HTMLDivElement>();
 
   const { user } = useAuth();
   const scrollTo = useScrollTo();
   const userCanPredict = postData && canPredictQuestion(postData);
   const userForecast =
     postData?.question?.my_forecasts?.latest?.forecast_values[1] ?? 0.5;
-  console.log(comment);
+
   const isCmmButtonVisible =
     user?.id !== comment.author.id &&
     (!!postData?.question ||
@@ -406,11 +409,15 @@ const Comment: FC<CommentProps> = ({
           }}
           cmmContext={cmmContext}
         />
-        <div className="mb-1 flex flex-col items-start gap-1">
+        <div
+          className={cn("flex flex-col items-start gap-1", {
+            "mb-1": !isCollapsed,
+          })}
+        >
           <span className="inline-flex w-full flex-col items-start justify-start text-base sm:flex-row sm:items-center">
             <div className="flex flex-row items-center">
               {" "}
-              <a
+              <Link
                 className="flex flex-row items-center no-underline"
                 href={`/accounts/profile/${comment.author.id}/`}
               >
@@ -426,21 +433,30 @@ const Comment: FC<CommentProps> = ({
                   ProjectPermissions.ADMIN && (
                   <Admin className="ml-2 text-lg" />
                 )}
-              </a>
+              </Link>
               <span className="mx-1 opacity-55">·</span>
               <CommentDate comment={comment} />
             </div>
-            {/* TODO: adjust also for mobile view */}
+
             {isCollapsed && (
               <div className="flex w-full flex-1 flex-row items-center justify-between sm:ml-5 sm:w-auto">
-                {/* TODO: add a helper that will parse the comment text and truncate it */}
-                <div className="max-w-[350px] truncate">
-                  <MarkdownEditor
-                    mode="read"
-                    markdown={getMarkdownSummary(comment.text, 350, 24)}
-                    contentEditableClassName="font-serif !text-gray-700 !dark:text-gray-700-dark *:m-0"
-                    withUgcLinks
-                  />
+                <div
+                  className="mr-3 line-clamp-1 flex-grow sm:mr-0 sm:max-w-[350px]"
+                  ref={ref}
+                >
+                  {!!width && (
+                    <MarkdownEditor
+                      mode="read"
+                      markdown={getMarkdownSummary(
+                        comment.text,
+                        width,
+                        24,
+                        8.1
+                      )}
+                      contentEditableClassName="font-inter !text-gray-700 !dark:text-gray-700-dark *:m-0"
+                      withUgcLinks
+                    />
+                  )}
                 </div>
                 <FontAwesomeIcon
                   size="sm"

--- a/front_end/src/components/comment_feed/comment_wrapper.tsx
+++ b/front_end/src/components/comment_feed/comment_wrapper.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { isNil } from "lodash";
 import Link from "next/link";
 import { FC, useState } from "react";
@@ -22,25 +24,22 @@ export const CommentWrapper: FC<Props> = ({
   last_viewed_at,
   postData,
 }) => {
+  const isUnread =
+    last_viewed_at && new Date(last_viewed_at) < new Date(comment.created_at);
+  const match = window.location.hash.match(/#comment-(\d+)/);
   const [isCollapsed, setIsCollapsed] = useState(
-    comment.author.is_bot &&
-      !isNil(comment.vote_score) &&
-      comment.vote_score < 3
+    isCommentCollapsed(comment, match)
   );
-  console.log(isCollapsed);
+
   return (
     <div
       key={comment.id}
       className={cn(
         "my-1.5 rounded-md border px-1.5 py-1 md:px-2.5 md:py-1.5",
         {
-          "border-blue-400 dark:border-blue-400-dark": !(
-            last_viewed_at &&
-            new Date(last_viewed_at) < new Date(comment.created_at)
-          ),
+          "border-blue-400 dark:border-blue-400-dark": !isUnread,
           "border-purple-500 bg-purple-100/50 dark:border-purple-500-dark/60 dark:bg-purple-100-dark/50":
-            last_viewed_at &&
-            new Date(last_viewed_at) < new Date(comment.created_at),
+            isUnread,
           "cursor-pointer hover:bg-blue-100 hover:dark:bg-blue-100-dark":
             isCollapsed,
         }
@@ -70,3 +69,20 @@ export const CommentWrapper: FC<Props> = ({
     </div>
   );
 };
+
+function isCommentCollapsed(
+  comment: CommentType,
+  match: RegExpMatchArray | null
+) {
+  if (match) {
+    const focus_comment_id = Number(match[1]);
+    if (focus_comment_id === comment.id) {
+      return false;
+    }
+  }
+  return (
+    comment.author.is_bot &&
+    !isNil(comment.vote_score) &&
+    comment.vote_score < 3
+  );
+}

--- a/front_end/src/components/comment_feed/comment_wrapper.tsx
+++ b/front_end/src/components/comment_feed/comment_wrapper.tsx
@@ -1,0 +1,72 @@
+import { isNil } from "lodash";
+import Link from "next/link";
+import { FC, useState } from "react";
+
+import Comment from "@/components/comment_feed/comment";
+import { CommentType } from "@/types/comment";
+import { PostWithForecasts } from "@/types/post";
+import cn from "@/utils/cn";
+
+import { SortOption } from ".";
+
+type Props = {
+  comment: CommentType;
+  last_viewed_at?: string;
+  profileId?: number;
+  postData?: PostWithForecasts;
+};
+
+export const CommentWrapper: FC<Props> = ({
+  comment,
+  profileId,
+  last_viewed_at,
+  postData,
+}) => {
+  const [isCollapsed, setIsCollapsed] = useState(
+    comment.author.is_bot &&
+      !isNil(comment.vote_score) &&
+      comment.vote_score < 3
+  );
+  console.log(isCollapsed);
+  return (
+    <div
+      key={comment.id}
+      className={cn(
+        "my-1.5 rounded-md border px-1.5 py-1 md:px-2.5 md:py-1.5",
+        {
+          "border-blue-400 dark:border-blue-400-dark": !(
+            last_viewed_at &&
+            new Date(last_viewed_at) < new Date(comment.created_at)
+          ),
+          "border-purple-500 bg-purple-100/50 dark:border-purple-500-dark/60 dark:bg-purple-100-dark/50":
+            last_viewed_at &&
+            new Date(last_viewed_at) < new Date(comment.created_at),
+          "cursor-pointer hover:bg-blue-100 hover:dark:bg-blue-100-dark":
+            isCollapsed,
+        }
+      )}
+      onClick={() => (isCollapsed ? setIsCollapsed(!isCollapsed) : null)}
+    >
+      {profileId && comment.on_post_data && (
+        <h3 className="mb-2 text-lg font-semibold">
+          <Link
+            href={`/questions/${comment.on_post_data.id}#comment-${comment.id}`}
+            className="text-blue-700 no-underline hover:text-blue-800 dark:text-blue-600-dark hover:dark:text-blue-300"
+          >
+            {comment.on_post_data.title}
+          </Link>
+        </h3>
+      )}
+      <Comment
+        onProfile={!!profileId}
+        comment={comment}
+        treeDepth={0}
+        /* replies should always be sorted from oldest to newest */
+        sort={"created_at" as SortOption}
+        postData={postData}
+        lastViewedAt={postData?.last_viewed_at}
+        isCollapsed={isCollapsed}
+      />
+    </div>
+  );
+};

--- a/front_end/src/components/comment_feed/index.tsx
+++ b/front_end/src/components/comment_feed/index.tsx
@@ -3,13 +3,11 @@
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { isNil } from "lodash";
-import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { FC, useCallback, useEffect, useMemo, useState } from "react";
 
 import { getComments, markPostAsRead } from "@/app/(main)/questions/actions";
 import { useContentTranslatedBannerProvider } from "@/app/providers";
-import Comment from "@/components/comment_feed/comment";
 import CommentEditor from "@/components/comment_feed/comment_editor";
 import { DefaultUserMentionsContextProvider } from "@/components/markdown_editor/plugins/mentions/components/default_mentions_context";
 import { MentionItem } from "@/components/markdown_editor/plugins/mentions/types";
@@ -29,6 +27,7 @@ import { logError } from "@/utils/errors";
 import CommentWelcomeMessage, {
   getIsMessagePreviouslyClosed,
 } from "./comment_welcome_message";
+import { CommentWrapper } from "./comment_wrapper";
 import Button from "../ui/button";
 import { FormErrorMessage } from "../ui/form_field";
 
@@ -452,43 +451,13 @@ const CommentFeed: FC<Props> = ({
           </DropdownMenu>
         </div>
         {comments.map((comment: CommentType) => (
-          <div
+          <CommentWrapper
             key={comment.id}
-            className={cn(
-              "my-1.5 rounded-md border px-1.5 py-1 md:px-2.5 md:py-1.5",
-              {
-                "border-blue-400 dark:border-blue-400-dark": !(
-                  postData?.last_viewed_at &&
-                  new Date(postData.last_viewed_at) <
-                    new Date(comment.created_at)
-                ),
-                "border-purple-500 bg-purple-100/50 dark:border-purple-500-dark/60 dark:bg-purple-100-dark/50":
-                  postData?.last_viewed_at &&
-                  new Date(postData.last_viewed_at) <
-                    new Date(comment.created_at),
-              }
-            )}
-          >
-            {profileId && comment.on_post_data && (
-              <h3 className="mb-2 text-lg font-semibold">
-                <Link
-                  href={`/questions/${comment.on_post_data.id}#comment-${comment.id}`}
-                  className="text-blue-700 no-underline hover:text-blue-800 dark:text-blue-600-dark hover:dark:text-blue-300"
-                >
-                  {comment.on_post_data.title}
-                </Link>
-              </h3>
-            )}
-            <Comment
-              onProfile={!!profileId}
-              comment={comment}
-              treeDepth={0}
-              /* replies should always be sorted from oldest to newest */
-              sort={"created_at" as SortOption}
-              postData={postData}
-              lastViewedAt={postData?.last_viewed_at}
-            />
-          </div>
+            comment={comment}
+            profileId={profileId}
+            last_viewed_at={postData?.last_viewed_at}
+            postData={postData}
+          />
         ))}
         {comments.length === 0 && !isLoading && (
           <>


### PR DESCRIPTION
Related to #1523

- implemented `CommentWrapper` component to manage collapsed state
- used `getMarkdownSummary` with `useContainerSize` to render comment preview
- when comment id is equal to comment hash in url, set `isCollapsed` to `false` by default