### PR TITLE
Change CP score styling in leaderboards

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -1069,5 +1069,7 @@
   "slider": "Posuvník",
   "lowerBound": "Dolní mez",
   "quartiles": "Kvartily",
-  "upperBound": "Horní mez"
+  "upperBound": "Horní mez",
+  "questionsBy": "Otázky od",
+  "leaderboardCpInfo": "Jedná se o hlavní predikci agregovanou ze všech předpovědí na každou otázku.<br></br>Zjistěte, jak se vypočítá <link>zde</link>."
 }

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1067,5 +1067,6 @@
   "slider": "Slider",
   "lowerBound": "Lower bound",
   "quartiles": "Quartiles",
-  "upperBound": "Upper bound"
+  "upperBound": "Upper bound",
+  "leaderboardCpInfo": "This is the main prediction aggregated from all forecasters on each question.<br></br>Learn how it's computed <link>here</link>."
 }

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -1069,5 +1069,7 @@
   "slider": "Deslizador",
   "lowerBound": "Límite inferior",
   "quartiles": "Cuartiles",
-  "upperBound": "Límite superior"
+  "upperBound": "Límite superior",
+  "questionsBy": "Preguntas por",
+  "leaderboardCpInfo": "Esta es la predicción principal agregada de todos los pronosticadores en cada pregunta.<br></br>Aprende cómo se calcula <link>aquí</link>."
 }

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -1067,5 +1067,7 @@
   "slider": "Deslizador",
   "lowerBound": "Limite inferior",
   "quartiles": "Quartis",
-  "upperBound": "Limite superior"
+  "upperBound": "Limite superior",
+  "questionsBy": "Perguntas por",
+  "leaderboardCpInfo": "Esta é a principal previsão agregada de todos os previsores em cada pergunta.<br></br>Saiba como é calculada <link>aqui</link>."
 }

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -1071,5 +1071,7 @@
   "slider": "滑块",
   "lowerBound": "下界",
   "quartiles": "四分位数",
-  "upperBound": "上界"
+  "upperBound": "上界",
+  "questionsBy": "问题由",
+  "leaderboardCpInfo": "这是从所有预测者对每个问题的总预测中得出的主要预测。<br></br>了解它是如何计算的<link>这里</link>。"
 }

--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/leaderboard_table/table_row.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/leaderboard_table/table_row.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { FC } from "react";
 
+import RichText from "@/components/rich_text";
+import Tooltip from "@/components/ui/tooltip";
 import { Href } from "@/types/navigation";
 import {
   CategoryKey,
@@ -64,8 +66,40 @@ const LeaderboardRow: FC<Props> = ({
           className="flex items-center justify-between gap-1.5 py-2.5 pl-2.5 text-gray-500 no-underline"
           prefetch={false}
         >
-          {!!medal && <MedalIcon type={medal} className="size-5" />}
-          <span className="flex-1 text-center">{rank}</span>
+          {!user && aggregation_method === "recency_weighted" ? (
+            <div className="flex flex-1 items-center justify-center">
+              <div className="relative text-blue-700 dark:text-blue-700-dark">
+                <span className="font-league-gothic text-lg">M</span>
+                <Tooltip
+                  showDelayMs={200}
+                  placement={"right"}
+                  tooltipContent={
+                    <RichText>
+                      {(tags) =>
+                        t.rich("leaderboardCpInfo", {
+                          ...tags,
+                          link: (chunks) => (
+                            <Link href={"/faq/#community-prediction"}>
+                              {chunks}
+                            </Link>
+                          ),
+                        })
+                      }
+                    </RichText>
+                  }
+                  className="absolute right-[-18px] inline-flex h-full items-center justify-center font-sans"
+                  tooltipClassName="font-sans text-center text-gray-800 dark:text-gray-800-dark border-blue-400 dark:border-blue-400-dark bg-gray-0 dark:bg-gray-0-dark"
+                >
+                  ⓘ
+                </Tooltip>
+              </div>
+            </div>
+          ) : (
+            <>
+              {!!medal && <MedalIcon type={medal} className="size-5" />}
+              <span className="flex-1 text-center">{rank}</span>
+            </>
+          )}
         </Link>
       </td>
       <td
@@ -76,14 +110,16 @@ const LeaderboardRow: FC<Props> = ({
       >
         <Link
           href={href}
-          className="flex items-center truncate px-4 py-2.5 no-underline"
+          className="flex items-center px-4 py-2.5 no-underline"
           prefetch={false}
         >
-          {user
-            ? formatUsername(user)
-            : aggregation_method == "recency_weighted"
-              ? t("communityPrediction")
-              : aggregation_method}
+          <span className="truncate">
+            {user
+              ? formatUsername(user)
+              : aggregation_method == "recency_weighted"
+                ? t("communityPrediction")
+                : aggregation_method}
+          </span>
         </Link>
       </td>
       <td className="hidden w-24 p-0 font-mono text-base leading-4 @md:!table-cell">


### PR DESCRIPTION
Related to #2140

- implemented a new rank cell with a tooltip for the CP row on the leaderboard table
- bonus: fixed truncate class didn’t work properly on the user column

![image](https://github.com/user-attachments/assets/61c185fb-5077-436e-b2a4-ee0703767dbd)

![image](https://github.com/user-attachments/assets/87f6a37e-6c21-4146-bf77-e3e04f07aa27)

![image](https://github.com/user-attachments/assets/ca301c2b-c54b-406a-9110-433a938d1357)
