### PR TITLE
Remove `resolved` filter for tournament unread comments order

### DIFF
--- a/front_end/src/components/tournament_filters.tsx
+++ b/front_end/src/components/tournament_filters.tsx
@@ -38,10 +38,7 @@ const OPEN_STATUS_FILTERS = [
   QuestionOrder.ScoreDesc,
   QuestionOrder.ScoreAsc,
 ];
-const RESOLVED_STATUS_FILTERS = [
-  QuestionOrder.HotAsc,
-  QuestionOrder.UnreadCommentCountDesc,
-];
+const RESOLVED_STATUS_FILTERS = [QuestionOrder.HotAsc];
 const FORECASTER_ID_FILTERS = [
   QuestionOrder.LastPredictionTimeAsc,
   QuestionOrder.LastPredictionTimeDesc,


### PR DESCRIPTION
Remove `resolved` filter for tournament unread comments order type

fixes #2099 