### PR TITLE
Improvements to BW Leaderboards

### DIFF
--- a/front_end/src/app/(campaigns-registration)/bridgewater/leaderboards/page.tsx
+++ b/front_end/src/app/(campaigns-registration)/bridgewater/leaderboards/page.tsx
@@ -73,10 +73,10 @@ export default async function Page() {
         <h1 className="mb-1 text-2xl font-bold">
           Bridgewater Forecasting Contest
         </h1>
-        <p className="mb-5 text-sm text-gray-700">
+        <p className="mb-5 text-sm text-gray-700 dark:text-gray-300">
           Leaderboards get updated when questions resolve.{" "}
           <Link
-            className="text-blue-700 hover:text-blue-800"
+            className="text-blue-700 hover:text-blue-800 dark:text-blue-400 hover:dark:text-blue-300"
             href="/tournament/bridgewater/"
           >
             View Tournament Page

--- a/front_end/src/app/(campaigns-registration)/bridgewater/leaderboards/page.tsx
+++ b/front_end/src/app/(campaigns-registration)/bridgewater/leaderboards/page.tsx
@@ -1,4 +1,5 @@
 import { google } from "googleapis";
+import Link from "next/link";
 
 import GlobalHeader from "@/app/(main)/components/headers/global_header";
 import ProfileApi from "@/services/profile";
@@ -69,7 +70,18 @@ export default async function Page() {
     <>
       <GlobalHeader />
       <main className="mt-12 flex h-fit min-h-screen flex-col items-center justify-start p-3 sm:p-5">
-        <h1 className="mb-6 text-2xl font-bold">Leaderboards</h1>
+        <h1 className="mb-1 text-2xl font-bold">
+          Bridgewater Forecasting Contest
+        </h1>
+        <p className="mb-5 text-sm text-gray-700">
+          Leaderboards get updated when questions resolve.{" "}
+          <Link
+            className="text-blue-700 hover:text-blue-800"
+            href="/tournament/bridgewater/"
+          >
+            View Tournament Page
+          </Link>
+        </p>
         <div className="w-full max-w-4xl">
           <LeaderboardTabs
             sheets={allSheets}


### PR DESCRIPTION
- Added `tabular-nums` to numerical table cells for alignment
- Better mobile support
- Added truncation for long usernames
- Only loads top 125 on page load, rest is loaded with a Load All button
- Updated page title, added a description and a link to the Tournament page