### PR TITLE
Images are not rendered in markdown editor

### DIFF
--- a/front_end/src/components/markdown_editor/editor.css
+++ b/front_end/src/components/markdown_editor/editor.css
@@ -45,7 +45,7 @@
   @apply max-h-[300px];
 }
 
-[data-editor-block-type="image"] > :last-child {
+[data-editor-block-type="image"] > :last-child:not(:only-child) {
   @apply hidden;
 }
 


### PR DESCRIPTION
Fixes #2497

- fixed render of images in the new version of the image plugin