### PR TITLE
Fixed `get_aggregated_forecasts_for_questions`

### DIFF
--- a/questions/services.py
+++ b/questions/services.py
@@ -824,7 +824,7 @@ def get_aggregated_forecasts_for_questions(
                 grouped[q.group].append(q)
 
         def rank_sorting_key(q: Question):
-            return q.group_rank
+            return q.group_rank or 0
 
         def cp_sorting_key(q: Question):
             """


### PR DESCRIPTION
Fixed `get_aggregated_forecasts_for_questions` exception for cases where  
`GroupOfQuestions.subquestions_order == MANUAL`, but some questions had a **null `group_rank`**.

This prevents crashes when manually ordered question groups contain unranked subquestions

fixes #2466 