### PR TITLE
Sentry initialization doesn't work on client

### DIFF
--- a/front_end/sentry.client.config.ts
+++ b/front_end/sentry.client.config.ts
@@ -1,9 +1,12 @@
 import * as Sentry from "@sentry/nextjs";
 
-if (!!process.env.PUBLIC_FRONTEND_SENTRY_DSN) {
+import { getPublicSetting } from "@/components/public_settings_script";
+
+const sentryDsn = getPublicSetting("PUBLIC_FRONTEND_SENTRY_DSN");
+if (!!sentryDsn) {
   Sentry.init({
     environment: process.env.METACULUS_ENV,
-    dsn: process.env.PUBLIC_FRONTEND_SENTRY_DSN,
+    dsn: sentryDsn,
     tracesSampleRate: 0.1,
     integrations: [Sentry.replayIntegration()],
     replaysSessionSampleRate: 0.1,

--- a/front_end/src/app/layout.tsx
+++ b/front_end/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { Toaster } from "react-hot-toast";
 
 import ChunkRetryScript from "@/components/chunk_retry_script";
 import GlobalModals from "@/components/global_modals";
+import PublicSettingsScript from "@/components/public_settings_script";
 import AppThemeProvided from "@/components/theme_provider";
 import { METAC_COLORS } from "@/constants/colors";
 import AuthProvider from "@/contexts/auth_context";
@@ -23,7 +24,6 @@ import ProfileApi from "@/services/profile";
 import { getPublicSettings } from "@/utils/public_settings.server";
 
 import { CSPostHogProvider, TranslationsBannerProvider } from "./providers";
-const publicSettings = getPublicSettings();
 
 const PostHogPageView = dynamic(
   () => import("@/components/posthog_page_view"),
@@ -113,6 +113,8 @@ const leagueGothic = localFont({
 });
 
 export async function generateMetadata(): Promise<Metadata> {
+  const publicSettings = getPublicSettings();
+
   return {
     title: "Metaculus",
     description: "Metaculus",
@@ -147,6 +149,7 @@ export default async function RootLayout({
   const locale = await getLocale();
   const messages = await getMessages();
   const user = await ProfileApi.getMyProfile();
+  const publicSettings = getPublicSettings();
 
   return (
     <html
@@ -156,6 +159,9 @@ export default async function RootLayout({
       // https://github.com/pacocoursey/next-themes?tab=readme-ov-file#with-app
       suppressHydrationWarning
     >
+      <head>
+        <PublicSettingsScript publicSettings={publicSettings} />
+      </head>
       <CSPostHogProvider>
         <body className="min-h-screen w-full bg-blue-200 dark:bg-blue-50-dark">
           <PostHogPageView />

--- a/front_end/src/components/public_settings_script.tsx
+++ b/front_end/src/components/public_settings_script.tsx
@@ -1,0 +1,41 @@
+import { unstable_noStore as noStore } from "next/cache";
+import { FC } from "react";
+
+import { PublicSettings } from "@/utils/public_settings";
+
+export const PUBLIC_SETTINGS_KEY = "PUBLIC_SETTINGS";
+
+type Props = {
+  publicSettings: PublicSettings;
+};
+
+const PublicSettingsScript: FC<Props> = ({ publicSettings }) => {
+  noStore(); // opt into dynamic rendering
+
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `
+        window['${PUBLIC_SETTINGS_KEY}'] = ${JSON.stringify(publicSettings)};
+        `,
+      }}
+    />
+  );
+};
+
+export function getPublicSetting<T extends keyof PublicSettings>(
+  key: T
+): PublicSettings[T] | undefined {
+  noStore();
+
+  if (!isBrowser()) {
+    return;
+  }
+
+  return window[PUBLIC_SETTINGS_KEY][key];
+}
+
+const isBrowser = () =>
+  Boolean(typeof window !== "undefined" && window[PUBLIC_SETTINGS_KEY]);
+
+export default PublicSettingsScript;


### PR DESCRIPTION
- implement alternative API for accessing public settings from `window` object
- updated Sentry initialization for the client

Example: https://metaculus.sentry.io/issues/6367530720/?project=4507883273125888&query=is:unresolved%20issue.priority:%5Bhigh,%20medium%5D&statsPeriod=24h&stream_index=0