### PR TITLE
Force include buildId into chunk files

### DIFF
--- a/front_end/next.config.mjs
+++ b/front_end/next.config.mjs
@@ -74,6 +74,14 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  webpack: (config, { buildId }) => {
+    config.output.filename = config.output.filename.replace(
+      "[chunkhash]",
+      buildId
+    );
+
+    return config;
+  },
 };
 
 export default withSentryConfig(withNextIntl(nextConfig), {


### PR DESCRIPTION
Force-included `buildId` in chunk filenames to prevent **404 errors** caused by webpack build naming collisions during chunk loading

https://github.com/vercel/next.js/discussions/65856#discussioncomment-9749287