### PR TITLE
Short title to be used in tab naming

### DIFF
--- a/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const parsedDescription = String(file).split("\n")[0];
 
   return {
-    title: postData.title,
+    title: postData.short_title ?? postData.title,
     description: !!parsedDescription ? parsedDescription : defaultDescription,
   };
 }

--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   const questionTitle = getQuestionTitle(postData);
   return {
-    title: questionTitle,
+    title: postData.short_title ?? questionTitle,
     description: null,
     openGraph: {
       type: "article",


### PR DESCRIPTION
Fixes #2484

- use `short_title` instead of `title` in `metadata`