### PR TITLE
CP fails to show in timeline graph when quartile out of bounds

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/detailed_question_card/continuous_chart_card.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { isNil } from "lodash";
 import { useTranslations } from "next-intl";
 import React, { FC, useCallback, useMemo, useState } from "react";
 
@@ -105,12 +106,14 @@ const DetailedContinuousChartCard: FC<Props> = ({
       value: cursorData?.center,
       questionType: question.type,
       scaling: question.scaling,
-      range: cursorData?.interval_lower_bound
-        ? [
-            cursorData?.interval_lower_bound as number,
-            cursorData?.interval_upper_bound as number,
-          ]
-        : [],
+      range:
+        !isNil(cursorData?.interval_lower_bound) &&
+        !isNil(cursorData?.interval_upper_bound)
+          ? [
+              cursorData?.interval_lower_bound as number,
+              cursorData?.interval_upper_bound as number,
+            ]
+          : [],
     });
   }, [
     t,

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -522,13 +522,13 @@ export function getUserPredictionDisplayValue(
     center,
     scaling ?? { range_min: 0, range_max: 1, zero_point: null }
   );
-  const scaledLower = lower
+  const scaledLower = !isNil(lower)
     ? scaleInternalLocation(
         lower,
         scaling ?? { range_min: 0, range_max: 1, zero_point: null }
       )
     : null;
-  const scaledUpper = upper
+  const scaledUpper = !isNil(upper)
     ? scaleInternalLocation(
         upper,
         scaling ?? { range_min: 0, range_max: 1, zero_point: null }
@@ -538,10 +538,10 @@ export function getUserPredictionDisplayValue(
   if (questionType === QuestionType.Date) {
     const displayCenter = format(fromUnixTime(scaledCenter), "yyyy-MM-dd");
     if (showRange) {
-      const displayLower = !!scaledLower
+      const displayLower = !isNil(scaledLower)
         ? format(fromUnixTime(scaledLower), "yyyy-MM-dd")
         : "...";
-      const displayUpper = !!scaledUpper
+      const displayUpper = !isNil(scaledUpper)
         ? format(fromUnixTime(scaledUpper), "yyyy-MM-dd")
         : "...";
       return `${displayCenter} (${displayLower} - ${displayUpper})`;
@@ -550,10 +550,10 @@ export function getUserPredictionDisplayValue(
   } else if (questionType === QuestionType.Numeric) {
     const displayCenter = abbreviatedNumber(scaledCenter);
     if (showRange) {
-      const displayLower = !!scaledLower
+      const displayLower = !isNil(scaledLower)
         ? abbreviatedNumber(scaledLower)
         : "...";
-      const displayUpper = !!scaledUpper
+      const displayUpper = !isNil(scaledUpper)
         ? abbreviatedNumber(scaledUpper)
         : "...";
       return `${displayCenter} (${displayLower} - ${displayUpper})`;


### PR DESCRIPTION
Related to #2220

- adjusted render of user and community predictions on chart cursor change