### PR TITLE
Consumer views: numeric tiles

### DIFF
--- a/front_end/src/components/cp_weekly_movement.tsx
+++ b/front_end/src/components/cp_weekly_movement.tsx
@@ -14,12 +14,14 @@ type Props = {
   question: QuestionWithForecasts;
   className?: string;
   checkDelta?: boolean;
+  displayUnit?: boolean;
 };
 
 const CPWeeklyMovement: FC<Props> = ({
   question,
   className,
   checkDelta = true,
+  displayUnit = true,
 }) => {
   const t = useTranslations();
   const weeklyMovement = getQuestionWeeklyMovement(question, checkDelta);
@@ -39,7 +41,10 @@ const CPWeeklyMovement: FC<Props> = ({
     <WeeklyMovement
       weeklyMovement={weeklyMovement}
       message={t("weeklyMovementChange", {
-        value: formatValueUnit(message, question.unit),
+        value: formatValueUnit(
+          message,
+          displayUnit ? question.unit : undefined
+        ),
       })}
       className={cn("text-xs", className)}
       iconClassName="text-sm"

--- a/front_end/src/components/post_card/consumer_post_card/continuous_cp_bar.tsx
+++ b/front_end/src/components/post_card/consumer_post_card/continuous_cp_bar.tsx
@@ -1,14 +1,17 @@
-import { FC } from "react";
+import React, { FC, ReactNode } from "react";
 
 import cn from "@/utils/cn";
+import { formatValueUnit, isUnitCompact } from "@/utils/questions";
 
 type Props = {
   communityPredictionDisplayValue: string | null;
+  unit?: string;
   isClosed: boolean;
 };
 // TODO: adjust for numeric questions when units will be implemented
 const ContinuousCPBar: FC<Props> = ({
   communityPredictionDisplayValue,
+  unit,
   isClosed,
 }) => {
   if (!communityPredictionDisplayValue) {
@@ -25,19 +28,32 @@ const ContinuousCPBar: FC<Props> = ({
           }
         )}
       >
-        <span
+        <div
           className={cn(
-            "text-lg font-bold leading-7 text-blue-700 dark:text-blue-700-dark",
+            "flex items-center gap-x-1.5 text-center text-lg font-bold uppercase leading-7 text-blue-700 dark:text-blue-700-dark sm:flex-col",
             {
               "text-gray-600 dark:text-gray-600-dark": isClosed,
             }
           )}
         >
-          {communityPredictionDisplayValue}
-        </span>
+          {renderDisplayValue(communityPredictionDisplayValue, unit)}
+        </div>
       </div>
     </div>
   );
 };
+
+function renderDisplayValue(displayValue: string, unit?: string): ReactNode {
+  if (!unit) return displayValue;
+
+  if (isUnitCompact(unit)) return formatValueUnit(displayValue, unit);
+
+  return (
+    <>
+      <div>{displayValue}</div>
+      <div className="text-xs font-medium">{unit}</div>
+    </>
+  );
+}
 
 export default ContinuousCPBar;

--- a/front_end/src/components/post_card/consumer_post_card/prediction_info.tsx
+++ b/front_end/src/components/post_card/consumer_post_card/prediction_info.tsx
@@ -68,7 +68,7 @@ const ConsumerPredictionInfo: FC<Props> = ({ post, forecastAvailability }) => {
         <QuestionForecastChip
           question={question as QuestionWithNumericForecasts}
         />
-        <CPWeeklyMovement question={question} />
+        <CPWeeklyMovement question={question} displayUnit={false} />
       </div>
     );
   }

--- a/front_end/src/components/post_card/consumer_post_card/question_forecast_chip.tsx
+++ b/front_end/src/components/post_card/consumer_post_card/question_forecast_chip.tsx
@@ -29,6 +29,7 @@ const QuestionForecastChip: FC<Props> = ({ question }) => {
   return (
     <ContinuousCPBar
       communityPredictionDisplayValue={communityPredictionDisplayValue}
+      unit={question.unit}
       isClosed={isClosed}
     />
   );

--- a/front_end/src/components/posts_feed/paginated_feed.tsx
+++ b/front_end/src/components/posts_feed/paginated_feed.tsx
@@ -145,6 +145,7 @@ const PaginatedPostsFeed: FC<Props> = ({
       isConsumerViewEnabled &&
       ((isQuestionPost(post) &&
         [
+          QuestionType.Numeric,
           QuestionType.Date,
           QuestionType.Binary,
           QuestionType.MultipleChoice,

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -396,7 +396,6 @@ export function getDisplayValue({
       scaling,
       truncation,
       dateFormatString,
-      unit,
     });
     return `${centerDisplay} \n(${lowerDisplay} - ${upperDisplay})`;
   }


### PR DESCRIPTION
<img width="653" alt="image" src="https://github.com/user-attachments/assets/cafe1d80-cb81-4b4b-8c57-53203c6605fb" />

closes #2350 