### PR TITLE
Accessing the site with an invalid token gives useless feedback

### DIFF
--- a/front_end/src/services/auth.ts
+++ b/front_end/src/services/auth.ts
@@ -27,7 +27,7 @@ class AuthApi {
   }
 
   static async verifyToken() {
-    return get("/auth/verify_token/");
+    return get("/auth/verify_token/", {}, { includeLocale: false });
   }
 
   static async exchangeSocialOauthCode(

--- a/front_end/src/utils/fetch.ts
+++ b/front_end/src/utils/fetch.ts
@@ -98,13 +98,18 @@ const defaultOptions: FetchOptions = {
 type FetchConfig = {
   emptyContentType?: boolean;
   passAuthHeader?: boolean;
+  includeLocale?: boolean;
 };
 const appFetch = async <T>(
   url: string,
   options: FetchOptions = {},
   config?: FetchConfig
 ): Promise<T> => {
-  let { emptyContentType = false, passAuthHeader = true } = config ?? {};
+  let {
+    emptyContentType = false,
+    passAuthHeader = true,
+    includeLocale = true,
+  } = config ?? {};
 
   // Warning: caching could be only applied to anonymised requests
   // To prevent user token leaks and storage spam.
@@ -115,7 +120,7 @@ const appFetch = async <T>(
 
   const authToken = passAuthHeader ? getServerSession() : null;
   const alphaToken = getAlphaTokenSession();
-  const locale = await getLocale();
+  const locale = includeLocale ? await getLocale() : "en";
 
   // Default values are configured in the next.config.mjs
   const finalUrl = `${process.env.API_BASE_URL}/api${url}`;


### PR DESCRIPTION
Closes #2092

This logic was already implemented in the `middleware`. However, since `getLocale()` was called inside the `middleware`, the error handling was tied to it rather than the token check. As a result, an invalid token was always present in the browser, causing the app to crash. Now, if the token is incorrect, the user is simply logged out, and the page loads as usual.