### PR TITLE
Resolved continuous groups are missing don't show your predictions in the table anymore

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/continuous_slider_wrapper.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/continuous_slider_wrapper.tsx
@@ -192,7 +192,6 @@ const SliderWrapper: FC<PropsWithChildren<SliderWrapperProps>> = ({
               }
               communityBounds={getCdfBounds(communityCdf)}
               communityQuartiles={option.communityQuartiles ?? undefined}
-              withUserQuartiles={option.resolution === null}
               withCommunityQuartiles={!user || !hideCP}
               isDirty={option.isDirty}
               hasUserForecast={hasUserForecast}


### PR DESCRIPTION
Related to #2189

Removed a condition to hide user quartiles for continuous groups when question is resolved:

<img width="740" alt="image" src="https://github.com/user-attachments/assets/d2f889a0-1e1f-460d-bfd1-f93b7acb30a2" />
