### PR TITLE
One cell of a table will never accept data

### DIFF
--- a/front_end/src/components/markdown_editor/initialized_editor.tsx
+++ b/front_end/src/components/markdown_editor/initialized_editor.tsx
@@ -142,7 +142,8 @@ const InitializedMarkdownEditor: FC<
   );
   const debouncedHandleEditorChange = useDebouncedCallback(
     handleEditorChange,
-    100
+    100,
+    { leading: true }
   );
 
   useEffect(() => {

--- a/front_end/src/hooks/use_debounce.ts
+++ b/front_end/src/hooks/use_debounce.ts
@@ -2,6 +2,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 type Timer = ReturnType<typeof setTimeout>;
 
+type DebounceOptions = {
+  leading?: boolean;
+  trailing?: boolean;
+};
+
 export const useDebouncedValue = <T>(value: T, delay: number) => {
   const [debouncedValue, setDebouncedValue] = useState(value);
 
@@ -20,14 +25,51 @@ export const useDebouncedValue = <T>(value: T, delay: number) => {
 
 export const useDebouncedCallback = <T>(
   func: (arg: T) => void,
-  wait: number
+  wait: number,
+  options?: DebounceOptions
 ) => {
   const timeout = useRef<Timer>();
+  const funcRef = useRef(func);
+  const argRef = useRef<T | null>(null);
 
-  const debouncedFunc = (arg: T) => {
-    clearTimeout(timeout.current);
-    timeout.current = setTimeout(() => func(arg), wait);
-  };
+  const { leading = false, trailing = true } = options ?? {};
 
-  return useCallback(debouncedFunc, [func, wait]);
+  // keep the function reference updated
+  useEffect(() => {
+    funcRef.current = func;
+  }, [func]);
+
+  // clean up timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeout.current) {
+        clearTimeout(timeout.current);
+      }
+    };
+  }, []);
+
+  return useCallback(
+    (arg: T) => {
+      argRef.current = arg;
+      const callNow = leading && !timeout.current;
+
+      if (timeout.current) {
+        clearTimeout(timeout.current);
+      }
+
+      timeout.current = setTimeout(() => {
+        if (trailing && !callNow) {
+          // okay to ignore since we update ref on every call
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          funcRef.current(argRef.current!);
+        }
+        timeout.current = undefined;
+      }, wait);
+
+      if (callNow) {
+        funcRef.current(arg);
+      }
+    },
+    [wait, leading, trailing]
+  );
 };


### PR DESCRIPTION
Related to #2208

The issue was caused by race-conditions when debouncing onChange event and submitting a mutation. 

- expanded `useDebouncedCallback` hook to allow leading execution of function (similar to what lodash provides)