### PR TITLE
UI fixes for group forecast maker

### DIFF
--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/leaderboard_table/table_row.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/leaderboard_table/table_row.tsx
@@ -69,7 +69,7 @@ const LeaderboardRow: FC<Props> = ({
           {!user && aggregation_method === "recency_weighted" ? (
             <div className="flex flex-1 items-center justify-center">
               <div className="relative text-blue-700 dark:text-blue-700-dark">
-                <span className="font-league-gothic text-lg">M</span>
+                <span className="font-league-gothic text-xl">M</span>
                 <Tooltip
                   showDelayMs={200}
                   placement={"right"}
@@ -90,7 +90,7 @@ const LeaderboardRow: FC<Props> = ({
                   className="absolute right-[-18px] inline-flex h-full items-center justify-center font-sans"
                   tooltipClassName="font-sans text-center text-gray-800 dark:text-gray-800-dark border-blue-400 dark:border-blue-400-dark bg-gray-0 dark:bg-gray-0-dark"
                 >
-                  ⓘ
+                  <span className="top-[0.5px] leading-none">ⓘ</span>
                 </Tooltip>
               </div>
             </div>

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_group_accordion/accordion_open_button.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_group_accordion/accordion_open_button.tsx
@@ -1,0 +1,49 @@
+import { DisclosureButton } from "@headlessui/react";
+import { FC, PropsWithChildren } from "react";
+
+import Button from "@/components/ui/button";
+import cn from "@/utils/cn";
+
+type Props = {
+  onClick: () => void;
+  open: boolean;
+  isDirty?: boolean;
+  isResolved?: boolean;
+};
+
+const AccordionOpenButton: FC<PropsWithChildren<Props>> = ({
+  onClick,
+  open,
+  isDirty,
+  isResolved,
+  children,
+}) => {
+  return (
+    <>
+      {/* Mobile button */}
+      <Button
+        className={cn(
+          "flex h-[58px] w-full gap-0.5 rounded-none bg-blue-100 p-0 text-left text-xs font-bold text-blue-700 dark:bg-blue-100-dark dark:text-blue-700-dark sm:hidden",
+          open && "sm:bg-blue-600/10 dark:sm:bg-blue-400/10",
+          !isResolved && isDirty && "bg-orange-100 dark:bg-orange-100-dark"
+        )}
+        onClick={onClick}
+        variant="text"
+      >
+        {children}
+      </Button>
+      {/* Desktop button */}
+      <DisclosureButton
+        className={cn(
+          "hidden h-[58px] w-full gap-0.5 bg-blue-100 text-left text-xs font-bold text-blue-700 dark:bg-blue-100-dark dark:text-blue-700-dark sm:flex",
+          open && "bg-blue-600/10 dark:bg-blue-400/10",
+          !isResolved && isDirty && "bg-orange-100 dark:bg-orange-100-dark"
+        )}
+      >
+        {children}
+      </DisclosureButton>
+    </>
+  );
+};
+
+export { AccordionOpenButton };

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_group_accordion/accordion_resolution_cell.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_group_accordion/accordion_resolution_cell.tsx
@@ -1,0 +1,45 @@
+import { FC } from "react";
+
+import ResolutionIcon from "@/components/icons/resolution";
+
+type Props = {
+  formatedResolution: string;
+  isResolved: boolean;
+  median: string | undefined;
+  userMedian: string | undefined;
+};
+
+const AccordionResolutionCell: FC<Props> = ({
+  formatedResolution,
+  isResolved,
+  median,
+  userMedian,
+}) => {
+  if (isResolved) {
+    return (
+      <div className="flex w-full items-center justify-center gap-1">
+        <ResolutionIcon />
+        <span
+          className="text-sm font-bold text-purple-800 dark:text-purple-800-dark"
+          suppressHydrationWarning
+        >
+          {formatedResolution}
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex w-full flex-col items-center justify-center gap-1">
+      <p className="m-0 text-sm leading-4 text-olive-800 dark:text-olive-800-dark">
+        {median}
+      </p>
+      {!!userMedian && (
+        <p className="m-0 text-sm leading-4 text-orange-700 dark:text-orange-700-dark">
+          {userMedian}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export { AccordionResolutionCell };

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_group_accordion/group_forecast_accordion.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_group_accordion/group_forecast_accordion.tsx
@@ -1,11 +1,10 @@
-import { useLocale, useTranslations } from "next-intl";
+import { useTranslations } from "next-intl";
 import { FC, useMemo } from "react";
 
 import { useAuth } from "@/contexts/auth_context";
 import { ErrorResponse } from "@/types/fetch";
 import { QuestionStatus } from "@/types/post";
 import { DistributionSliderComponent } from "@/types/question";
-import { formatResolution } from "@/utils/questions";
 
 import { AccordionItem } from "./group_forecast_accordion_item";
 import { useHideCP } from "../../cp_provider";
@@ -41,7 +40,6 @@ const GroupForecastAccordion: FC<Props> = ({
   handlePredictSubmit,
 }) => {
   const t = useTranslations();
-  const locale = useLocale();
   const { hideCP } = useHideCP();
   const { user } = useAuth();
   const showCP = !user || !hideCP;
@@ -70,10 +68,10 @@ const GroupForecastAccordion: FC<Props> = ({
     <div className="w-full">
       {!!resolvedOptions.length && (
         <div className="mb-0.5 flex w-full gap-0.5 text-left text-xs font-bold text-blue-700 dark:text-blue-700-dark">
-          <div className="shrink grow bg-blue-600/15 py-1 dark:bg-blue-400/15">
-            <span className="pl-4">{groupVariable}</span>
+          <div className="shrink grow overflow-hidden bg-blue-600/15 py-1 dark:bg-blue-400/15">
+            <span className="line-clamp-2 pl-4">{groupVariable}</span>
           </div>
-          <div className="max-w-[105px] shrink grow-[3] bg-blue-600/15 py-1 text-center dark:bg-blue-400/15 sm:max-w-[422px]">
+          <div className="min-w-[105px] max-w-[105px] shrink grow-[3] bg-blue-600/15 py-1 text-center dark:bg-blue-400/15 sm:min-w-[422px] sm:max-w-[422px]">
             {t("resolution")}
           </div>
           <div className="w-[43px] shrink-0 grow-0 bg-blue-600/15 py-1 dark:bg-blue-400/15"></div>
@@ -83,13 +81,9 @@ const GroupForecastAccordion: FC<Props> = ({
         return (
           <AccordionItem
             option={option}
-            resolution={formatResolution(
-              option.resolution,
-              option.question.type,
-              locale
-            )}
             showCP={true}
             subQuestionId={subQuestionId}
+            isResolvedOption={true}
             key={option.id}
           >
             <SliderWrapper
@@ -106,8 +100,8 @@ const GroupForecastAccordion: FC<Props> = ({
       })}
       {!!activeOptions.length && (
         <div className="mb-0.5 mt-2 flex w-full gap-0.5 text-left text-xs font-bold text-blue-700 dark:text-blue-700-dark">
-          <div className="shrink grow bg-blue-600/15 py-1 dark:bg-blue-400/15">
-            <span className="pl-4">{groupVariable}</span>
+          <div className="shrink grow overflow-hidden bg-blue-600/15 py-1 dark:bg-blue-400/15">
+            <span className="line-clamp-2 pl-4">{groupVariable}</span>
           </div>
           <div className="flex max-w-[105px] shrink grow-[3] gap-0.5 text-center sm:max-w-[422px]">
             <div className="w-[105px] bg-blue-600/15 py-1 dark:bg-blue-400/15">

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/continuous_slider_wrapper.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/continuous_slider_wrapper.tsx
@@ -1,3 +1,4 @@
+import { isNil } from "lodash";
 import { useLocale, useTranslations } from "next-intl";
 import { FC, PropsWithChildren, useState, useMemo, useCallback } from "react";
 
@@ -24,6 +25,7 @@ import ContinuousSlider from "../continuous_slider";
 import { ConditionalTableOption } from "../group_forecast_table";
 import NumericForecastTable from "../numeric_table";
 import PredictButton from "../predict_button";
+import ScoreDisplay from "../resolution/score_display";
 
 type SliderWrapperProps = {
   option: ConditionalTableOption;
@@ -219,6 +221,12 @@ const SliderWrapper: FC<PropsWithChildren<SliderWrapperProps>> = ({
           )}
         </>
       </div>
+
+      {!isNil(option.question.resolution) && (
+        <div className="my-4 p-4">
+          <ScoreDisplay question={option.question} variant="transparent" />
+        </div>
+      )}
     </div>
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/resolution/score_display.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/resolution/score_display.tsx
@@ -7,16 +7,17 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { FC } from "react";
 
-import SectionToggle from "@/components/ui/section_toggle";
+import SectionToggle, { SectionVariant } from "@/components/ui/section_toggle";
 import { QuestionWithForecasts, ScoreData } from "@/types/question";
 import cn from "@/utils/cn";
 
 type Props = {
   question: QuestionWithForecasts;
   className?: string;
+  variant?: SectionVariant;
 };
 
-const ScoreDisplay: FC<Props> = ({ question, className }) => {
+const ScoreDisplay: FC<Props> = ({ question, className, variant }) => {
   const t = useTranslations();
   const cp_scores = question.aggregations.recency_weighted.score_data;
   const user_scores = question.my_forecasts?.score_data;
@@ -84,7 +85,11 @@ const ScoreDisplay: FC<Props> = ({ question, className }) => {
         )}
       </div>
       {checkAdditionalScores(user_scores, cp_scores) && (
-        <SectionToggle title="Additional Scores" defaultOpen={false}>
+        <SectionToggle
+          title="Additional Scores"
+          defaultOpen={false}
+          variant={variant}
+        >
           <div className="my-4 grid grid-cols-2 gap-1.5 sm:grid-cols-4">
             {user_scores?.spot_baseline_score != null && (
               <div className="box flex flex-col items-center justify-center gap-1 border border-gray-400 p-2.5 text-center text-gray-700 dark:border-gray-400-dark dark:text-gray-700-dark">

--- a/front_end/src/components/ui/section_toggle.tsx
+++ b/front_end/src/components/ui/section_toggle.tsx
@@ -11,7 +11,7 @@ import { FC, PropsWithChildren } from "react";
 
 import cn from "@/utils/cn";
 
-export type SectionVariant = "primary" | "light" | "gold";
+export type SectionVariant = "primary" | "light" | "gold" | "transparent";
 
 type Props = {
   title?: string;
@@ -44,6 +44,7 @@ const SectionToggle: FC<PropsWithChildren<Props>> = ({
             "bg-blue-200 dark:bg-blue-200-dark": variant === "primary",
             "bg-gray-0 dark:bg-gray-0-dark": variant === "light",
             "bg-gold-200 dark:bg-gold-200-dark": variant === "gold",
+            "bg-transparent dark:bg-transparent": variant === "transparent",
             "bg-opacity-50": !open,
           })}
         >


### PR DESCRIPTION
- #2181
  - changed render of resolution field for closed continuous group question
  - if question have resolution - display it, otherwise show CP and user forecast
- #2201
  - adjusted render of subquestion title to wrap it and truncate if it overflows
  - adjusted font size and code structure for group accordion component
- #2240
  - improved styles for `ScoreDisplay` in continuous group
  - added it into subquestion mobile view