### PR TITLE
Consumer Views QA feedback

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -1162,5 +1162,6 @@
   "cpAscendingSubquestionOrder": "Předpověď komunity (Vzestupně)",
   "cpDescendingSubquestionOrder": "Předpověď komunity (Sestupně)",
   "groupSorting": "Třídění skupin",
-  "groupSortingDescription": "Pořadí podotázek ve skupině"
+  "groupSortingDescription": "Pořadí podotázek ve skupině",
+  "today": "Dnes"
 }

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1160,5 +1160,6 @@
   "cpAscendingSubquestionOrder": "Community Prediction (Ascending)",
   "cpDescendingSubquestionOrder": "Community Prediction (Descending)",
   "groupSorting": "Group sorting",
-  "groupSortingDescription": "The order of the subquestions in the group"
+  "groupSortingDescription": "The order of the subquestions in the group",
+  "today": "Today"
 }

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -1162,5 +1162,6 @@
   "cpAscendingSubquestionOrder": "Predicción de la Comunidad (Ascendente)",
   "cpDescendingSubquestionOrder": "Predicción de la Comunidad (Descendente)",
   "groupSorting": "Ordenación por grupos",
-  "groupSortingDescription": "El orden de las subpreguntas en el grupo"
+  "groupSortingDescription": "El orden de las subpreguntas en el grupo",
+  "today": "Hoy"
 }

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -1160,5 +1160,6 @@
   "cpAscendingSubquestionOrder": "Previsão da Comunidade (Ascendente)",
   "cpDescendingSubquestionOrder": "Previsão da Comunidade (Descendente)",
   "groupSorting": "Ordenação do grupo",
-  "groupSortingDescription": "A ordem das subperguntas no grupo"
+  "groupSortingDescription": "A ordem das subperguntas no grupo",
+  "today": "Hoje"
 }

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -1164,5 +1164,6 @@
   "cpAscendingSubquestionOrder": "社区预测（升序）",
   "cpDescendingSubquestionOrder": "社区预测（降序）",
   "groupSorting": "分组排序",
-  "groupSortingDescription": "分组中子问题的顺序"
+  "groupSortingDescription": "分组中子问题的顺序",
+  "today": "今天"
 }

--- a/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/date_card_tooltip.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/date_card_tooltip.tsx
@@ -7,14 +7,17 @@ type Props = {
   points: {
     label: string;
     color: ThemeColor;
+    x: number;
   }[];
 };
 
 const DateForecastCardTooltip: FC<Props> = ({ points }) => {
   const { getThemeColor } = useAppTheme();
+  const sortedPoints = [...points].sort((a, b) => a.x - b.x);
+
   return (
     <div className="flex flex-wrap items-center justify-center gap-2">
-      {points.map((point) => (
+      {sortedPoints.map((point) => (
         <div
           key={point.label}
           className="flex items-center gap-1 text-center text-sm"

--- a/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/index.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/index.tsx
@@ -2,6 +2,7 @@ import "./styles.scss";
 
 import { isNil } from "lodash";
 import { useLocale } from "next-intl";
+import { useTranslations } from "next-intl";
 import { FC, useState } from "react";
 import {
   VictoryAxis,
@@ -52,6 +53,7 @@ const TICKS_ARRAY = Array.from({ length: 9 }, (_, i) => 0.04 + (i * 0.92) / 8);
 const DateForecastCard: FC<Props> = ({ questionsGroup, height = 100 }) => {
   const { questions } = questionsGroup;
   const locale = useLocale();
+  const t = useTranslations();
   const { theme, getThemeColor } = useAppTheme();
   const chartTheme = theme === "dark" ? darkTheme : lightTheme;
   const { ref: chartContainerRef, width: chartWidth } =
@@ -63,21 +65,29 @@ const DateForecastCard: FC<Props> = ({ questionsGroup, height = 100 }) => {
   const scaling = getContinuousGroupScaling(questions);
   const shouldDisplayChart = !!chartWidth;
   const isBigChartView = chartWidth > SMALL_CHART_WIDTH;
-  const { adjustedScaling, points } = generateChartData(choices, scaling);
+  const { adjustedScaling, points, todayLine } = generateChartData(
+    choices,
+    scaling
+  );
   const [labelOverlap, setLabelOverlap] = useState<
     {
       label: string;
       color: ThemeColor;
+      x: number;
     }[]
   >([]);
-  const onLabelOverlap = (label: string, color: ThemeColor) => {
+  const onLabelOverlap = (label: string, color: ThemeColor, x: number) => {
     setLabelOverlap((prev) => {
       if (prev.some((item) => item.label === label)) {
         return prev;
       }
-      return [...prev, { label, color }];
+      return [...prev, { label, color, x }];
     });
   };
+
+  if (points.length === 0) {
+    return null;
+  }
 
   return (
     <>
@@ -109,11 +119,17 @@ const DateForecastCard: FC<Props> = ({ questionsGroup, height = 100 }) => {
             }
           >
             <VictoryAxis
-              tickFormat={(tick, index) =>
-                isBigChartView
-                  ? formatTickLabel(tick, adjustedScaling, index)
-                  : ""
-              }
+              tickFormat={(tick, index) => {
+                if (!isBigChartView) {
+                  return "";
+                }
+                if (!isNil(todayLine)) {
+                  return tick < todayLine - 0.1 || tick > todayLine + 0.1
+                    ? formatTickLabel(tick, adjustedScaling, index)
+                    : "";
+                }
+                return formatTickLabel(tick, adjustedScaling, index);
+              }}
               tickValues={TICKS_ARRAY}
               style={{
                 ticks: {
@@ -128,7 +144,7 @@ const DateForecastCard: FC<Props> = ({ questionsGroup, height = 100 }) => {
                 },
                 tickLabels: {
                   fill: () => getThemeColor(METAC_COLORS.gray["500"]),
-                  fontSize: 11,
+                  fontSize: 14,
                 },
               }}
             />
@@ -146,12 +162,13 @@ const DateForecastCard: FC<Props> = ({ questionsGroup, height = 100 }) => {
                   axis: { stroke: "transparent" },
                   tickLabels: {
                     fill: () => getThemeColor(METAC_COLORS.gray["500"]),
-                    fontSize: 11,
+                    fontSize: 14,
                   },
                 }}
                 offsetY={15}
               />
             )}
+
             <VictoryScatter
               data={points}
               size={8}
@@ -176,6 +193,25 @@ const DateForecastCard: FC<Props> = ({ questionsGroup, height = 100 }) => {
                 />
               }
             />
+            {/* Today line */}
+            {todayLine && (
+              <VictoryAxis
+                tickFormat={() => t("today")}
+                tickValues={[todayLine]}
+                orientation="bottom"
+                style={{
+                  ticks: { stroke: "transparent" },
+                  grid: {
+                    stroke: getThemeColor(METAC_COLORS.purple["700"]),
+                  },
+                  axis: { stroke: "transparent" },
+                  tickLabels: {
+                    fill: () => getThemeColor(METAC_COLORS.purple["700"]),
+                    fontSize: 14,
+                  },
+                }}
+              />
+            )}
           </VictoryChart>
         )}
       </div>
@@ -270,8 +306,16 @@ function generateChartData(choices: ChoiceItem[], originalScaling: Scaling) {
     };
   });
 
+  const nowTimestamp = Date.now() / 1000;
+
+  let todayPoint = null;
+  if (nowTimestamp <= scaling.range_max && nowTimestamp >= scaling.range_min) {
+    todayPoint = unscaleNominalLocation(nowTimestamp, scaling);
+  }
+
   return {
     adjustedScaling: scaling,
+    todayLine: todayPoint,
     points: points.map((point) => {
       // this should always return an object
       const pointData = choices.find((choice) => choice.id === point.id);

--- a/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/scatter_label.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/scatter_label.tsx
@@ -10,7 +10,7 @@ import { ThemeColor } from "@/types/theme";
 type Props = VictoryLabelProps & {
   chartWidth: number;
   scale?: { x: (x: number) => number; y: (y: number) => number };
-  onLabelOverlap: (label: string, color: ThemeColor) => void;
+  onLabelOverlap: (label: string, color: ThemeColor, x: number) => void;
 };
 
 const SMALL_CHART_WIDTH = 400;
@@ -36,7 +36,7 @@ const ScatterLabel: FC<Props> = ({ chartWidth, ...props }) => {
       const allowedDistance = datum?.labelWidth / 2 + item.labelWidth / 2;
       if (Math.abs(scaledX - scaledItemX) <= allowedDistance) {
         setIsOverlapping(true);
-        onLabelOverlap(label, datum?.color);
+        onLabelOverlap(label, datum?.color, x);
         break;
       }
     }

--- a/front_end/src/components/consumer_post_card/time_series_chart/time_series_label.tsx
+++ b/front_end/src/components/consumer_post_card/time_series_chart/time_series_label.tsx
@@ -24,12 +24,16 @@ const TimeSeriesLabel: FC<Props & any> = ({
   const shouldTrancateText = labelVisibilityMap.some(
     (value: boolean) => !value
   );
-  const getLabelColor = (datum: any) => {
+  const getLabelColor = (datum: any, isChipText?: boolean) => {
     if (datum.resolution) {
-      return getThemeColor(METAC_COLORS.purple["700"]);
+      return getThemeColor(
+        isChipText ? METAC_COLORS.purple["600"] : METAC_COLORS.purple["700"]
+      );
     }
     if (datum.isClosed) {
-      return getThemeColor(METAC_COLORS.gray["700"]);
+      return getThemeColor(
+        isChipText ? METAC_COLORS.gray["500"] : METAC_COLORS.gray["700"]
+      );
     }
     return getThemeColor(METAC_COLORS.blue["700"]);
   };
@@ -43,6 +47,7 @@ const TimeSeriesLabel: FC<Props & any> = ({
         {...rest}
         style={{
           fontSize: 14,
+          fontFamily: "var(--font-inter-variable)",
           fill: ({ datum }: any) => getLabelColor(datum),
         }}
         text={({ datum, index }: any) =>
@@ -62,18 +67,20 @@ const TimeSeriesLabel: FC<Props & any> = ({
         <VictoryLabel
           datum={datum}
           y={scale.y(datum.y)}
-          dy={-20}
+          dy={["no", "yes"].includes(datum.resolution as string) ? -26 : -23}
           {...rest}
           style={{
-            fontSize: 12,
+            fontSize: 14,
             fontWeight: 500,
-            fill: ({ datum }: any) => getLabelColor(datum),
+            lineHeight: "16px",
+            fontFamily: "var(--font-inter-variable)",
+            fill: ({ datum }: any) => getLabelColor(datum, true),
           }}
           text={({ datum, index }: any) =>
             labelVisibilityMap[index]
               ? datum.isClosed
-                ? t("closed")
-                : t("resolved")
+                ? t("closed").toUpperCase()
+                : t("resolved").toUpperCase()
               : ""
           }
         />
@@ -81,11 +88,13 @@ const TimeSeriesLabel: FC<Props & any> = ({
       <VictoryLabel
         datum={datum}
         y={scale.y(datum.y)}
-        dy={-5}
+        dy={["no", "yes"].includes(datum.resolution as string) ? -8 : -5}
         {...rest}
+        className="font-inter"
         style={{
           fontSize: 16,
           fontWeight: 700,
+          fontFamily: "var(--font-inter-variable)",
           fill: ({ datum }: any) => getLabelColor(datum),
         }}
         text={({ datum, index }: any) =>

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -1438,7 +1438,7 @@ export function getResolutionPosition({
     return 0;
   }
   if (adjustBinaryPoint && ["no", "yes"].includes(resolution as string)) {
-    return 0;
+    return 0.4;
   }
 
   if (


### PR DESCRIPTION
- don't render charts if all questions are resolved unsucessfully
- implemented redesigned resolved view for fan graph binary groups
- limit number of subquestions to show in fan graph binary groups based on chart width
- fixed order of items in the legend for date group chart
- added today marker on x-axis for date group