### PR TITLE
Moved Indexes section in tournaments page

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournaments/page.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/page.tsx
@@ -54,15 +54,6 @@ export default async function Tournaments() {
 
       <hr className="hidden border-gray-300 dark:border-gray-300-dark md:block" />
 
-      {indexes.length > 0 && (
-        <TournamentsList
-          title={t("Indexes")}
-          items={indexes}
-          cardsPerPage={12}
-          withEmptyState
-        />
-      )}
-
       <TournamentsList
         title={t("ActiveTournaments")}
         items={activeTournaments}
@@ -75,6 +66,15 @@ export default async function Tournaments() {
         items={questionSeries}
         cardsPerPage={12}
       />
+
+      {indexes.length > 0 && (
+        <TournamentsList
+          title={t("Indexes")}
+          items={indexes}
+          cardsPerPage={12}
+          withEmptyState
+        />
+      )}
 
       <TournamentsList
         title={t("Archive")}


### PR DESCRIPTION
Not it's between the question series and archive sections

closes #2516 