### PR TITLE
Mouseovering group question timelines shows wrong values

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choice_group_chart.tsx
@@ -188,10 +188,14 @@ const MultipleChoiceGroupChart: FC<Props> = ({
     return choiceItems
       .filter(({ active }) => active)
       .map(
-        (
-          { choice, userValues, color, userTimestamps: timestamps, closeTime },
-          index
-        ) => {
+        ({
+          id,
+          choice,
+          userValues,
+          color,
+          userTimestamps: timestamps,
+          closeTime,
+        }) => {
           return {
             choiceLabel: choice,
             color,
@@ -199,8 +203,8 @@ const MultipleChoiceGroupChart: FC<Props> = ({
               timestamps,
               values: userValues,
               cursorTimestamp,
-              question: questions[index],
               closeTime,
+              question: questions.find((q) => q.id === id),
             }),
           };
         }


### PR DESCRIPTION
Related to #2250

- fixed cursor label value for user prediction on group question chart