### PR TITLE
My table prediction shifts after collapsing numeric subquestion

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_input/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/continuous_input/index.tsx
@@ -1,6 +1,6 @@
 import { isNil } from "lodash";
 import { useTranslations } from "next-intl";
-import React, { FC, ReactNode, useEffect } from "react";
+import React, { FC, ReactNode, useEffect, useRef } from "react";
 
 import { useHideCP } from "@/app/(main)/questions/[id]/components/cp_provider";
 import ContinuousTable from "@/app/(main)/questions/[id]/components/forecast_maker/continuous_table";
@@ -76,11 +76,15 @@ const ContinuousInput: FC<Props> = ({
   const { hideCP } = useHideCP();
   const t = useTranslations();
   const previousForecast = question.my_forecasts?.latest;
-
+  const isMounted = useRef(false);
   const withCommunityQuartiles = !user || !hideCP;
 
   // populate forecast data from another tab
   useEffect(() => {
+    if (!isMounted.current) {
+      isMounted.current = true;
+      return;
+    }
     if (
       forecastInputMode === ContinuousForecastInputType.Quantile &&
       (isDirty ||

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/continuous_input_wrapper.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/continuous_input_wrapper.tsx
@@ -82,7 +82,7 @@ const ContinuousInputWrapper: FC<PropsWithChildren<Props>> = ({
     );
 
   const [submitError, setSubmitError] = useState<ErrorResponse>();
-  const forecastInputMode = option.forecastInputMode;
+  const { forecastInputMode, isDirty, userQuantileForecast } = option;
 
   const forecast = useMemo(
     () =>
@@ -202,7 +202,11 @@ const ContinuousInputWrapper: FC<PropsWithChildren<Props>> = ({
                 variant="secondary"
                 type="reset"
                 onClick={() => handleResetForecasts(option)}
-                disabled={!option.isDirty}
+                disabled={
+                  forecastInputMode === ContinuousForecastInputType.Slider
+                    ? !isDirty
+                    : !userQuantileForecast.some((q) => q.isDirty)
+                }
               >
                 {t("discardChangesButton")}
               </Button>


### PR DESCRIPTION
Fixes #2478

- fix forecast shift after collapsing numeric subquestion
- adjusted "discard changes" button for table tab