### PR TITLE
Something amiss with change-this-week in index

### DIFF
--- a/front_end/src/app/(main)/notebooks/components/index_notebook/index.tsx
+++ b/front_end/src/app/(main)/notebooks/components/index_notebook/index.tsx
@@ -107,6 +107,8 @@ function calculateIndex(posts: PostWithForecastsAndWeight[]): {
   if (weightSum === 0) {
     return { index: 0, indexWeekAgo: 0 };
   }
+  const dateNow = new Date();
+  const weekAgoDate = subWeeks(dateNow, 1);
 
   const { scoreSum, weeklyScoreSum } = posts.reduce(
     (acc, post) => {
@@ -125,11 +127,14 @@ function calculateIndex(posts: PostWithForecastsAndWeight[]): {
       let postValue = 0;
       let postValueWeekAgo = 0;
       const cp = latestAggregation.centers?.at(-1);
-      const latestDate = fromUnixTime(latestAggregation.start_time);
-      const weekAgoDate = subWeeks(latestDate, 1);
-      const weekAgoCP = historyAggregation.find(
-        (el) => fromUnixTime(el.start_time) >= weekAgoDate
-      )?.centers?.[0];
+
+      const weekAgoCP =
+        historyAggregation.find(
+          (el) =>
+            el.end_time &&
+            fromUnixTime(el.end_time) >=
+              fromUnixTime(weekAgoDate.getTime() / 1000)
+        )?.centers?.[0] ?? null;
 
       switch (post.question.type) {
         case QuestionType.Binary: {

--- a/front_end/src/app/(main)/notebooks/components/index_notebook/index_community_prediction.tsx
+++ b/front_end/src/app/(main)/notebooks/components/index_notebook/index_community_prediction.tsx
@@ -30,7 +30,9 @@ const CommunityPrediction: FC<Props> = ({ rawValue, displayValue, post }) => {
       <span className="font-bold text-gray-700 dark:text-gray-700-dark">
         {displayValue}
       </span>
-      {!!post.question && <CPWeeklyMovement question={post.question} />}
+      {!!post.question && (
+        <CPWeeklyMovement question={post.question} checkDelta={false} />
+      )}
     </div>
   );
 };

--- a/front_end/src/components/weekly_movement.tsx
+++ b/front_end/src/components/weekly_movement.tsx
@@ -36,6 +36,7 @@ const WeeklyMovement: FC<Props> = ({
               isNegative
                 ? "text-salmon-600 dark:text-salmon-600-dark"
                 : "text-olive-700 dark:text-olive-700-dark",
+              "mr-1",
               iconClassName
             )}
             icon={isNegative ? faCaretDown : faCaretUp}


### PR DESCRIPTION
Related to #2279

- adjusted render of question weekly movement to ignore minimum delta change
- fixed weekAgoCP mismatch inside calculateIndex and getQuestionWeeklyMovement functions
- adjusted weekly movement calculation to compare last CP week ago from actual time instead of the last forecast time

Local index page:

![image](https://github.com/user-attachments/assets/82c800a9-27ee-48b8-b2ef-ecb4d72a2ac1)

Production index page:

![image](https://github.com/user-attachments/assets/cd076477-6c0c-40f8-b7d4-e961e0db5c8a)
