### PR TITLE
Embed image modal is displayed beneath the comments section

### DIFF
--- a/front_end/src/components/markdown_editor/editor.css
+++ b/front_end/src/components/markdown_editor/editor.css
@@ -7,6 +7,13 @@
   --baseBorder: theme("colors.gray.500.DEFAULT");
 }
 
+.mdxeditor-popup-container {
+  @apply z-100;
+  [role="dialog"] {
+    @apply flex flex-col xs:flex-row;
+  }
+}
+
 .markdown-editor-form .mdxeditor-toolbar {
   @apply sticky top-0 z-10;
 }


### PR DESCRIPTION
Fixes #2564

- fixed editor modals overlap