### PR TITLE
Subquestion labels are cut off if they are too long

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_group_accordion/group_forecast_accordion_item.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_group_accordion/group_forecast_accordion_item.tsx
@@ -6,6 +6,8 @@ import { useLocale } from "next-intl";
 import { FC, PropsWithChildren, useState } from "react";
 
 import ContinuousAreaChart from "@/components/charts/continuous_area_chart";
+import TruncatedTextTooltip from "@/components/truncated_text_tooltip";
+import { useBreakpoint } from "@/hooks/tailwind";
 import { ContinuousForecastInputType } from "@/types/charts";
 import { QuestionStatus } from "@/types/post";
 import { Quantile } from "@/types/question";
@@ -59,7 +61,7 @@ const AccordionItem: FC<PropsWithChildren<AccordionItemProps>> = ({
     scaling: question.scaling,
     unit,
   });
-
+  const isLargeScreen = useBreakpoint("sm");
   const showUserPrediction = hasUserForecast || isDirty;
   const isResolvedOption = type === QuestionStatus.RESOLVED;
   const latest = question.aggregations.recency_weighted.latest;
@@ -123,24 +125,27 @@ const AccordionItem: FC<PropsWithChildren<AccordionItemProps>> = ({
               isDirty={!isResolvedOption && isDirty}
             >
               <div className="flex h-full shrink grow items-center overflow-hidden">
-                <span className="line-clamp-2 pl-4 pr-2 text-sm font-bold text-gray-900 dark:text-gray-900-dark sm:text-base">
-                  {title}
-                </span>
-              </div>
-              <div className="flex h-full min-w-[105px] max-w-[105px] shrink-0 grow-[3] items-center justify-center gap-0.5 sm:min-w-[420px] sm:max-w-[420px]">
-                <AccordionResolutionCell
-                  formatedResolution={formatedResolution}
-                  resolution={resolution}
-                  median={median}
-                  userMedian={
-                    !isNil(option.userQuartiles?.median)
-                      ? userMedian
-                      : undefined
-                  }
-                  type={type}
+                <TruncatedTextTooltip
+                  text={title}
+                  showTooltip={!open}
+                  className="line-clamp-2 pl-4 pr-2 text-sm font-bold text-gray-900 dark:text-gray-900-dark sm:text-base"
+                  tooltipClassName="text-center !border-blue-400 dark:!border-blue-400-dark bg-gray-0 dark:bg-gray-0-dark text-sm font-bold text-gray-900 dark:text-gray-900-dark sm:text-base p-2"
                 />
-                <div className="hidden h-full shrink-0 grow-0 items-center justify-center sm:block sm:w-[325px]">
-                  {!open && (
+              </div>
+              {(!open || !isLargeScreen) && (
+                <div className="flex h-full min-w-[105px] max-w-[105px] shrink-0 grow-[3] items-center justify-center gap-0.5 sm:min-w-[420px] sm:max-w-[420px]">
+                  <AccordionResolutionCell
+                    formatedResolution={formatedResolution}
+                    resolution={resolution}
+                    median={median}
+                    userMedian={
+                      !isNil(option.userQuartiles?.median)
+                        ? userMedian
+                        : undefined
+                    }
+                    type={type}
+                  />
+                  <div className="hidden h-full shrink-0 grow-0 items-center justify-center sm:block sm:w-[325px]">
                     <ContinuousAreaChart
                       data={continuousAreaChartData}
                       graphType="pmf"
@@ -151,9 +156,9 @@ const AccordionItem: FC<PropsWithChildren<AccordionItemProps>> = ({
                       questionType={question.type}
                       resolution={question.resolution}
                     />
-                  )}
+                  </div>
                 </div>
-              </div>
+              )}
               <div className="flex h-full w-[43px] shrink-0 grow-0 items-center justify-center">
                 <div className="flex size-[26px] items-center justify-center rounded-full border border-blue-400 bg-blue-100 dark:border-blue-400-dark dark:bg-blue-100-dark">
                   <FontAwesomeIcon

--- a/front_end/src/components/truncated_text_tooltip.tsx
+++ b/front_end/src/components/truncated_text_tooltip.tsx
@@ -1,0 +1,71 @@
+import { FC, useEffect, useState } from "react";
+
+import Tooltip from "@/components/ui/tooltip";
+import useContainerSize from "@/hooks/use_container_size";
+import cn from "@/utils/cn";
+
+type Props = {
+  text: string;
+  className?: string;
+  tooltipClassName?: string;
+  showDelayMs?: number;
+  placement?: "top" | "bottom" | "left" | "right";
+  showTooltip?: boolean;
+};
+
+const TruncatedTextTooltip: FC<Props> = ({
+  text,
+  className,
+  tooltipClassName,
+  showDelayMs = 200,
+  placement = "bottom",
+  showTooltip = true,
+}) => {
+  const { ref, width } = useContainerSize<HTMLSpanElement>();
+  const [isTextTruncated, setIsTextTruncated] = useState(false);
+
+  useEffect(() => {
+    if (ref.current) {
+      const temp = ref.current.cloneNode(true) as HTMLElement;
+      temp.style.position = "fixed";
+      temp.style.overflow = "scroll";
+      temp.style.visibility = "hidden";
+      temp.style.width = width.toString() + "px";
+      ref.current.parentElement?.appendChild(temp);
+      const scrollHeight = temp.scrollHeight;
+      const displayHeight = ref.current.clientHeight;
+
+      setIsTextTruncated(scrollHeight > displayHeight);
+      ref.current.parentElement?.removeChild(temp);
+    }
+  }, [width, ref]);
+
+  return (
+    <Tooltip
+      tooltipContent={text}
+      showDelayMs={showDelayMs}
+      placement={placement}
+      tooltipClassName={cn(tooltipClassName, {
+        hidden: !isTextTruncated || !showTooltip,
+      })}
+    >
+      <span
+        ref={ref}
+        className={cn("overflow-hidden", className)}
+        onTouchStart={(e) => {
+          if (isTextTruncated) {
+            const mouseEnterEvent = new MouseEvent("mouseenter", {
+              bubbles: true,
+              cancelable: true,
+            });
+            e.currentTarget.dispatchEvent(mouseEnterEvent);
+          }
+        }}
+      >
+        {text}
+      </span>
+    </Tooltip>
+  );
+};
+
+export default TruncatedTextTooltip;


### PR DESCRIPTION
Fixes #2399

- adjusted render of `AccordionItem` with open state
- implemented reusable `TruncatedTextTooltip` component, to render label only when text is truncated
- adjusted label render on mobile devices