### PR TITLE
Unintended display of no. of forecasters for resolved non-groups

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_resolution_status.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_resolution_status.tsx
@@ -23,7 +23,6 @@ const QuestionResolutionStatus: FC<Props> = ({ post }) => {
       return (
         <PredictionChip
           question={question}
-          prediction={latest_cp.centers[0]}
           status={post.status}
           className="items-end"
         />
@@ -32,7 +31,6 @@ const QuestionResolutionStatus: FC<Props> = ({ post }) => {
       return (
         <PredictionChip
           question={question}
-          prediction={latest_cp.centers[1]}
           status={post.status}
           className="items-end"
         />

--- a/front_end/src/components/conditional_tile/conditional_chart.tsx
+++ b/front_end/src/components/conditional_tile/conditional_chart.tsx
@@ -105,7 +105,6 @@ const ConditionalChart: FC<Props> = ({
             <PredictionChip
               question={question}
               status={PostStatus.RESOLVED}
-              prediction={pctCandidate}
               size="compact"
             />
           )}
@@ -196,7 +195,6 @@ const ConditionalChart: FC<Props> = ({
             <PredictionChip
               question={question}
               status={PostStatus.RESOLVED}
-              prediction={prediction}
               size="compact"
             />
           )}

--- a/front_end/src/components/forecast_card.tsx
+++ b/front_end/src/components/forecast_card.tsx
@@ -230,10 +230,10 @@ const ForecastCard: FC<Props> = ({
             <PredictionChip
               question={question}
               status={post.status}
-              prediction={cursorForecast?.centers?.at(-1)}
+              predictionOverride={cursorForecast?.centers?.at(-1)}
               className="ForecastCard-prediction"
-              unresovledChipStyle={embedTheme?.predictionChip}
-              compact
+              unresolvedChipStyle={embedTheme?.predictionChip}
+              enforceCPDisplay
             />
           );
         }

--- a/front_end/src/components/post_card/index.tsx
+++ b/front_end/src/components/post_card/index.tsx
@@ -53,7 +53,7 @@ const PostCard: FC<Props> = ({ post }) => {
                 authorUsername={post.author_username}
                 curationStatus={post.status}
                 hideCP={hideCP}
-                forecasters={post.nr_forecasters}
+                forecasters={internalPost.question.nr_forecasters}
                 canPredict={canPredict}
               />
             )}

--- a/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
+++ b/front_end/src/components/post_card/question_chart_tile/question_numeric_tile.tsx
@@ -46,8 +46,6 @@ const QuestionNumericTile: FC<Props> = ({
   const { onReaffirm } = useCardReaffirmContext();
 
   const latest = question.aggregations.recency_weighted.latest;
-  const prediction = latest?.centers?.[0];
-
   const continuousAreaChartData = getContinuousAreaChartData(
     latest,
     question.my_forecasts?.latest
@@ -117,12 +115,13 @@ const QuestionNumericTile: FC<Props> = ({
       <div className="mr-3 inline-flex flex-col justify-center gap-0.5 text-xs font-semibold text-gray-600 dark:text-gray-600-dark xs:max-w-[650px]">
         <PredictionChip
           question={question}
-          prediction={prediction}
           status={curationStatus as PostStatus}
           showUserForecast
           hideCP={hideCP}
           onReaffirm={onReaffirm ? handleReaffirmClick : undefined}
           canPredict={canPredict}
+          showWeeklyMovement
+          enforceCPDisplay
         />
 
         <ForecastersCounter forecasters={forecasters} className="p-1" />


### PR DESCRIPTION
Fixes #2422

- removed `nr_forecasters` rendering from prediction chip as it's already rendered on feed tiles
- additionally fixes redundant CP renders on resolved/closed questions when viewing question details page

Before:

<img width="735" alt="image" src="https://github.com/user-attachments/assets/5c4b1e46-a6bb-4feb-b869-668c193f3e3b" />

<img width="819" alt="image" src="https://github.com/user-attachments/assets/8167e435-89cb-4233-b55f-8a98b86c7d5d" />

Now:

<img width="735" alt="image" src="https://github.com/user-attachments/assets/a76ab319-7bd9-4156-8794-1e15a83b9cfe" />

<img width="800" alt="image" src="https://github.com/user-attachments/assets/f8e74c33-755e-459c-b456-5c739597f28b" />
