### PR TITLE
Move the comments feed state in a Context Provider

### DIFF
--- a/front_end/src/app/(main)/accounts/profile/[id]/page.tsx
+++ b/front_end/src/app/(main)/accounts/profile/[id]/page.tsx
@@ -9,6 +9,7 @@ import strip from "strip-markdown";
 import MedalsPage from "@/app/(main)/(leaderboards)/medals/components/medals_page";
 import { MedalsWidget } from "@/app/(main)/(leaderboards)/medals/components/medals_widget";
 import UserInfo from "@/app/(main)/accounts/profile/components/user_info";
+import CommentsFeedProvider from "@/app/(main)/components/comments_feed_provider";
 import CalibrationChart from "@/app/(main)/questions/track-record/components/charts/calibration_chart";
 import CommentFeed from "@/components/comment_feed";
 import AwaitedPostsFeed from "@/components/posts_feed";
@@ -136,7 +137,12 @@ export default async function Profile(props: Props) {
       )}
       {mode === ProfilePageMode.Comments && (
         <div className="flex flex-col rounded bg-white px-4 py-1 dark:bg-blue-900 md:px-6 md:py-2">
-          <CommentFeed profileId={profile.id} rootCommentStructure={false} />
+          <CommentsFeedProvider
+            profileId={profile.id}
+            rootCommentStructure={false}
+          >
+            <CommentFeed profileId={profile.id} rootCommentStructure={false} />
+          </CommentsFeedProvider>
         </div>
       )}
       {mode === ProfilePageMode.Questions && (

--- a/front_end/src/app/(main)/components/comments_feed_provider.tsx
+++ b/front_end/src/app/(main)/components/comments_feed_provider.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import {
+  createContext,
+  FC,
+  PropsWithChildren,
+  useContext,
+  useState,
+} from "react";
+
+import { SortOption } from "@/components/comment_feed";
+import { getCommentsParams } from "@/services/comments";
+import { BECommentType, CommentType } from "@/types/comment";
+import { parseComment } from "@/utils/comments";
+import { logError } from "@/utils/errors";
+
+import { getComments } from "../questions/actions";
+
+type ErrorType = Error & { digest?: string };
+
+export type CommentsFeedContextType = {
+  comments: CommentType[];
+  setComments: (comments: CommentType[]) => void;
+  isLoading: boolean;
+  setIsLoading: (isFeedLoading: boolean) => void;
+  error: ErrorType | undefined;
+  offset: number;
+  setOffset: (offset: number) => void;
+  totalCount: number | "?";
+  setTotalCount: (totalCount: number) => void;
+  sort: SortOption;
+  setSort: (sort: SortOption) => void;
+  fetchComments: (
+    keepComments: boolean,
+    params: getCommentsParams
+  ) => Promise<void>;
+};
+
+const COMMENTS_PER_PAGE = 10;
+
+export const CommentsFeedContext =
+  createContext<CommentsFeedContextType | null>(null);
+
+function parseCommentsArray(
+  beComments: BECommentType[],
+  rootsOnly: boolean = true
+): CommentType[] {
+  const commentMap = new Map<number, CommentType>();
+
+  beComments.forEach((comment) => {
+    commentMap.set(comment.id, parseComment(comment));
+  });
+
+  if (!rootsOnly) {
+    return Array.from(commentMap.values());
+  }
+
+  const rootComments: CommentType[] = [];
+
+  beComments.forEach((comment) => {
+    if (comment.parent_id === null) {
+      const commentData = commentMap.get(comment.id);
+      if (commentData) {
+        rootComments.push(commentData);
+      }
+    } else {
+      const parentComment = commentMap.get(comment.parent_id);
+      const childComment = commentMap.get(comment.id);
+      if (parentComment && childComment) {
+        parentComment.children.push(childComment);
+      }
+    }
+  });
+
+  return rootComments;
+}
+
+type BaseProviderProps = {
+  rootCommentStructure: boolean;
+};
+type PostProviderProps = {
+  postId: number;
+  profileId?: never;
+};
+type ProfileProviderProps = {
+  profileId: number;
+  postId?: never;
+};
+
+const CommentsFeedProvider: FC<
+  PropsWithChildren<
+    BaseProviderProps & (PostProviderProps | ProfileProviderProps)
+  >
+> = ({ children, postId, profileId, rootCommentStructure }) => {
+  const [sort, setSort] = useState<SortOption>("created_at");
+  const [comments, setComments] = useState<CommentType[]>([]);
+  const [totalCount, setTotalCount] = useState<number | "?">("?");
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<ErrorType | undefined>(undefined);
+  const [offset, setOffset] = useState<number>(0);
+
+  const fetchComments = async (
+    keepComments: boolean = true,
+    params: getCommentsParams
+  ) => {
+    try {
+      setIsLoading(true);
+      setError(undefined);
+      const response = await getComments({
+        post: postId,
+        author: profileId,
+        /* if we're on a post, fetch only parent comments with children annotated.  if this is a profile, fetch only the author's comments, including parents and children */
+        limit: COMMENTS_PER_PAGE,
+        use_root_comments_pagination: rootCommentStructure,
+        ...params,
+      });
+      if ("errors" in response) {
+        logError(response.errors, "Error fetching comments:");
+      } else {
+        setTotalCount(response.total_count ?? response.count);
+
+        const sortedComments = parseCommentsArray(
+          response.results as unknown as BECommentType[],
+          rootCommentStructure
+        );
+        if (keepComments && offset > 0) {
+          setComments((prevComments) => [...prevComments, ...sortedComments]);
+        } else {
+          setComments(sortedComments);
+        }
+        if (response.next) {
+          const nextOffset = new URL(response.next).searchParams.get("offset");
+          setOffset(
+            nextOffset ? Number(nextOffset) : (prev) => prev + COMMENTS_PER_PAGE
+          );
+        } else {
+          setOffset(-1);
+        }
+      }
+    } catch (err) {
+      const error = err as Error & { digest?: string };
+      setError(error);
+      logError(err, `Error fetching comments: ${err}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <CommentsFeedContext.Provider
+      value={{
+        comments,
+        setComments,
+        isLoading,
+        setIsLoading,
+        setOffset,
+        setTotalCount,
+        error,
+        offset,
+        totalCount,
+        sort,
+        setSort,
+        fetchComments,
+      }}
+    >
+      {children}
+    </CommentsFeedContext.Provider>
+  );
+};
+
+export default CommentsFeedProvider;
+
+export const useCommentsFeed = () => {
+  const context = useContext(CommentsFeedContext);
+  if (!context) {
+    throw new Error(
+      "useCommentsFeed must be used within a CommentsFeedProvider"
+    );
+  }
+
+  return context;
+};

--- a/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page_compotent.tsx
+++ b/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page_compotent.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 import { FC } from "react";
 
+import CommentsFeedProvider from "@/app/(main)/components/comments_feed_provider";
 import CommunityHeader from "@/app/(main)/components/headers/community_header";
 import Header from "@/app/(main)/components/headers/header";
 import NotebookContentSections from "@/app/(main)/notebooks/components/notebook_content_sections";
@@ -191,11 +192,16 @@ const IndividualNotebookPage: FC<{
                 </div>
               )}
             </div>
-            <CommentFeed
-              postData={postData}
-              id={NOTEBOOK_COMMENTS_TITLE}
-              inNotebook={true}
-            />
+            <CommentsFeedProvider
+              postId={postData.id}
+              rootCommentStructure={true}
+            >
+              <CommentFeed
+                postData={postData}
+                id={NOTEBOOK_COMMENTS_TITLE}
+                inNotebook={true}
+              />
+            </CommentsFeedProvider>
           </div>
         </div>
       </main>

--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page_component.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page_component.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { FC } from "react";
 
+import CommentsFeedProvider from "@/app/(main)/components/comments_feed_provider";
 import CommunityHeader from "@/app/(main)/components/headers/community_header";
 import Header from "@/app/(main)/components/headers/header";
 import CommentFeed from "@/components/comment_feed";
@@ -75,112 +76,114 @@ const IndividualQuestionPage: FC<{
   const questionTitle = getQuestionTitle(postData);
   return (
     <EmbedModalContextProvider>
-      <HideCPProvider post={postData}>
-        {isCommunityQuestion ? (
-          <CommunityHeader community={currentCommunity} />
-        ) : (
-          <Header />
-        )}
-        <main
-          className={cn(
-            "mx-auto flex w-full max-w-max flex-col scroll-smooth py-4 md:py-10",
-            {
-              "sm:mt-5": isCommunityQuestion,
-            }
+      <CommentsFeedProvider postId={postData.id} rootCommentStructure={true}>
+        <HideCPProvider post={postData}>
+          {isCommunityQuestion ? (
+            <CommunityHeader community={currentCommunity} />
+          ) : (
+            <Header />
           )}
-        >
-          <div className="flex gap-4">
-            <div className="relative w-full">
-              {isCommunityQuestion && (
-                <div className="absolute z-0 -mt-[41px] hidden w-full sm:block">
-                  <CommunityDisclaimer
-                    project={postData.projects.default_project}
-                    variant="inline"
-                  />
-                </div>
-              )}
-              <div className="relative z-10 flex w-full flex-col gap-4">
-                <section className="w-[48rem] max-w-full rounded border-transparent bg-gray-0 px-3 pt-4 text-gray-900 after:mt-6 after:block after:w-full after:content-[''] dark:border-blue-200-dark dark:bg-gray-0-dark dark:text-gray-900-dark xs:px-4 lg:border">
-                  {isCommunityQuestion && (
+          <main
+            className={cn(
+              "mx-auto flex w-full max-w-max flex-col scroll-smooth py-4 md:py-10",
+              {
+                "sm:mt-5": isCommunityQuestion,
+              }
+            )}
+          >
+            <div className="flex gap-4">
+              <div className="relative w-full">
+                {isCommunityQuestion && (
+                  <div className="absolute z-0 -mt-[41px] hidden w-full sm:block">
                     <CommunityDisclaimer
                       project={postData.projects.default_project}
-                      variant="standalone"
-                      className="mb-4 block sm:hidden"
+                      variant="inline"
                     />
-                  )}
-
-                  <PostHeader post={postData} questionTitle={questionTitle} />
-                  {!postData.conditional && (
-                    <div className="mt-2 flex justify-between gap-2 xs:gap-4 sm:gap-8 lg:mb-2 lg:mt-4">
-                      <h1 className="m-0 text-xl leading-tight sm:text-3xl">
-                        {postData.title}
-                      </h1>
-                      {postData.resolved && !!postData.question && (
-                        <QuestionResolutionStatus post={postData} />
-                      )}
-                    </div>
-                  )}
-
-                  {isConditionalPost(postData) && (
-                    <ConditionalTile
-                      post={postData}
-                      withNavigation
-                      withCPRevealBtn
-                    />
-                  )}
-                  <QuestionHeaderInfo post={postData} />
-
-                  {isQuestionPost(postData) && (
-                    <DetailedQuestionCard post={postData} />
-                  )}
-                  {isGroupOfQuestionsPost(postData) && (
-                    <DetailedGroupCard
-                      post={postData}
-                      preselectedQuestionId={preselectedGroupQuestionId}
-                    />
-                  )}
-
-                  <ForecastMaker post={postData} />
-                  <ResolutionCriteria post={postData} />
-
-                  {isConditionalPost(postData) && (
-                    <ConditionalTimeline post={postData} />
-                  )}
-
-                  <div className="flex flex-col gap-2.5">
-                    {!!keyFactors.length && (
-                      <KeyFactorsSection keyFactors={keyFactors} />
-                    )}
-                    <BackgroundInfo post={postData} />
-                    {!!postData.group_of_questions && (
-                      <ContinuousGroupTimeline
-                        post={postData}
-                        preselectedQuestionId={preselectedGroupQuestionId}
-                        className="mt-2"
+                  </div>
+                )}
+                <div className="relative z-10 flex w-full flex-col gap-4">
+                  <section className="w-[48rem] max-w-full rounded border-transparent bg-gray-0 px-3 pt-4 text-gray-900 after:mt-6 after:block after:w-full after:content-[''] dark:border-blue-200-dark dark:bg-gray-0-dark dark:text-gray-900-dark xs:px-4 lg:border">
+                    {isCommunityQuestion && (
+                      <CommunityDisclaimer
+                        project={postData.projects.default_project}
+                        variant="standalone"
+                        className="mb-4 block sm:hidden"
                       />
                     )}
-                    <HistogramDrawer post={postData} />
-                  </div>
-                </section>
-                <Sidebar
-                  postData={postData}
-                  allowModifications={allowModifications}
-                  layout="mobile"
-                  questionTitle={questionTitle}
-                />
-                <CommentFeed postData={postData} />
-              </div>
-            </div>
-            <Sidebar
-              postData={postData}
-              allowModifications={allowModifications}
-              questionTitle={questionTitle}
-            />
-          </div>
-        </main>
 
-        <QuestionEmbedModal postId={postData.id} postTitle={postData.title} />
-      </HideCPProvider>
+                    <PostHeader post={postData} questionTitle={questionTitle} />
+                    {!postData.conditional && (
+                      <div className="mt-2 flex justify-between gap-2 xs:gap-4 sm:gap-8 lg:mb-2 lg:mt-4">
+                        <h1 className="m-0 text-xl leading-tight sm:text-3xl">
+                          {postData.title}
+                        </h1>
+                        {postData.resolved && !!postData.question && (
+                          <QuestionResolutionStatus post={postData} />
+                        )}
+                      </div>
+                    )}
+
+                    {isConditionalPost(postData) && (
+                      <ConditionalTile
+                        post={postData}
+                        withNavigation
+                        withCPRevealBtn
+                      />
+                    )}
+                    <QuestionHeaderInfo post={postData} />
+
+                    {isQuestionPost(postData) && (
+                      <DetailedQuestionCard post={postData} />
+                    )}
+                    {isGroupOfQuestionsPost(postData) && (
+                      <DetailedGroupCard
+                        post={postData}
+                        preselectedQuestionId={preselectedGroupQuestionId}
+                      />
+                    )}
+
+                    <ForecastMaker post={postData} />
+                    <ResolutionCriteria post={postData} />
+
+                    {isConditionalPost(postData) && (
+                      <ConditionalTimeline post={postData} />
+                    )}
+
+                    <div className="flex flex-col gap-2.5">
+                      {!!keyFactors.length && (
+                        <KeyFactorsSection keyFactors={keyFactors} />
+                      )}
+                      <BackgroundInfo post={postData} />
+                      {!!postData.group_of_questions && (
+                        <ContinuousGroupTimeline
+                          post={postData}
+                          preselectedQuestionId={preselectedGroupQuestionId}
+                          className="mt-2"
+                        />
+                      )}
+                      <HistogramDrawer post={postData} />
+                    </div>
+                  </section>
+                  <Sidebar
+                    postData={postData}
+                    allowModifications={allowModifications}
+                    layout="mobile"
+                    questionTitle={questionTitle}
+                  />
+                  <CommentFeed postData={postData} />
+                </div>
+              </div>
+              <Sidebar
+                postData={postData}
+                allowModifications={allowModifications}
+                questionTitle={questionTitle}
+              />
+            </div>
+          </main>
+
+          <QuestionEmbedModal postId={postData.id} postTitle={postData.title} />
+        </HideCPProvider>
+      </CommentsFeedProvider>
     </EmbedModalContextProvider>
   );
 };


### PR DESCRIPTION
The state of comments needs to be managed from different parts of the questions pages, like the Key Factors section and needs to stay at a higher level.