### PR TITLE
Update only the embed_vector field inside the post task

### DIFF
--- a/posts/services/search.py
+++ b/posts/services/search.py
@@ -63,7 +63,7 @@ def update_post_search_embedding_vector(post: Post):
     )
 
     post.embedding_vector = vector
-    post.save()
+    post.save(update_fields=["embedding_vector"])
 
 
 def perform_post_search(qs, search_text: str):


### PR DESCRIPTION
This was running in parallel with the translations task and was overriding the translation fields with the old ones from when the task was started.
This fix ensures only the embed_vector field is set.