### PR TITLE
Feat/simulate leaderboard

### DIFF
--- a/questions/admin.py
+++ b/questions/admin.py
@@ -127,15 +127,12 @@ class QuestionAdmin(CustomTranslationAdmin, DynamicArrayMixin):
         from scoring.utils import score_question
 
         for question in queryset:
-            if question.resolution in ["", None, "ambiguous", "annulled"]:
+            resolution = question.resolution
+            if not resolution or resolution in ["ambiguous", "annulled"]:
                 continue
-            spot_forecast_time = (
-                question.cp_reveal_time.timestamp() if question.cp_reveal_time else None
-            )
             score_question(
                 question=question,
-                resolution=question.resolution,
-                spot_forecast_time=spot_forecast_time,
+                resolution=resolution,
             )
 
     trigger_scoring.short_description = "Trigger Scoring (does nothing if not resolved)"

--- a/questions/services.py
+++ b/questions/services.py
@@ -574,9 +574,6 @@ def unresolve_question(question: Question):
     score_question(
         question,
         None,  # None is the equivalent of unsetting scores
-        spot_scoring_time=(
-            spot_scoring_time.timestamp() if spot_scoring_time else None
-        ),
         score_types=score_types,
     )
 

--- a/questions/tasks.py
+++ b/questions/tasks.py
@@ -58,9 +58,6 @@ def resolve_question_and_send_notifications(question_id: int):
     score_question(
         question,
         question.resolution,
-        spot_scoring_time=(
-            spot_scoring_time.timestamp() if spot_scoring_time else None
-        ),
         score_types=score_types,
     )
 

--- a/scoring/admin.py
+++ b/scoring/admin.py
@@ -2,9 +2,15 @@ from admin_auto_filters.filters import AutocompleteFilterFactory
 from django.contrib import admin, messages
 
 from projects.models import Project
-from scoring.models import (ArchivedScore, Leaderboard, LeaderboardEntry,
-                            LeaderboardsRanksEntry, MedalExclusionRecord,
-                            Score, UserWeight)
+from scoring.models import (
+    ArchivedScore,
+    Leaderboard,
+    LeaderboardEntry,
+    LeaderboardsRanksEntry,
+    MedalExclusionRecord,
+    Score,
+    UserWeight,
+)
 from scoring.utils import update_project_leaderboard
 
 

--- a/scoring/admin.py
+++ b/scoring/admin.py
@@ -2,15 +2,9 @@ from admin_auto_filters.filters import AutocompleteFilterFactory
 from django.contrib import admin, messages
 
 from projects.models import Project
-from scoring.models import (
-    UserWeight,
-    Leaderboard,
-    LeaderboardEntry,
-    Score,
-    MedalExclusionRecord,
-    ArchivedScore,
-    LeaderboardsRanksEntry,
-)
+from scoring.models import (ArchivedScore, Leaderboard, LeaderboardEntry,
+                            LeaderboardsRanksEntry, MedalExclusionRecord,
+                            Score, UserWeight)
 from scoring.utils import update_project_leaderboard
 
 

--- a/scoring/management/commands/simulate_remove_users.py
+++ b/scoring/management/commands/simulate_remove_users.py
@@ -119,19 +119,12 @@ def _move_leaderboard_forecasts_by_num_days(
 ) -> None:
     try:
         project = leaderboard.project
-
-        # Get all posts in this project
         posts = Post.objects.filter(
             Q(default_project=project) | Q(projects=project)
         ).distinct()
-
-        # Get all questions from these posts
         questions = Question.objects.filter(related_posts__post__in=posts).distinct()
-
-        # Get all forecasts for these questions by these users
         forecasts = Forecast.objects.filter(question__in=questions, author__in=users)
 
-        # Update each forecast's timestamp
         count = 0
         for forecast in forecasts:
             days_to_add = num_days
@@ -141,9 +134,8 @@ def _move_leaderboard_forecasts_by_num_days(
             forecast.save()
             count += 1
 
-        print(f"Updated {count} forecasts")
+        print(f"Updated {count} forecasts into the future")
 
-        # Rescore the affected questions
         for question in questions:
             resolution = question.resolution
             if not resolution or resolution in ["ambiguous", "annulled"]:
@@ -154,7 +146,6 @@ def _move_leaderboard_forecasts_by_num_days(
             )
         print(f"Rescored {len(questions)} questions")
 
-        # Force update the leaderboard
         print("Force updating leaderboard...")
         update_project_leaderboard(
             project=project, leaderboard=leaderboard, force_update=True

--- a/scoring/management/commands/simulate_remove_users.py
+++ b/scoring/management/commands/simulate_remove_users.py
@@ -44,7 +44,10 @@ class Command(BaseCommand):
                 )
                 return
 
-            if leaderboard.project and leaderboard.project.type == Project.ProjectTypes.SITE_MAIN:
+            if (
+                leaderboard.project
+                and leaderboard.project.type == Project.ProjectTypes.SITE_MAIN
+            ):
                 if not leaderboard.start_time or not leaderboard.end_time:
                     self.stdout.write(
                         self.style.ERROR(
@@ -103,8 +106,6 @@ def simulate_leaderboard_without_users(
         raise
 
     return updated_leaderboard_json
-
-
 
 
 def _move_leaderboard_forecasts_by_num_days(
@@ -171,6 +172,7 @@ def _get_leaderboard_representation(leaderboard: Leaderboard) -> list[dict[str, 
         }
         for entry in entries
     ]
+
 
 def _display_leaderboard(leaderboard: list[dict[str, Any]] | Leaderboard) -> None:
     if isinstance(leaderboard, Leaderboard):

--- a/scoring/management/commands/simulate_remove_users.py
+++ b/scoring/management/commands/simulate_remove_users.py
@@ -1,0 +1,191 @@
+import csv
+from datetime import timedelta
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandParser
+from django.db import transaction
+from django.db.models import Q
+
+from posts.models import Post
+from questions.models import Forecast, Question
+from scoring.models import Leaderboard
+from scoring.utils import score_question, update_project_leaderboard
+from users.models import User
+
+
+class Command(BaseCommand):
+    help = "Simulates removing specified users from a leaderboard and shows the resulting rankings"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "leaderboard_id",
+            type=int,
+            help="ID of the leaderboard to simulate changes on",
+        )
+        parser.add_argument(
+            "usernames",
+            nargs="+",
+            type=str,
+            help="List of usernames to simulate removing",
+        )
+        parser.add_argument(
+            "--output",
+            type=str,
+            help="Optional path to save results as CSV",
+            default=None,
+        )
+
+    def handle(self, *args: Any, **options: dict[str, Any]) -> None:
+        try:
+            leaderboard = Leaderboard.objects.get(id=options["leaderboard_id"])
+            users = list(User.objects.filter(username__in=options["usernames"]))
+
+            if not users:
+                self.stdout.write(
+                    self.style.ERROR("No valid users found with the provided usernames")
+                )
+                return
+
+            self.stdout.write("Original leaderboard:")
+            display_leaderboard(leaderboard)
+
+            self.stdout.write("\nSimulating leaderboard without specified users...")
+            updated_leaderboard = simulate_leaderboard_without_users(leaderboard, users)
+
+            self.stdout.write("\nSimulated leaderboard:")
+            display_leaderboard(updated_leaderboard)
+
+            if options["output"]:
+                file_path_to_save_to = options["output"]
+                assert isinstance(file_path_to_save_to, str)
+                _save_leaderboard_to_csv(updated_leaderboard, file_path_to_save_to)
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"\nResults saved to CSV file: {file_path_to_save_to}"
+                    )
+                )
+
+        except Leaderboard.DoesNotExist:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Leaderboard with ID {options['leaderboard_id']} not found"
+                )
+            )
+
+
+def simulate_leaderboard_without_users(
+    leaderboard: Leaderboard,
+    users: list[User],
+) -> list[dict[str, Any]]:
+    num_days = 365 * 500
+
+    try:
+        with transaction.atomic():
+            print("\nMoving forecasts forward...")
+            _move_leaderboard_forecasts_by_num_days(leaderboard, users, num_days)
+            updated_leaderboard_json = _get_leaderboard_representation(leaderboard)
+
+            # Force rollback to revert all changes
+            transaction.set_rollback(True)
+            print("\nRolling back all changes...")
+
+    except Exception as e:
+        print(f"\nError occurred: {str(e)}")
+        print("Rolling back all changes...")
+        transaction.set_rollback(True)
+        raise
+
+    return updated_leaderboard_json
+
+
+def display_leaderboard(leaderboard: list[dict[str, Any]] | Leaderboard) -> None:
+    if isinstance(leaderboard, Leaderboard):
+        leaderboard_json = _get_leaderboard_representation(leaderboard)
+    else:
+        leaderboard_json = leaderboard
+
+    print("Rank | Username | Score | Take | Prize")
+    print("-" * 50)
+    for entry in leaderboard_json:
+        print(
+            f"{entry['rank']:4d} | {entry['username']:20s} | {entry['score']:6.2f} | {entry['take']:6.2f} | {entry['prize']:6.2f}%"
+        )
+
+
+def _move_leaderboard_forecasts_by_num_days(
+    leaderboard: Leaderboard,
+    users: list[User],
+    num_days: int,
+) -> None:
+    try:
+        project = leaderboard.project
+
+        # Get all posts in this project
+        posts = Post.objects.filter(
+            Q(default_project=project) | Q(projects=project)
+        ).distinct()
+
+        # Get all questions from these posts
+        questions = Question.objects.filter(related_posts__post__in=posts).distinct()
+
+        # Get all forecasts for these questions by these users
+        forecasts = Forecast.objects.filter(question__in=questions, author__in=users)
+
+        # Update each forecast's timestamp
+        count = 0
+        for forecast in forecasts:
+            days_to_add = num_days
+            forecast.start_time = forecast.start_time + timedelta(days=days_to_add)
+            if forecast.end_time:
+                forecast.end_time = forecast.end_time + timedelta(days=days_to_add)
+            forecast.save()
+            count += 1
+
+        print(f"Updated {count} forecasts")
+
+        # Rescore the affected questions
+        for question in questions:
+            resolution = question.resolution
+            if not resolution or resolution in ["ambiguous", "annulled"]:
+                continue
+            score_question(
+                question=question,
+                resolution=resolution,
+            )
+        print(f"Rescored {len(questions)} questions")
+
+        # Force update the leaderboard
+        print("Force updating leaderboard...")
+        update_project_leaderboard(
+            project=project, leaderboard=leaderboard, force_update=True
+        )
+        print("Leaderboard updated successfully")
+
+    except User.DoesNotExist:
+        print("User not found")
+
+
+def _save_leaderboard_to_csv(
+    leaderboard_data: list[dict[str, Any]], output_path: str
+) -> None:
+    with open(output_path, "w", newline="") as csvfile:
+        fieldnames = ["rank", "username", "score", "take", "prize"]
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+
+        writer.writeheader()
+        writer.writerows(leaderboard_data)
+
+
+def _get_leaderboard_representation(leaderboard: Leaderboard) -> list[dict[str, Any]]:
+    entries = leaderboard.entries.select_related("user").order_by("rank")
+
+    return [
+        {
+            "rank": entry.rank if entry.rank is not None else -1,
+            "username": entry.user.username if entry.user else "N/A",
+            "score": round(entry.score, 2) if entry.score is not None else -1,
+            "take": round(entry.take, 2) if entry.take is not None else -1,
+            "prize": round(entry.prize, 2) if entry.prize is not None else -1,
+        }
+        for entry in entries
+    ]

--- a/scoring/score_math.py
+++ b/scoring/score_math.py
@@ -323,7 +323,7 @@ def evaluate_question(
     question: Question,
     resolution_bucket: int | None,
     score_types: list[Score.ScoreTypes],
-    spot_forecast_timestamp: float,
+    spot_forecast_timestamp: float | None = None,
 ) -> list[Score]:
     if resolution_bucket is None:
         return []
@@ -374,6 +374,7 @@ def evaluate_question(
                     open_bounds_count,
                 )
             case ScoreTypes.SPOT_BASELINE:
+                assert spot_forecast_timestamp is not None, "Spot forecast timestamp is required for spot baseline scoring"
                 open_bounds_count = bool(question.open_upper_bound) + bool(
                     question.open_lower_bound
                 )
@@ -413,6 +414,7 @@ def evaluate_question(
                     geometric_means=geometric_means,
                 )
             case ScoreTypes.SPOT_PEER:
+                assert spot_forecast_timestamp is not None, "Spot forecast timestamp is required for spot peer scoring"
                 user_scores = evaluate_forecasts_peer_spot_forecast(
                     user_forecasts,
                     user_forecasts,

--- a/scoring/score_math.py
+++ b/scoring/score_math.py
@@ -323,7 +323,7 @@ def evaluate_question(
     question: Question,
     resolution_bucket: int | None,
     score_types: list[Score.ScoreTypes],
-    spot_forecast_timestamp: float | None = None,
+    spot_forecast_timestamp: float,
 ) -> list[Score]:
     if resolution_bucket is None:
         return []

--- a/scoring/utils.py
+++ b/scoring/utils.py
@@ -43,6 +43,8 @@ def score_question(
             spot_scoring_time = question.spot_scoring_time.timestamp()
         elif question.cp_reveal_time:
             spot_scoring_time = question.cp_reveal_time.timestamp()
+        else:
+            spot_scoring_time = None
     else:
         spot_scoring_time = override_spot_scoring_time
 

--- a/scoring/utils.py
+++ b/scoring/utils.py
@@ -7,9 +7,22 @@ from io import StringIO
 
 import numpy as np
 from django.db import transaction
-from django.db.models import (Case, Count, Exists, ExpressionWrapper, F,
-                              FloatField, Func, IntegerField, OuterRef, Q,
-                              QuerySet, Sum, Value, When)
+from django.db.models import (
+    Case,
+    Count,
+    Exists,
+    ExpressionWrapper,
+    F,
+    FloatField,
+    Func,
+    IntegerField,
+    OuterRef,
+    Q,
+    QuerySet,
+    Sum,
+    Value,
+    When,
+)
 from django.db.models.functions import Coalesce, ExtractYear, Power
 from django.utils import timezone
 from sql_util.aggregates import SubqueryAggregate
@@ -19,9 +32,14 @@ from posts.models import Post
 from projects.models import Project
 from questions.models import Forecast, Question, QuestionPost
 from questions.types import AggregationMethod
-from scoring.models import (ArchivedScore, Leaderboard, LeaderboardEntry,
-                            LeaderboardsRanksEntry, MedalExclusionRecord,
-                            Score)
+from scoring.models import (
+    ArchivedScore,
+    Leaderboard,
+    LeaderboardEntry,
+    LeaderboardsRanksEntry,
+    MedalExclusionRecord,
+    Score,
+)
 from scoring.score_math import evaluate_question
 from users.models import User
 from utils.dtypes import generate_map_from_list

--- a/utils/the_math/formulas.py
+++ b/utils/the_math/formulas.py
@@ -149,7 +149,7 @@ def bucket_index_to_unscaled_location(bucket_index: int, question: "Question") -
 
 def string_location_to_unscaled_location(
     string_location: str, question: "Question"
-) -> float:
+) -> float | None:
     if string_location in ["", None, "ambiguous", "annulled"]:
         return None
     scaled_location = string_location_to_scaled_location(string_location, question)
@@ -157,9 +157,9 @@ def string_location_to_unscaled_location(
 
 
 def string_location_to_bucket_index(
-    string_location: str, question: "Question"
+    string_location: str | None, question: "Question"
 ) -> int | None:
-    if string_location in ["", None, "ambiguous", "annulled"]:
+    if not string_location or string_location in ["ambiguous", "annulled"]:
         return None
     unscaled_location = string_location_to_unscaled_location(string_location, question)
     return unscaled_location_to_bucket_index(unscaled_location, question)


### PR DESCRIPTION
Created action that simulates leaderboards after removing a list of users by username. It does this by pushing all of that user's forecast into the future by 500 years. Theoretically this should work for all our leaderboards, but at least spot score (which is what it was tested with).

Also updated some type checking and logic unification for 'spot score time' during scoring.