### PR TITLE
Graph when creating continuous questions no longer has axis ticks / numbers

### DIFF
--- a/front_end/src/app/(main)/questions/components/group_form.tsx
+++ b/front_end/src/app/(main)/questions/components/group_form.tsx
@@ -718,7 +718,6 @@ const GroupForm: React.FC<Props> = ({
                         hasForecasts={
                           subQuestion.has_forecasts && mode !== "create"
                         }
-                        chartWidth={720}
                         onChange={({
                           min: range_min,
                           max: range_max,

--- a/front_end/src/app/(main)/questions/components/numeric_question_input.tsx
+++ b/front_end/src/app/(main)/questions/components/numeric_question_input.tsx
@@ -41,7 +41,6 @@ const NumericQuestionInput: React.FC<{
   defaultOpenLowerBound: boolean | undefined | null;
   defaultZeroPoint: number | undefined | null;
   hasForecasts: boolean;
-  chartWidth?: number;
   control?: UseFormReturn;
   index?: number;
 }> = ({
@@ -53,7 +52,6 @@ const NumericQuestionInput: React.FC<{
   defaultOpenLowerBound,
   defaultZeroPoint,
   hasForecasts,
-  chartWidth = 800,
   control,
   index,
 }) => {
@@ -446,7 +444,6 @@ const NumericQuestionInput: React.FC<{
               question={question}
               readOnly={false}
               height={100}
-              width={chartWidth}
               showCP={false}
             />
           </>

--- a/front_end/src/components/charts/continuous_area_chart.tsx
+++ b/front_end/src/components/charts/continuous_area_chart.tsx
@@ -161,6 +161,7 @@ const ContinuousAreaChart: FC<Props> = ({
         scaling: scaling,
         unit,
         shortLabels,
+        adjustLabels: true,
       }),
     [chartWidth, questionType, scaling, unit, xDomain, shortLabels]
   );
@@ -171,6 +172,7 @@ const ContinuousAreaChart: FC<Props> = ({
         axisLength: height - BOTTOM_PADDING - paddingTop,
         direction: "vertical",
         domain: yDomain,
+        adjustLabels: true,
       }),
     [height, yDomain, paddingTop]
   );


### PR DESCRIPTION
Fixes #2501 
Fixes #2545

- adjusted calculation of ticks to prevent 0 interval value
- removed hardcoded value of chart width in question creation forms
- adjusted chart tick labels formatting