### PR TITLE
Delete FAQ mention of private questions

### DIFF
--- a/front_end/src/app/(main)/faq/page.tsx
+++ b/front_end/src/app/(main)/faq/page.tsx
@@ -94,7 +94,7 @@ export default async function FAQ() {
               </a>
             </li>
             <li>
-              <a href="#question-private">What is a private question?</a>
+              <a href="#question-private">Where are my private questions?</a>
             </li>
             <li>
               <a href="#comments">
@@ -875,28 +875,14 @@ export default async function FAQ() {
           className="scroll-mt-nav text-xl font-semibold"
           id="question-private"
         >
-          What is a private question?
+          Where are my private questions?
         </h3>
         <p>
-          Private questions are questions that are not visible to the broader
-          community. They aren&apos;t subject to the normal review process, so
-          you can create one and predict on it right away. You can resolve your
-          own private questions at any time, but points for private predictions
-          won&apos;t be added to your overall Metaculus score and they
-          won&apos;t affect your ranking on the leaderboard.
-        </p>
-        <p>
-          You can use private questions for anything you want. Use them as
-          practice to calibrate your predictions before playing for points,
-          create a question series on a niche topic, or pose personal questions
-          that only you can resolve.{" "}
-          <strong>You can even invite up to 19 other users</strong> to view and
-          predict on your own questions!
-        </p>
-        <p>
-          To invite other forecasters to your private question, click the
-          &apos;...&apos; more options menu and select &apos;Share Private
-          Question&apos;.
+          Private questions are deprecated, it is no longer possible to create
+          new ones. If you had private questions, you can still find them by
+          going to the <a href="/questions/">Feed Home</a>, selecting &quot;My
+          questions and posts&quot; in the sidebar, and using the
+          &quot;Personal&quot; special filter.
         </p>
 
         <h3 className="scroll-mt-nav text-xl font-semibold" id="comments">
@@ -2406,7 +2392,7 @@ export default async function FAQ() {
             this means that, starting from the moment you withdrew and until you
             make a new prediction:
           </p>
-          <p>
+          <div className="text-gray-700 dark:text-gray-400">
             <ul className="list-disc pl-5">
               <li>
                 You stop accruing scores, including Peer scores, Baseline
@@ -2417,7 +2403,7 @@ export default async function FAQ() {
                 You aren’t part of the Community Prediction or other aggregates.
               </li>
             </ul>
-          </p>
+          </div>
           <p>
             None of those behaviours are retroactive: you still get scores and
             coverage for times up until you withdrew, and your past predictions

--- a/front_end/src/app/(main)/faq/page_pt.tsx
+++ b/front_end/src/app/(main)/faq/page_pt.tsx
@@ -83,7 +83,9 @@ export default function FAQ() {
               </a>
             </li>
             <li>
-              <a href="#question-private">O que é uma pergunta privada?</a>
+              <a href="#question-private">
+                Onde estão minhas questões privadas?
+              </a>
             </li>
             <li>
               <a href="#comments">
@@ -875,30 +877,16 @@ export default function FAQ() {
           className="scroll-mt-nav text-xl font-semibold"
           id="question-private"
         >
-          O que é uma pergunta privada?
+          Onde estão minhas questões privadas?
         </h3>
         <p>
-          Questões privadas são questões que não são visíveis para a comunidade
-          em geral. Eles não estão sujeitos ao processo de revisão normal, então
-          você pode criar um e prever sobre ele imediatamente. Você pode
-          resolver suas próprias perguntas privadas a qualquer momento, mas
-          pontos para previsões privadas não serão adicionados à sua pontuação
-          geral do Metaculus e eles não afetarão sua classificação na tabela de
-          classificação.
+          As questões privadas estão descontinuadas, não é mais possível criar
+          novas. Se você tinha questões privadas, ainda pode encontrá-las indo
+          para a <a href="/questions/">Página Inicial do Feed</a>, selecionando
+          &quot;Minhas questões e posts&quot; na barra lateral e usando o filtro
+          especial &quot;Pessoal&quot;.
         </p>
-        <p>
-          Você pode usar perguntas privadas para qualquer coisa que você quiser.
-          Use-os como prática para calibrar suas previsões antes de jogar por
-          pontos, criar uma série de perguntas sobre um tópico de nicho ou fazer
-          perguntas pessoais que só você pode resolver.{""}
-          <strong>Você pode até convidar até 19 outros usuários</strong>
-          para visualizar e prever em suas próprias perguntas!
-        </p>
-        <p>
-          Para convidar outros meteorologistas para sua pergunta privada, clique
-          no menu de opções &quot;...&quot; e selecione &quot;Compartilhar
-          Pergunta Privada&quot;.
-        </p>
+
         <h3 className="scroll-mt-nav text-xl font-semibold" id="comments">
           Quais são as regras e diretrizes para comentários e discussões?
         </h3>
@@ -2426,7 +2414,7 @@ export default function FAQ() {
             novamente. Concretamente, isso significa que, a partir do momento em
             que você se retirou e até fazer uma nova previsão:
           </p>
-          <p>
+          <div className="text-gray-700 dark:text-gray-400">
             <ul className="list-disc pl-5">
               <li>
                 Você para de acumular pontuações, incluindo escores de pares,
@@ -2440,7 +2428,7 @@ export default function FAQ() {
                 agregados.
               </li>
             </ul>
-          </p>
+          </div>
           <p>
             Nenhum desses comportamentos é retroativo: você ainda obtém
             pontuações e cobertura por horas até que você se retirou, e suas


### PR DESCRIPTION
Related to #1512

- resolved hydration error (ul tag was nested in p)
- added a new block about private questions for both locales