### PR TITLE
Improved layout rendering for project pages with no cover image

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
@@ -20,13 +20,13 @@ import ProjectsApi from "@/services/projects";
 import { SearchParams } from "@/types/navigation";
 import { ProjectPermissions } from "@/types/post";
 import { ProjectVisibility, TournamentType } from "@/types/projects";
-import cn from "@/utils/cn";
 import { formatDate } from "@/utils/date_formatters";
 import { getPublicSettings } from "@/utils/public_settings.server";
 
-import TournamentDropdownMenu from "../components/dropdown_menu";
+import HeaderBlockNav from "../components/header_block_navigation";
 import TournamentFeed from "../components/tournament_feed";
 import TournamentTimeline from "../components/tournament_timeline";
+
 const LazyProjectMembers = dynamic(() => import("../components/members"), {
   ssr: false,
 });
@@ -67,11 +67,6 @@ export default async function TournamentSlug({ params }: Props) {
   const t = await getTranslations();
   const locale = await getLocale();
   const isQuestionSeries = tournament.type === TournamentType.QuestionSeries;
-  const title = isQuestionSeries
-    ? t("QuestionSeries")
-    : tournament.type === TournamentType.Index
-      ? t("Index")
-      : t("Tournament");
   const questionsTitle = isQuestionSeries
     ? t("SeriesContents")
     : t("questions");
@@ -82,28 +77,14 @@ export default async function TournamentSlug({ params }: Props) {
     <main className="mx-auto mb-16 min-h-min w-full max-w-[780px] flex-auto px-0 sm:mt-[52px]">
       {/* header block */}
       <div className="overflow-hidden rounded-b-md bg-gray-0 dark:bg-gray-0-dark sm:rounded-md">
-        <div className="relative h-[130px] w-full">
-          <div
-            className={cn(
-              "absolute z-10 flex h-6 w-full flex-wrap items-center justify-between gap-2.5 bg-transparent p-[10px] text-[20px] uppercase text-gray-100 dark:text-gray-100-dark"
-            )}
-          >
-            <div className="flex items-center gap-2">
-              <Link
-                href={"/tournaments"}
-                className="block rounded-sm bg-black/30 px-1.5 py-1 text-xs font-bold leading-4 text-gray-0 no-underline hover:text-gray-400 dark:hover:text-gray-400-dark"
-              >
-                {title}
-              </Link>
-              {tournament.default_permission === null && (
-                <strong className="block rounded-sm bg-black/30 px-1.5 py-1 text-xs font-bold uppercase leading-4 text-gray-0">
-                  {t("private")}
-                </strong>
-              )}
-            </div>
-            <TournamentDropdownMenu tournament={tournament} />
-          </div>
-          {!!tournament.header_image && (
+        {!!tournament.header_image && (
+          <div className="relative h-[130px] w-full">
+            <HeaderBlockNav
+              tournament={tournament}
+              className="absolute z-10 px-4 py-3 md:p-2.5"
+              variant="image_overflow"
+            />
+
             <Image
               src={tournament.header_image}
               alt=""
@@ -112,9 +93,15 @@ export default async function TournamentSlug({ params }: Props) {
               className="size-full object-cover object-center"
               unoptimized
             />
-          )}
-        </div>
+          </div>
+        )}
         <div className="px-4 pb-5 pt-4 sm:p-8">
+          {!tournament.header_image && (
+            <HeaderBlockNav
+              tournament={tournament}
+              className="mb-2.5 md:mb-4"
+            />
+          )}
           <div className="flex items-start justify-between gap-1 sm:gap-4">
             <h1 className="m-0 text-xl text-blue-800 dark:text-blue-800-dark md:text-2xl lg:text-3xl xl:text-4xl">
               {tournament.name}

--- a/front_end/src/app/(main)/(tournaments)/tournament/components/dropdown_menu.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/components/dropdown_menu.tsx
@@ -8,12 +8,17 @@ import Button from "@/components/ui/button";
 import DropdownMenu, { MenuItemProps } from "@/components/ui/dropdown_menu";
 import { useAuth } from "@/contexts/auth_context";
 import { Tournament } from "@/types/projects";
+import cn from "@/utils/cn";
 
 type Props = {
   tournament: Tournament;
+  variant?: "image_overflow" | "default";
 };
 
-const TournamentDropdownMenu: FC<Props> = ({ tournament }) => {
+const TournamentDropdownMenu: FC<Props> = ({
+  tournament,
+  variant = "default",
+}) => {
   const t = useTranslations();
 
   const { user } = useAuth();
@@ -35,12 +40,18 @@ const TournamentDropdownMenu: FC<Props> = ({ tournament }) => {
   return (
     <DropdownMenu items={menuItems} className="normal-case">
       <Button
-        className="rounded-full border-0 bg-black/50 hover:bg-blue-500 dark:bg-black/50 dark:hover:bg-blue-500-dark"
+        className={cn({
+          "border-0 bg-black/50 hover:bg-black/30 dark:bg-black/50":
+            variant === "image_overflow",
+        })}
         presentationType="icon"
+        variant="tertiary"
       >
         <FontAwesomeIcon
           icon={faEllipsis}
-          className="text-gray-0 dark:text-gray-0"
+          className={cn({
+            "text-gray-0 dark:text-gray-0": variant === "image_overflow",
+          })}
         />
       </Button>
     </DropdownMenu>

--- a/front_end/src/app/(main)/(tournaments)/tournament/components/header_block_navigation.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/components/header_block_navigation.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { FC } from "react";
+
+import { Tournament, TournamentType } from "@/types/projects";
+import cn from "@/utils/cn";
+
+import TournamentDropdownMenu from "./dropdown_menu";
+
+const HeaderBlockNav: FC<{
+  tournament: Tournament;
+  variant?: "image_overflow" | "default";
+  className?: string;
+}> = ({ tournament, variant = "default", className }) => {
+  const t = useTranslations();
+
+  let title: string;
+  switch (tournament.type) {
+    case TournamentType.QuestionSeries:
+      title = t("QuestionSeries");
+      break;
+    case TournamentType.Index:
+      title = t("Index");
+      break;
+    default:
+      title = t("Tournament");
+      break;
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex h-6 w-full flex-wrap items-center justify-between gap-2.5 bg-transparent uppercase text-gray-100 dark:text-gray-100-dark",
+        className
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <Link
+          href={"/tournaments"}
+          className={cn(
+            "block rounded-sm px-1.5 py-1 text-xs font-bold leading-4 no-underline",
+            {
+              "bg-black/30 text-gray-0 hover:text-gray-400 dark:hover:text-gray-400-dark":
+                variant === "image_overflow",
+              "bg-blue-700/30 text-blue-700 hover:bg-blue-700/40 dark:bg-blue-700-dark/30 dark:text-blue-700-dark dark:hover:bg-blue-700-dark/40":
+                variant === "default",
+            }
+          )}
+        >
+          {title}
+        </Link>
+        {tournament.default_permission === null && (
+          <strong
+            className={cn(
+              "block rounded-sm px-1.5 py-1 text-xs font-bold uppercase leading-4",
+              {
+                "bg-black/30 text-gray-0": variant === "image_overflow",
+                "bg-blue-700/30 text-blue-700 dark:bg-blue-700-dark/30 dark:text-blue-700-dark":
+                  variant === "default",
+              }
+            )}
+          >
+            {t("private")}
+          </strong>
+        )}
+      </div>
+      <TournamentDropdownMenu tournament={tournament} variant={variant} />
+    </div>
+  );
+};
+
+export default HeaderBlockNav;


### PR DESCRIPTION
Related to #2312

<img width="814" alt="image" src="https://github.com/user-attachments/assets/76736e66-3199-443f-bf1f-d17c82463674" />

<img width="448" alt="image" src="https://github.com/user-attachments/assets/f16a622f-3b05-4f5c-8e74-abe0b072ee29" />

<img width="837" alt="image" src="https://github.com/user-attachments/assets/0d3c03bd-954d-4259-92bb-a92b2c40febf" />

<img width="457" alt="image" src="https://github.com/user-attachments/assets/64ee0bec-cfae-4997-bb85-e9c74ef7b019" />
