### PR TITLE
Consumer Views - Date tiles

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -1109,5 +1109,7 @@
   "sourceMode": "Režim zdroje",
   "reject": "Zamítnout",
   "sendBackToReview": "Vrátit k posouzení",
-  "deleteRejectPostDescription": "Opravdu chcete {destructiveAction} tuto otázku?"
+  "deleteRejectPostDescription": "Opravdu chcete {destructiveAction} tuto otázku?",
+  "forecastRevealed": "Předpověď odhalena",
+  "closedForForecastingDescription": "Tato otázka je uzavřena pro předpovídání. Zobrazuje se poslední předpověď komunity."
 }

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1106,5 +1106,7 @@
   "markdownHelp": "Markdown help",
   "sourceMode": "Source mode",
   "deleteRejectPostDescription": "Are you sure you want to {destructiveAction} this question?",
-  "sendBackToReview": "Send back to review"
+  "sendBackToReview": "Send back to review",
+  "forecastRevealed": "Forecast revealed",
+  "closedForForecastingDescription": "This question is closed for forecasting. Latest Community prediction is displayed."
 }

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -1109,5 +1109,7 @@
   "sourceMode": "Modo fuente",
   "reject": "Rechazar",
   "sendBackToReview": "Enviar de nuevo a revisión",
-  "deleteRejectPostDescription": "¿Estás seguro de que quieres {destructiveAction} esta pregunta?"
+  "deleteRejectPostDescription": "¿Estás seguro de que quieres {destructiveAction} esta pregunta?",
+  "forecastRevealed": "Pronóstico revelado",
+  "closedForForecastingDescription": "Esta pregunta está cerrada para pronósticos. Se muestra la última predicción de la comunidad."
 }

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -1107,5 +1107,7 @@
   "sourceMode": "Modo de origem",
   "reject": "Rejeitar",
   "sendBackToReview": "Enviar de volta para revisão",
-  "deleteRejectPostDescription": "Tem certeza de que deseja {destructiveAction} esta pergunta?"
+  "deleteRejectPostDescription": "Tem certeza de que deseja {destructiveAction} esta pergunta?",
+  "forecastRevealed": "Previsão revelada",
+  "closedForForecastingDescription": "Esta pergunta está fechada para previsões. A última previsão da Comunidade está exibida."
 }

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -1111,5 +1111,7 @@
   "sourceMode": "源模式",
   "reject": "拒绝",
   "sendBackToReview": "退回审核",
-  "deleteRejectPostDescription": "您确定要{destructiveAction}这个问题吗？"
+  "deleteRejectPostDescription": "您确定要{destructiveAction}这个问题吗？",
+  "forecastRevealed": "预测已揭示",
+  "closedForForecastingDescription": "此问题已关闭预测。显示的是最新的社区预测。"
 }

--- a/front_end/src/app/providers.tsx
+++ b/front_end/src/app/providers.tsx
@@ -12,10 +12,11 @@ import {
 } from "react";
 
 import { getAnalyticsCookieConsentGiven } from "@/app/(main)/components/cookies_banner";
-import { usePublicSettings } from "@/contexts/public_settings_context";
+import { getPublicSetting } from "@/components/public_settings_script";
 
 export function CSPostHogProvider({ children }: { children: ReactNode }) {
-  const { PUBLIC_POSTHOG_KEY, PUBLIC_POSTHOG_BASE_URL } = usePublicSettings();
+  const PUBLIC_POSTHOG_KEY = getPublicSetting("PUBLIC_POSTHOG_KEY");
+  const PUBLIC_POSTHOG_BASE_URL = getPublicSetting("PUBLIC_POSTHOG_BASE_URL");
 
   useEffect(() => {
     if (PUBLIC_POSTHOG_KEY) {

--- a/front_end/src/components/post_card/consumer_post_card/index.tsx
+++ b/front_end/src/components/post_card/consumer_post_card/index.tsx
@@ -1,0 +1,84 @@
+import { isNil } from "lodash";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { FC } from "react";
+
+import { PostStatus, PostWithForecasts } from "@/types/post";
+import cn from "@/utils/cn";
+import { getPostLink } from "@/utils/navigation";
+import {
+  getGroupForecastAvailability,
+  getQuestionForecastAvailability,
+} from "@/utils/questions";
+
+import ConsumerKeyFactor from "./key_factor";
+import ConsumerPredictionInfo from "./prediction_info";
+
+type Props = {
+  post: PostWithForecasts;
+};
+
+const ConsumerPostCard: FC<Props> = ({ post }) => {
+  const { title, key_factors } = post;
+
+  const t = useTranslations();
+  const isShortTitle = title.length < 100;
+  const forecastAvailability = getPostForecastAvailability(post);
+
+  return (
+    <Link
+      href={getPostLink(post)}
+      className={cn(
+        "flex flex-col items-center rounded border border-blue-400 bg-gray-0 p-6 no-underline @container dark:border-blue-400-dark dark:bg-gray-0-dark"
+      )}
+    >
+      <div className="flex w-full flex-col items-center justify-between gap-4 @[500px]:flex-row @[500px]:gap-2">
+        <div className="flex flex-col gap-4 @[500px]:gap-2">
+          <h4 className="m-0 max-w-xl text-center text-base font-medium @[500px]:text-left">
+            {title}
+          </h4>
+          {[PostStatus.PENDING_RESOLUTION, PostStatus.CLOSED].includes(
+            post.status
+          ) && (
+            <p className="m-0 text-center text-xs font-normal leading-4 text-gray-1000 text-opacity-50 @[500px]:text-left dark:text-gray-1000-dark dark:text-opacity-50">
+              {t("closedForForecastingDescription")}
+            </p>
+          )}
+          {key_factors && (
+            <ConsumerKeyFactor
+              keyFactor={key_factors}
+              className={cn("mt-2 hidden w-full @[500px]:mt-0", {
+                "hidden @[500px]:flex": isShortTitle,
+              })}
+            />
+          )}
+        </div>
+
+        <ConsumerPredictionInfo
+          post={post}
+          forecastAvailability={forecastAvailability}
+        />
+      </div>
+      {key_factors && (
+        <ConsumerKeyFactor
+          keyFactor={key_factors}
+          className={cn("mt-4 flex w-full @[500px]:mt-5", {
+            "@[500px]:hidden": isShortTitle,
+          })}
+        />
+      )}
+    </Link>
+  );
+};
+
+function getPostForecastAvailability(post: PostWithForecasts) {
+  const { question, group_of_questions } = post;
+  if (!isNil(question)) {
+    return getQuestionForecastAvailability(question);
+  } else if (!isNil(group_of_questions)) {
+    return getGroupForecastAvailability(group_of_questions.questions);
+  }
+  return null;
+}
+
+export default ConsumerPostCard;

--- a/front_end/src/components/post_card/consumer_post_card/key_factor.tsx
+++ b/front_end/src/components/post_card/consumer_post_card/key_factor.tsx
@@ -1,0 +1,36 @@
+import { useTranslations } from "next-intl";
+import { FC } from "react";
+
+import { KeyFactor } from "@/types/comment";
+import cn from "@/utils/cn";
+
+type Props = {
+  keyFactor: KeyFactor[];
+  className?: string;
+};
+
+const ConsumerKeyFactor: FC<Props> = ({ keyFactor, className }) => {
+  const t = useTranslations();
+  // TODO: Adjust to render only the top key factor with min amount of upvotes
+  const keyFactoreData = keyFactor[0];
+  if (!keyFactoreData) {
+    return null;
+  }
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-1 rounded bg-mint-200 p-3 dark:bg-mint-200-dark",
+        className
+      )}
+    >
+      <h4 className="m-0 text-sm font-bold uppercase leading-4 text-mint-900 text-opacity-55 dark:text-mint-900-dark">
+        {t("keyFactor")}
+      </h4>
+      <p className="m-0 text-sm font-medium leading-5 text-gray-800 dark:text-gray-800-dark">
+        {keyFactoreData.text}
+      </p>
+    </div>
+  );
+};
+
+export default ConsumerKeyFactor;

--- a/front_end/src/components/post_card/consumer_post_card/prediction_info.tsx
+++ b/front_end/src/components/post_card/consumer_post_card/prediction_info.tsx
@@ -1,0 +1,130 @@
+import { intlFormatDistance } from "date-fns";
+import { isNil } from "lodash";
+import { useLocale, useTranslations } from "next-intl";
+import { FC } from "react";
+
+import { PostWithForecasts, QuestionStatus } from "@/types/post";
+import { ForecastAvailability, QuestionType } from "@/types/question";
+import "@github/relative-time-element";
+import { getDisplayValue } from "@/utils/charts";
+import cn from "@/utils/cn";
+import { formatResolution, isSuccessfullyResolved } from "@/utils/questions";
+
+type Props = {
+  post: PostWithForecasts;
+  forecastAvailability?: ForecastAvailability | null;
+};
+
+const ConsumerPredictionInfo: FC<Props> = ({ post, forecastAvailability }) => {
+  const { question, group_of_questions } = post;
+  const t = useTranslations();
+  const locale = useLocale();
+
+  // CP empty
+  if (forecastAvailability?.isEmpty) {
+    return null;
+  }
+  // CP hidden
+  if (!isNil(forecastAvailability?.cpRevealsOn)) {
+    return (
+      <div className="flex min-w-[200px] max-w-[200px] flex-col items-center gap-0">
+        <span className="text-xs font-normal leading-4 text-purple-700 dark:text-purple-700-dark">
+          {t("forecastRevealed")}{" "}
+        </span>
+        <relative-time
+          datetime={forecastAvailability.cpRevealsOn}
+          lang={locale}
+          className="text-base font-medium leading-6 text-purple-800 dark:text-purple-800-dark"
+        >
+          {intlFormatDistance(forecastAvailability.cpRevealsOn, new Date(), {
+            locale,
+          })}
+        </relative-time>
+      </div>
+    );
+  }
+
+  // TODO: implement view for group and MC questions
+  if (group_of_questions || question?.type === QuestionType.MultipleChoice) {
+    return <div>Group or MC question</div>;
+  }
+
+  if (question) {
+    // Resolved/Annulled/Ambiguous
+    if (question.resolution) {
+      const formatedResolution = formatResolution(
+        question.resolution,
+        question.type,
+        locale
+      );
+      const successfullResolution = isSuccessfullyResolved(question.resolution);
+      return (
+        <div className="flex min-w-[200px] max-w-[200px] justify-center">
+          <div
+            className={cn(
+              "flex w-fit flex-col items-center rounded bg-purple-100 px-4 py-2 dark:bg-purple-100-dark",
+              {
+                "bg-gray-300 dark:bg-gray-300-dark": !successfullResolution,
+              }
+            )}
+          >
+            {successfullResolution && (
+              <span className="text-xs font-medium uppercase leading-4 text-purple-600 dark:text-purple-600-dark">
+                {t("resolved")}
+              </span>
+            )}
+            <span
+              className={cn(
+                "text-base font-medium leading-6 text-purple-800 dark:text-purple-800-dark",
+                {
+                  "text-gray-700 dark:text-gray-700-dark":
+                    !successfullResolution,
+                }
+              )}
+            >
+              {formatedResolution}
+            </span>
+          </div>
+        </div>
+      );
+    }
+
+    // Open/Closed
+    const isClosed = question.status === QuestionStatus.CLOSED;
+    const latest = question.aggregations.recency_weighted.latest;
+    const communityPredictionDisplayValue = latest
+      ? getDisplayValue({
+          value: latest.centers?.[0],
+          questionType: question.type,
+          scaling: question.scaling,
+        })
+      : null;
+
+    return (
+      <div className="flex min-w-[200px] max-w-[200px] justify-center">
+        <div
+          className={cn(
+            "flex w-fit flex-col items-center rounded border-2 border-blue-400 bg-transparent px-5 py-2 dark:border-blue-400-dark dark:bg-transparent",
+            {
+              "border-gray-300 dark:border-gray-300-dark": isClosed,
+            }
+          )}
+        >
+          <span
+            className={cn(
+              "text-lg font-bold leading-7 text-blue-700 dark:text-blue-700-dark",
+              {
+                "text-gray-600 dark:text-gray-600-dark": isClosed,
+              }
+            )}
+          >
+            {communityPredictionDisplayValue}
+          </span>
+        </div>
+      </div>
+    );
+  }
+  return null;
+};
+
+export default ConsumerPredictionInfo;

--- a/front_end/src/components/post_card/index.tsx
+++ b/front_end/src/components/post_card/index.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { FC, useState } from "react";
 
 import HideCPProvider from "@/app/(main)/questions/[id]/components/cp_provider";
@@ -7,6 +8,7 @@ import NotebookTile from "@/components/post_card/notebook_tile";
 import { CardReaffirmContextProvider } from "@/components/post_card/reaffirm_context";
 import { useAuth } from "@/contexts/auth_context";
 import { PostStatus, PostWithForecasts } from "@/types/post";
+import { QuestionType } from "@/types/question";
 import {
   canPredictQuestion,
   isConditionalPost,
@@ -16,6 +18,7 @@ import {
 } from "@/utils/questions";
 
 import BasicPostCard from "./basic_post_card";
+import ConsumerPostCard from "./consumer_post_card";
 import PostCardErrorBoundary from "./error_boundary";
 import GroupOfQuestionsTile from "./group_of_questions_tile";
 import QuestionChartTile from "./question_chart_tile";
@@ -29,10 +32,20 @@ const PostCard: FC<Props> = ({ post }) => {
   const hideCP =
     user?.hide_community_prediction &&
     ![PostStatus.CLOSED, PostStatus.RESOLVED].includes(post.status);
+  const isConsumerViewEnabled = useFeatureFlagEnabled("consumerView");
 
   const [internalPost, setInternalPost] = useState<PostWithForecasts>(post);
 
   const canPredict = canPredictQuestion(internalPost);
+
+  // TODO: adjust condition for other post types when ready
+  if (
+    isConsumerViewEnabled &&
+    post.question &&
+    post.question.type === QuestionType.Date
+  ) {
+    return <ConsumerPostCard post={internalPost} />;
+  }
 
   return (
     <CardReaffirmContextProvider


### PR DESCRIPTION
Related to #2351

- created a PostHog flag to show the consumer view only for admins
- fixed an issue with environment variables not being correctly passed to PostHog initialization
- implemented ConsumerPostCard, ConsumerKeyFactor and ConsumerPredictionInfo for the new layout
- integrated them for posts with date questions