### PR TITLE
Total forecasters shown as zero after subquestion resolves

### DIFF
--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -1026,7 +1026,7 @@ export function generateChoiceItemsFromGroupQuestions(
       const aggregationForecast = aggregationHistory.find((forecast) => {
         return (
           forecast.start_time <= timestamp &&
-          (forecast.end_time === null || forecast.end_time > timestamp)
+          (forecast.end_time === null || forecast.end_time >= timestamp)
         );
       });
       aggregationValues.push(aggregationForecast?.centers?.[0] || null);


### PR DESCRIPTION
Related to #2213

- fixed the condition for aggregationForecast timestamp data assertion

