### PR TITLE
Fixed timeline for projects

### DIFF
--- a/projects/admin.py
+++ b/projects/admin.py
@@ -127,10 +127,7 @@ class PostInlineBase(admin.TabularInline):
         if not project.close_date:
             return None
 
-        return not any(
-            q.scheduled_close_time > project.close_date
-            for q in questions
-        )
+        return not any(q.scheduled_close_time > project.close_date for q in questions)
 
     closes_before.short_description = "Closes Before"
     closes_before.boolean = True
@@ -142,14 +139,10 @@ class PostInlineBase(admin.TabularInline):
         if not project.close_date:
             return None
 
-        return not any(
-            q.scheduled_resolve_time > project.close_date
-            for q in questions
-        )
+        return not any(q.scheduled_resolve_time > project.close_date for q in questions)
 
     resolves_before.short_description = "Resolves Before"
     resolves_before.boolean = True
-
 
 
 class PostDefaultProjectInline(PostInlineBase):

--- a/projects/services/common.py
+++ b/projects/services/common.py
@@ -226,10 +226,6 @@ def get_project_timeline_data(project: Project):
 
     for post in posts:
         for question in post.get_questions():
-            # Don't include questions that resolve after tournament end_date
-            #if question.scheduled_resolve_time > project_close_date:
-            #    continue
-
             if all_questions_resolved:
                 all_questions_resolved = (
                     question.actual_resolve_time


### PR DESCRIPTION
- Fixed project timeline to respect `Project.close_date`
- Added admin improvements to the project page to display whether post closes/resolves within current Project timelines:
<img width="314" alt="image" src="https://github.com/user-attachments/assets/b10d3f4e-f1cb-47f4-9caf-d0dfdcc36f2e" />
