### PR TITLE
Comment link scroll should work on deep threads

### DIFF
--- a/front_end/src/components/comment_feed/index.tsx
+++ b/front_end/src/components/comment_feed/index.tsx
@@ -28,7 +28,7 @@ import { BECommentType, CommentType } from "@/types/comment";
 import { PostWithForecasts } from "@/types/post";
 import { QuestionType } from "@/types/question";
 import cn from "@/utils/cn";
-import { parseComment } from "@/utils/comments";
+import { getCommentIdToFocusOn, parseComment } from "@/utils/comments";
 import { logError } from "@/utils/errors";
 
 import CommentWelcomeMessage, {
@@ -143,22 +143,6 @@ const CommentFeed: FC<Props> = ({
     userCommentsAmount !== null &&
     userCommentsAmount < NEW_USER_COMMENT_LIMIT &&
     !PUBLIC_MINIMAL_UI;
-  /**
-   * Returns commentId to focus on if id is provided and comment is not already rendered
-   */
-  const getCommentIdToFocusOn = () => {
-    const match =
-      typeof window !== "undefined" &&
-      window.location.hash.match(/comment-(\d+)/);
-
-    const focus_comment_id = match ? match[1] : undefined;
-    // Check whether comment is already rendered. In this case we don't need to re-fetch the page
-    const isCommentLoaded =
-      focus_comment_id &&
-      document.getElementById(`comment-${focus_comment_id}`);
-
-    if (focus_comment_id && !isCommentLoaded) return focus_comment_id;
-  };
 
   const [feedFilters, setFeedFilters] = useState<getCommentsParams>(() => ({
     is_private: false,

--- a/front_end/src/utils/comments.ts
+++ b/front_end/src/utils/comments.ts
@@ -76,3 +76,19 @@ export function parseUserMentions(
   );
   return markdown;
 }
+
+/**
+ * Returns commentId to focus on if id is provided and comment is not already rendered
+ */
+export function getCommentIdToFocusOn() {
+  const match =
+    typeof window !== "undefined" &&
+    window.location.hash.match(/comment-(\d+)/);
+
+  const focus_comment_id = match ? match[1] : undefined;
+  // Check whether comment is already rendered. In this case we don't need to re-fetch the page
+  const isCommentLoaded =
+    focus_comment_id && document.getElementById(`comment-${focus_comment_id}`);
+
+  if (focus_comment_id && !isCommentLoaded) return focus_comment_id;
+}


### PR DESCRIPTION
Fixes to #2283

- added a check for the selected comment hash within the comment tree.
- adjusted the expanded state so that if a focused comment is within the comment tree it expands properly