### PR TITLE
Notebook approval is broken

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/post_approval_modal.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/post_approval_modal.tsx
@@ -44,7 +44,10 @@ const PostApprovalModal: FC<{
 
   useEffect(() => {
     setSubmitErrors(undefined);
-    if (!isBefore(approvalData.open_time, post.scheduled_close_time)) {
+    if (
+      !post.notebook &&
+      !isBefore(approvalData.open_time, post.scheduled_close_time)
+    ) {
       setSubmitErrors(new Error(t("closeDateError")));
     }
   }, [approvalData.open_time, post.scheduled_close_time, t]);
@@ -123,7 +126,8 @@ const PostApprovalModal: FC<{
             onClick={handleSubmit}
             disabled={
               isLoading ||
-              !isBefore(approvalData.open_time, post.scheduled_close_time)
+              (!post.notebook &&
+                !isBefore(approvalData.open_time, post.scheduled_close_time))
             }
             variant="primary"
           >


### PR DESCRIPTION
Related to #2193

- adjusted approval modal not to compare open/close dates for notebooks