### PR TITLE
Make graph take all vertical space in group feed tile

### DIFF
--- a/front_end/src/components/multiple_choice_tile/index.tsx
+++ b/front_end/src/components/multiple_choice_tile/index.tsx
@@ -10,6 +10,7 @@ import MultipleChoiceChart from "@/components/charts/multiple_choice_chart";
 import ForecastAvailabilityChartOverflow from "@/components/post_card/chart_overflow";
 import useCardReaffirmContext from "@/components/post_card/reaffirm_context";
 import PredictionChip from "@/components/prediction_chip";
+import useContainerSize from "@/hooks/use_container_size";
 import { ForecastPayload } from "@/services/questions";
 import { TimelineChartZoomOption } from "@/types/charts";
 import { ChoiceItem } from "@/types/choices";
@@ -60,6 +61,8 @@ type ContinuousMultipleChoiceTileProps = BaseProps &
     scaling?: Scaling | undefined;
   };
 
+const CHART_HEIGHT = 100;
+
 export const ContinuousMultipleChoiceTile: FC<
   ContinuousMultipleChoiceTileProps
 > = ({
@@ -70,7 +73,7 @@ export const ContinuousMultipleChoiceTile: FC<
   visibleChoicesCount,
   defaultChartZoom,
   withZoomPicker,
-  chartHeight = 100,
+  chartHeight,
   chartTheme,
   question,
   groupType,
@@ -81,7 +84,7 @@ export const ContinuousMultipleChoiceTile: FC<
   canPredict,
 }) => {
   const { onReaffirm } = useCardReaffirmContext();
-
+  const { ref, height } = useContainerSize<HTMLDivElement>();
   // when resolution chip is shown we want to hide the chart and display the chip
   // (e.g. multiple-choice question on questions feed)
   // otherwise, resolution status will be populated near the every choice
@@ -108,6 +111,7 @@ export const ContinuousMultipleChoiceTile: FC<
           <PredictionChip question={question} status={PostStatus.RESOLVED} />
         ) : (
           <MultipleChoiceTileLegend
+            ref={ref}
             choices={choices}
             visibleChoicesCount={visibleChoicesCount}
             questionType={groupType}
@@ -123,7 +127,7 @@ export const ContinuousMultipleChoiceTile: FC<
             timestamps={timestamps}
             actualCloseTime={actualCloseTime}
             choiceItems={choices}
-            height={chartHeight}
+            height={chartHeight ?? Math.max(height, CHART_HEIGHT)}
             extraTheme={chartTheme}
             defaultZoom={defaultChartZoom}
             withZoomPicker={withZoomPicker}
@@ -161,6 +165,7 @@ export const FanGraphMultipleChoiceTile: FC<
   canPredict,
 }) => {
   const { onReaffirm } = useCardReaffirmContext();
+  const { ref, height } = useContainerSize<HTMLDivElement>();
 
   const { canReaffirm, forecast } = useMemo(
     () => generateReaffirmData({ groupQuestions, groupType }),
@@ -177,6 +182,7 @@ export const FanGraphMultipleChoiceTile: FC<
     <div className="MultipleChoiceTile ml-0 mr-2 flex w-full grid-cols-[200px_auto] flex-col items-start gap-3 pr-1 xs:grid">
       <div className="resize-container">
         <MultipleChoiceTileLegend
+          ref={ref}
           choices={choices}
           visibleChoicesCount={visibleChoicesCount}
           hideCP={hideCP}
@@ -190,7 +196,7 @@ export const FanGraphMultipleChoiceTile: FC<
       <div className="w-full">
         <FanGraphGroupChart
           questions={groupQuestions}
-          height={chartHeight}
+          height={chartHeight ?? Math.max(height, CHART_HEIGHT)}
           pointSize={8}
           hideCP={hideCP}
           withTooltip={false}

--- a/front_end/src/components/multiple_choice_tile/multiple_choice_tile_legend.tsx
+++ b/front_end/src/components/multiple_choice_tile/multiple_choice_tile_legend.tsx
@@ -1,7 +1,7 @@
 import { faEllipsis } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslations } from "next-intl";
-import React, { FC } from "react";
+import React, { FC, RefObject } from "react";
 
 import ReaffirmButton from "@/components/post_card/reaffirm_button";
 import { ChoiceItem } from "@/types/choices";
@@ -18,6 +18,7 @@ type Props = {
   optionLabelClassName?: string;
   onReaffirm?: () => void;
   canPredict?: boolean;
+  ref?: RefObject<HTMLDivElement | null>;
 };
 
 const MultipleChoiceTileLegend: FC<Props> = ({
@@ -29,6 +30,7 @@ const MultipleChoiceTileLegend: FC<Props> = ({
   optionLabelClassName,
   onReaffirm,
   canPredict = false,
+  ref,
 }) => {
   const t = useTranslations();
 
@@ -36,7 +38,7 @@ const MultipleChoiceTileLegend: FC<Props> = ({
   const otherItemsCount = choices.length - visibleChoices.length;
 
   return (
-    <div className="embed-gap flex flex-col gap-2">
+    <div className="embed-gap flex flex-col gap-2" ref={ref}>
       {visibleChoices.map(
         ({
           choice,

--- a/front_end/src/components/post_card/group_of_questions_tile/group_continuous_tile.tsx
+++ b/front_end/src/components/post_card/group_of_questions_tile/group_continuous_tile.tsx
@@ -23,7 +23,6 @@ import {
   sortGroupPredictionOptions,
 } from "@/utils/questions";
 
-const CHART_HEIGHT = 100;
 const VISIBLE_CHOICES_COUNT = 3;
 
 type Props = {
@@ -68,7 +67,6 @@ const GroupContinuousTile: FC<Props> = ({ post, hideCP }) => {
           groupType={questionType}
           hideCP={hideCP}
           forecastAvailability={forecastAvailability}
-          chartHeight={CHART_HEIGHT}
           canPredict={canPredict}
         />
       );


### PR DESCRIPTION
Resolves #1456

- adjusted MC and group questions charts in feed to take all available vertical space
  - still enforce min height of 100px