### PR TITLE
Prevent short comments

### DIFF
--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -452,7 +452,7 @@
   "newest": "Newest",
   "stale": "Stale",
   "newComments": "New Comments",
-  "commentTooShort": "Your comment is too short. Try adding more details or insights so it adds value to the conversation.<br></br>Check our <link>Guidelines</link> for more information.",
+  "commentTooShort": "Your comment is too short. Try adding more details or insights so it adds value to the conversation.<br></br><info>Check our <link>Guidelines</link> for more information.</info>",
   "divergence": "Divergence",
   "myPredictions": "My Predictions",
   "special": "Special",

--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -473,7 +473,7 @@ const Comment: FC<CommentProps> = ({
           )}
         </div>
         {!!errorMessage && isEditing && (
-          <div className="text-end text-red-500 dark:text-red-500-dark">
+          <div className="text-balance text-center text-red-500 dark:text-red-500-dark">
             {errorMessage}
           </div>
         )}

--- a/front_end/src/components/comment_feed/comment_editor.tsx
+++ b/front_end/src/components/comment_feed/comment_editor.tsx
@@ -199,7 +199,7 @@ const CommentEditor: FC<CommentEditorProps> = ({
         </div>
       )}
       {!!errorMessage && (
-        <div className="text-end text-red-500 dark:text-red-500-dark">
+        <div className="text-balance text-center text-red-500 dark:text-red-500-dark">
           {errorMessage}
         </div>
       )}

--- a/front_end/src/components/comment_feed/validate_comment.tsx
+++ b/front_end/src/components/comment_feed/validate_comment.tsx
@@ -21,6 +21,7 @@ export function validateComment(
         {(tags) =>
           t.rich("commentTooShort", {
             ...tags,
+            info: (chunks) => <p className="mt-2 text-sm">{chunks}</p>,
             link: (chunks) => <Link href="/help/guidelines/">{chunks}</Link>,
           })
         }


### PR DESCRIPTION
Related to #2070

Apply the latest suggested layout for error messages when creating a comment:

<img width="751" alt="image" src="https://github.com/user-attachments/assets/5068dd2f-a5e4-4b36-97ca-ceca982394f5" />
