### PR TITLE
Show tournament timeline `Tournament.close_date`

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/components/tournament_timeline.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/components/tournament_timeline.tsx
@@ -51,7 +51,7 @@ const TournamentTimeline: FC<Props> = async ({ tournament }) => {
               : null
           }
           latestScheduledCloseTimestamp={getTimestampFromDateString(
-            latest_scheduled_close_time
+            tournament.close_date || latest_scheduled_close_time
           )}
         />
       ) : (


### PR DESCRIPTION
Show tournament timeline close date take from `Tournament.close_date` instead of dynamic generation

closes #2551 