### PR TITLE
When zooming timeline graphs of binary questions, always include either 0% or 100% in the scale

### DIFF
--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -20,7 +20,7 @@ import {
   VictoryThemeDefinition,
 } from "victory";
 
-import { lightTheme, darkTheme } from "@/constants/chart_theme";
+import { darkTheme, lightTheme } from "@/constants/chart_theme";
 import { METAC_COLORS } from "@/constants/colors";
 import useAppTheme from "@/hooks/use_app_theme";
 import useContainerSize from "@/hooks/use_container_size";
@@ -645,6 +645,7 @@ function buildChartData({
     isChartEmpty: !domainTimestamps.length,
     minValues: areas.map((a) => ({ timestamp: a.x, y: a.y0 })),
     maxValues: areas.map((a) => ({ timestamp: a.x, y: a.y })),
+    includeClosestBoundOnZoom: questionType === QuestionType.Binary,
   });
   const yScale = generateScale({
     displayType: questionType,

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -556,6 +556,7 @@ function buildChartData({
     isChartEmpty: !domainTimestamps.length,
     minValues: area.map((d) => ({ timestamp: d.x, y: d.y0 })),
     maxValues: area.map((d) => ({ timestamp: d.x, y: d.y })),
+    includeClosestBoundOnZoom: questionType === QuestionType.Binary,
   });
   const yScale: Scale = generateScale({
     displayType: questionType,

--- a/front_end/src/utils/charts/axis.ts
+++ b/front_end/src/utils/charts/axis.ts
@@ -92,6 +92,7 @@ type GenerateYDomainParams = {
   zoom: TimelineChartZoomOption;
   isChartEmpty: boolean;
   zoomDomainPadding?: number;
+  includeClosestBoundOnZoom?: boolean;
 };
 
 export function generateYDomain({
@@ -101,6 +102,7 @@ export function generateYDomain({
   maxValues,
   minTimestamp,
   zoomDomainPadding = 0.05,
+  includeClosestBoundOnZoom = false,
 }: GenerateYDomainParams): {
   originalYDomain: Tuple<number>;
   zoomedYDomain: Tuple<number>;
@@ -130,14 +132,21 @@ export function generateYDomain({
   const distanceToZero = Math.abs(minValue - zoomDomainPadding);
   const distanceToOne = Math.abs(1 - (maxValue + zoomDomainPadding));
 
-  if (distanceToZero === distanceToOne) {
-    zoomedYDomain = [0, 1];
+  if (includeClosestBoundOnZoom) {
+    if (distanceToZero === distanceToOne) {
+      zoomedYDomain = [0, 1];
+    } else {
+      // Include the closer bound
+      zoomedYDomain =
+        distanceToZero < distanceToOne
+          ? [0, Math.min(1, maxValue + zoomDomainPadding)]
+          : [Math.max(0, minValue - zoomDomainPadding), 1];
+    }
   } else {
-    // Include the closer bound
-    zoomedYDomain =
-      distanceToZero < distanceToOne
-        ? [0, Math.min(1, maxValue + zoomDomainPadding)]
-        : [Math.max(0, minValue - zoomDomainPadding), 1];
+    zoomedYDomain = [
+      Math.max(0, minValue - zoomDomainPadding),
+      Math.min(1, maxValue + zoomDomainPadding),
+    ];
   }
 
   return {


### PR DESCRIPTION
Resolves #2385

- adjusted calculation of zoomed yDomain to always include either 0 or 1