### PR TITLE
Subquestion table interaction is on top of combined timeline graph drop down menu

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/choices_legend/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/choices_legend/index.tsx
@@ -72,7 +72,7 @@ const ChoicesLegend: FC<Props> = ({
               </PopoverButton>
               <PopoverPanel
                 anchor="bottom"
-                className="flex max-h-48 w-max flex-col overflow-y-auto rounded border border-gray-300 bg-gray-0 p-1 text-xs [--anchor-gap:4px] dark:border-gray-300-dark dark:bg-gray-0-dark"
+                className="z-100 flex max-h-48 w-max flex-col overflow-y-auto rounded border border-gray-300 bg-gray-0 p-1 text-xs [--anchor-gap:4px] dark:border-gray-300-dark dark:bg-gray-0-dark"
               >
                 <Checkbox
                   checked={areAllSelected}


### PR DESCRIPTION
Related to #2264

- adjust z-index for subquestions popover