### PR TITLE
Mention menu appears below comment interface

### DIFF
--- a/front_end/src/components/markdown_editor/editor.css
+++ b/front_end/src/components/markdown_editor/editor.css
@@ -14,6 +14,11 @@
   }
 }
 
+/* user mentions menu */
+#typeahead-menu {
+  @apply z-100;
+}
+
 .markdown-editor-form .mdxeditor-toolbar {
   @apply sticky top-0 z-10;
 }

--- a/front_end/src/components/markdown_editor/initialized_editor.tsx
+++ b/front_end/src/components/markdown_editor/initialized_editor.tsx
@@ -28,6 +28,7 @@ import {
   toolbarPlugin,
   UndoRedo,
 } from "@mdxeditor/editor";
+import { BeautifulMentionsTheme } from "lexical-beautiful-mentions";
 import React, {
   FC,
   ForwardedRef,
@@ -60,6 +61,11 @@ import { mentionsPlugin } from "./plugins/mentions";
 import { SourceModeTitle } from "./source_mode_title";
 
 type EditorMode = "write" | "read";
+
+const beautifulMentionsTheme: BeautifulMentionsTheme = {
+  "@": "block rounded",
+  "@Focused": "ring-2 ring-offset-1 ring-blue-500 dark:ring-blue-500-dark",
+};
 
 const jsxComponentDescriptors: JsxComponentDescriptor[] = [
   embeddedQuestionDescriptor,
@@ -265,6 +271,9 @@ const InitializedMarkdownEditor: FC<
         ...(editorDiffSourcePlugin ? [editorDiffSourcePlugin] : []),
         ...(editorToolbarPlugin ? [editorToolbarPlugin] : []),
       ]}
+      lexicalTheme={{
+        beautifulMentions: beautifulMentionsTheme,
+      }}
     />
   );
 };

--- a/front_end/src/components/markdown_editor/plugins/mentions/components/mention.tsx
+++ b/front_end/src/components/markdown_editor/plugins/mentions/components/mention.tsx
@@ -4,14 +4,14 @@ import { forwardRef } from "react";
 const CustomMentionComponent = forwardRef<
   HTMLAnchorElement,
   BeautifulMentionComponentProps
->(({ trigger, value, data: myData, children, ...other }, ref) => {
+>(({ trigger, value, data: myData, children, className, ...other }, ref) => {
   // combination on inline-block and block is used as a workaround for Chrome bug on Android
   // when element is duplicated when typing
   // github.com/facebook/lexical/issues/4636
   // https://issues.chromium.org/issues/41254240
   return (
     <span className="inline-block">
-      <span {...other} ref={ref} className="block">
+      <span {...other} ref={ref} className={className}>
         {trigger}({value})
       </span>
     </span>


### PR DESCRIPTION
Fixes #2582

- fixed similar issue we recently had with "embed image" modal, which is a regression after adding communities disclaimer

<img width="802" alt="image" src="https://github.com/user-attachments/assets/120e7845-5440-439c-893f-4050b28072d1" />

Closes #1597

- applied styles for mention node in focused state

<img width="666" alt="image" src="https://github.com/user-attachments/assets/37a650e3-27d7-412a-ade9-7dd47486ceac" />