### PR TITLE
new sorting should be open_by instead

### DIFF
--- a/front_end/src/app/(main)/questions/components/feed_filters/main.tsx
+++ b/front_end/src/app/(main)/questions/components/feed_filters/main.tsx
@@ -63,7 +63,7 @@ const MainFeedFilters: FC<Props> = ({ following }) => {
         label: t("movers"),
       },
       {
-        value: QuestionOrder.PublishTimeDesc,
+        value: QuestionOrder.OpenTimeDesc,
         label: t("new"),
       },
     ],

--- a/front_end/src/app/(main)/questions/components/feed_filters/my_questions_and_posts.tsx
+++ b/front_end/src/app/(main)/questions/components/feed_filters/my_questions_and_posts.tsx
@@ -86,7 +86,7 @@ const MyQuestionsAndPostsFilters: FC = () => {
       { value: QuestionOrder.CommentCountDesc, label: t("totalComments") },
       { value: QuestionOrder.VotesDesc, label: t("mostUpvotes") },
       {
-        value: QuestionOrder.PublishTimeDesc,
+        value: QuestionOrder.OpenTimeDesc,
         label: t("newest"),
       },
     ],

--- a/front_end/src/app/(main)/questions/helpers/filters.ts
+++ b/front_end/src/app/(main)/questions/helpers/filters.ts
@@ -336,7 +336,7 @@ export function getMainOrderOptions(
       label: t("movers"),
     },
     {
-      value: QuestionOrder.PublishTimeDesc,
+      value: QuestionOrder.OpenTimeDesc,
       label: t("new"),
     },
   ];

--- a/front_end/src/types/question.ts
+++ b/front_end/src/types/question.ts
@@ -13,6 +13,7 @@ export enum QuestionOrder {
   ActivityDesc = "-activity",
   WeeklyMovementDesc = "-weekly_movement",
   PublishTimeDesc = "-published_at",
+  OpenTimeDesc = "-open_time",
   LastPredictionTimeAsc = "user_last_forecasts_date",
   LastPredictionTimeDesc = "-user_last_forecasts_date",
   DivergenceDesc = "-divergence",

--- a/posts/models.py
+++ b/posts/models.py
@@ -239,7 +239,10 @@ class PostQuerySet(models.QuerySet):
             ),
             _user_permission=models.Case(
                 models.When(
-                    Q(default_project__created_by_id__isnull=False, default_project__created_by_id=user_id),
+                    Q(
+                        default_project__created_by_id__isnull=False,
+                        default_project__created_by_id=user_id,
+                    ),
                     then=models.Value(ObjectPermission.ADMIN),
                 ),
                 default=Coalesce(
@@ -601,6 +604,8 @@ class Post(TimeStampedModel, TranslatedModel):  # type: ignore
                 ],
                 default=None,
             )
+        elif self.notebook_id:
+            open_time = self.published_at
 
         self.open_time = open_time
 


### PR DESCRIPTION
closes #2113

sorting by "new" should actually sort by open time not publish time. publish time now signals when a question becomes viewable, while open_time displays when forecasting can start. once in a while these would be flipped in order in the feed and causes confusion.

@hlbmtc  I checked through the logic and believe that adding an `open_time` to Posts with notebooks doesn't break anything, but wanted to get your thoughts on it as well.