### PR TITLE
approval modal quickfixes

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/post_approval_modal.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/post_approval_modal.tsx
@@ -55,14 +55,14 @@ const PostApprovalModal: FC<{
         "yyyy-MM-dd'T'HH:mm:ss'Z'"
       ),
     scheduled_close_time:
-      post.question?.scheduled_close_time ??
+      post.scheduled_close_time ??
       formatInTimeZone(
         addDays(new Date(), 30),
         "UTC",
         "yyyy-MM-dd'T'HH:mm:ss'Z'"
       ),
     scheduled_resolve_time:
-      post.question?.scheduled_resolve_time ??
+      post.scheduled_resolve_time ??
       formatInTimeZone(
         addDays(new Date(), 30),
         "UTC",

--- a/posts/services/common.py
+++ b/posts/services/common.py
@@ -498,10 +498,14 @@ def approve_post(
     questions = post.get_questions()
 
     for question in questions:
-        question.open_time = open_time
-        question.cp_reveal_time = cp_reveal_time
-        question.scheduled_close_time = scheduled_close_time
-        question.scheduled_resolve_time = scheduled_resolve_time
+        question.open_time = question.open_time or open_time
+        question.cp_reveal_time = question.cp_reveal_time or cp_reveal_time
+        question.scheduled_close_time = (
+            question.scheduled_close_time or scheduled_close_time
+        )
+        question.scheduled_resolve_time = (
+            question.scheduled_resolve_time or scheduled_resolve_time
+        )
 
     post.save()
     Question.objects.bulk_update(


### PR DESCRIPTION
closes #2523 

populate approval with post time details
only update question details if not already set during approval logic