### PR TITLE
On mobile, when editing a notebook, the wysiwyg toolbar is partially hidden by the navbar and the table of contents

### DIFF
--- a/front_end/src/app/(main)/accounts/profile/components/user_info.tsx
+++ b/front_end/src/app/(main)/accounts/profile/components/user_info.tsx
@@ -242,7 +242,7 @@ const UserInfo: FC<UserInfoProps> = ({ profile, isCurrentUser }) => {
   return (
     <form
       action={formAction}
-      className=" rounded  bg-blue-300 p-4 dark:bg-blue-300-dark md:p-6"
+      className="rounded bg-blue-300 p-4 dark:bg-blue-300-dark md:p-6"
     >
       <div className="mb-6 flex flex-col gap-2  md:mb-8">
         <h1 className="mt-0 inline text-3xl md:text-4xl">

--- a/front_end/src/components/markdown_editor/editor.css
+++ b/front_end/src/components/markdown_editor/editor.css
@@ -7,8 +7,12 @@
   --baseBorder: theme("colors.gray.500.DEFAULT");
 }
 
+.markdown-editor-form .mdxeditor-toolbar {
+  @apply sticky top-0 z-10;
+}
+
 .mdxeditor-toolbar {
-  @apply sticky flex-wrap top-12;
+  @apply sticky top-12 flex-wrap;
   & [class*="toolbarTitleMode"] {
     display: none; /* We render our custom source mode title instead */
   }

--- a/front_end/src/components/ui/form_field.tsx
+++ b/front_end/src/components/ui/form_field.tsx
@@ -195,7 +195,7 @@ export const MarkdownEditorField = <T extends FieldValues = FieldValues>({
     <>
       <div
         className={cn(
-          "relative overflow-y-scroll rounded border border-gray-500 dark:border-gray-500-dark",
+          "relative max-h-[80vh] overflow-y-scroll rounded border border-gray-500 dark:border-gray-500-dark",
           className
         )}
       >
@@ -218,7 +218,7 @@ export const MarkdownEditorField = <T extends FieldValues = FieldValues>({
           markdown={field.value ?? ""}
           onChange={field.onChange}
           onBlur={field.onBlur}
-          className="w-full"
+          className="markdown-editor-form w-full"
         />
       </div>
       {errors && (


### PR DESCRIPTION
Fixes #2382

- adjusted the toolbar position inside form field (`MarkdownEditorFieldas`) it creates own scrolling context

