### PR TITLE
Temporary disable custom group question sorting

### DIFF
--- a/front_end/src/utils/questions.ts
+++ b/front_end/src/utils/questions.ts
@@ -523,7 +523,12 @@ export function sortGroupPredictionOptions<QT>(
       range_max: b.scaling?.range_max ?? 1,
       zero_point: b.scaling?.zero_point ?? null,
     });
-
+    // TODO: remove when BE fixes will be deployed
+    if (group?.graph_type === GroupOfQuestionsGraphType.FanGraph) {
+      return 0;
+    }
+    return bValueScaled - aValueScaled;
+    // end of TODO
     const aResTime = new Date(a.scheduled_resolve_time).getTime();
     const bResTime = new Date(b.scheduled_resolve_time).getTime();
 


### PR DESCRIPTION
This is a workaround to fix broken group tiles on feed:

![image](https://github.com/user-attachments/assets/290f12b6-c768-4cae-99e4-153d77fe7057)

vs 

![image](https://github.com/user-attachments/assets/35d369f2-e817-414b-ab8a-701e61cea997)

---

The issue here that BE doesn't respect `group.subquestions_order` configuration when returning the CP on top 3 subquestions on the group question. This PR introduces a temporary workaround to fix tiles rendering by returning to previous implementation. 