### PR TITLE
Added project timeline data

### DIFF
--- a/projects/services/common.py
+++ b/projects/services/common.py
@@ -3,6 +3,7 @@ from typing import Iterable
 
 from django.db import IntegrityError, transaction
 from django.db.models import Q
+from django.utils import timezone
 
 from notifications.constants import MailingTags
 from notifications.services import (
@@ -197,3 +198,55 @@ def get_projects_for_posts(
             post_projects_map[m2m_obj.post_id].append(project)
 
     return post_projects_map
+
+
+def get_project_timeline_data(project: Project):
+    all_questions_resolved = True
+    all_questions_closed = True
+
+    cp_reveal_times = []
+    actual_resolve_times = []
+    scheduled_resolve_times = []
+    actual_close_times = []
+    scheduled_close_times = []
+
+    posts = (
+        Post.objects.filter_projects(project)
+        .filter_questions()
+        .prefetch_questions()
+        .filter(curation_status=Post.CurationStatus.APPROVED)
+    )
+
+    for post in posts:
+        if not post.resolved:
+            all_questions_resolved = False
+        if not post.actual_close_time or post.actual_close_time > timezone.now():
+            all_questions_closed = False
+
+        questions = post.get_questions()
+
+        for question in questions:
+            if question.cp_reveal_time:
+                cp_reveal_times.append(question.cp_reveal_time)
+
+            if question.actual_resolve_time:
+                actual_resolve_times.append(question.actual_resolve_time)
+
+        if post.scheduled_resolve_time:
+            scheduled_resolve_times.append(post.scheduled_resolve_time)
+
+        if post.actual_close_time:
+            actual_close_times.append(post.actual_close_time)
+
+        if post.scheduled_close_time:
+            scheduled_close_times.append(post.scheduled_close_time)
+
+    return {
+        "last_cp_reveal_time": max(cp_reveal_times, default=None),
+        "latest_actual_resolve_time": max(actual_resolve_times, default=None),
+        "latest_scheduled_resolve_time": max(scheduled_resolve_times, default=None),
+        "latest_actual_close_time": max(actual_close_times, default=None),
+        "latest_scheduled_close_time": max(scheduled_close_times, default=None),
+        "all_questions_resolved": all_questions_resolved,
+        "all_questions_closed": all_questions_closed,
+    }

--- a/projects/views/common.py
+++ b/projects/views/common.py
@@ -28,6 +28,7 @@ from projects.services.common import (
     subscribe_project,
     unsubscribe_project,
     get_site_main_project,
+    get_project_timeline_data,
 )
 from questions.models import Question
 from users.services.common import get_users_by_usernames
@@ -180,6 +181,7 @@ def tournament_by_slug_api_view(request: Request, slug: str):
 
     data = TournamentSerializer(obj).data
     data["questions_count"] = getattr(obj, "questions_count", None)
+    data["timeline"] = get_project_timeline_data(obj)
 
     if request.user.is_authenticated:
         data["is_subscribed"] = obj.subscriptions.filter(user=request.user).exists()


### PR DESCRIPTION
Added `timeline` object to the Tournament page response. Required for "Redesigned Project pages" project

Related to - https://github.com/Metaculus/metaculus/pull/2286