### PR TITLE
resolution fixes

### DIFF
--- a/front_end/src/components/charts/continuous_area_chart.tsx
+++ b/front_end/src/components/charts/continuous_area_chart.tsx
@@ -172,14 +172,15 @@ const ContinuousAreaChart: FC<Props> = ({
     [height, yDomain, paddingTop]
   );
 
-  const resolutionPoint = !isNil(resolution)
-    ? getResolutionData({
-        questionType,
-        resolution,
-        resolveTime: 1,
-        scaling,
-      })
-    : null;
+  const resolutionPoint =
+    !isNil(resolution) && resolution !== ""
+      ? getResolutionData({
+          questionType,
+          resolution,
+          resolveTime: 1,
+          scaling,
+        })
+      : null;
 
   // TODO: find a nice way to display the out of bounds weights as numbers
   // const massBelowBounds = dataset[0];

--- a/front_end/src/components/prediction_chip.tsx
+++ b/front_end/src/components/prediction_chip.tsx
@@ -159,7 +159,7 @@ const PredictionChip: FC<Props> = ({
           )}
         >
           <Label className="text-purple-900 dark:text-purple-900-dark">
-            {t("resolved")} :
+            {t("resolved")}:
           </Label>
           <Chip
             size={size}

--- a/front_end/src/utils/questions.ts
+++ b/front_end/src/utils/questions.ts
@@ -223,6 +223,7 @@ export function formatResolution({
           scaling,
           actual_resolve_time,
           unit,
+          precision: 10,
         })
       );
     }
@@ -238,6 +239,7 @@ export function formatResolution({
           scaling,
           actual_resolve_time,
           unit,
+          precision: 10,
         })
       );
     }
@@ -279,7 +281,10 @@ export function formatResolution({
   }
 
   if (!isNaN(Number(resolution)) && resolution.trim() !== "") {
-    return formatValueUnit(abbreviatedNumber(Number(resolution)), unit);
+    return formatValueUnit(
+      abbreviatedNumber(Number(resolution), 10, false),
+      unit
+    );
   }
 
   if (questionType === QuestionType.MultipleChoice) {


### PR DESCRIPTION
closes #2520
closes #2458

if a question's resolution field is set to the empty string, don't interpret that as a resolution of 0
don't round resolution values (have a precision of 10)