### PR TITLE
Consumer Views QA

### DIFF
--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_choice_bar.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_choice_bar.tsx
@@ -58,16 +58,22 @@ const ForecastChoiceBar: FC<Props> = ({
       <span className="z-10 text-nowrap">
         {displayedResolution ? (
           <>
-            {isResolutionSuccessful ? (
+            {isResolutionSuccessful && (
               <span className="font-medium capitalize text-purple-600 dark:text-purple-600-dark">
                 {t("result")}:{" "}
               </span>
-            ) : null}
+            )}
             <span className="font-bold">
-              {unit
-                ? String(displayedResolution).replace(unit, "")
-                : displayedResolution}
-              {unit && <span className="font-normal">{unit}</span>}
+              {isResolutionSuccessful ? (
+                <>
+                  {unit
+                    ? String(displayedResolution).replace(unit, "")
+                    : displayedResolution}
+                  {unit && <span className="font-normal">{unit}</span>}
+                </>
+              ) : (
+                displayedResolution
+              )}
             </span>
           </>
         ) : (

--- a/front_end/src/components/consumer_post_card/index.tsx
+++ b/front_end/src/components/consumer_post_card/index.tsx
@@ -15,6 +15,7 @@ import {
   isGroupOfQuestionsPost,
   isQuestionPost,
   isMultipleChoicePost,
+  ANNULLED_RESOLUTION,
 } from "@/utils/questions";
 
 import ConsumerKeyFactor from "./key_factor";
@@ -31,8 +32,20 @@ const ConsumerPostCard: FC<Props> = ({ post, forCommunityFeed }) => {
   const t = useTranslations();
   const isShortTitle = title.length < 100;
   const forecastAvailability = getPostForecastAvailability(post);
-  const isGroupOrMCPost =
-    isGroupOfQuestionsPost(post) || isMultipleChoicePost(post);
+  const isGroupPost = isGroupOfQuestionsPost(post);
+  const isMcPost = isMultipleChoicePost(post);
+  const isGroupOrMCPost = isGroupPost || isMcPost;
+
+  // Don’t display a question in Consumer Views if all subquestions are annulled
+  if (isGroupPost) {
+    const allQuestionsResolvedAnnulled =
+      post.group_of_questions.questions.every(
+        (q) => q.resolution === ANNULLED_RESOLUTION
+      );
+    if (allQuestionsResolvedAnnulled) {
+      return null;
+    }
+  }
 
   return (
     <div>

--- a/front_end/src/components/consumer_post_card/prediction_info.tsx
+++ b/front_end/src/components/consumer_post_card/prediction_info.tsx
@@ -49,16 +49,18 @@ const ConsumerPredictionInfo: FC<Props> = ({ post, forecastAvailability }) => {
       const formatedResolution = formatResolution({
         resolution: question.resolution,
         questionType: question.type,
+        scaling: question.scaling,
         locale,
         unit: question.unit,
         actual_resolve_time: question.actual_resolve_time ?? null,
-        shortBounds: true,
+        completeBounds: true,
+        longBounds: true,
       });
-      const successfullResolution = isSuccessfullyResolved(question.resolution);
+      const successfullyResolved = isSuccessfullyResolved(question.resolution);
       return (
         <QuestionResolutionChip
           formatedResolution={formatedResolution}
-          successfullResolution={successfullResolution}
+          successfullyResolved={successfullyResolved}
           unit={question.unit}
         />
       );

--- a/front_end/src/components/consumer_post_card/question_resolution_chip.tsx
+++ b/front_end/src/components/consumer_post_card/question_resolution_chip.tsx
@@ -5,13 +5,13 @@ import cn from "@/utils/cn";
 
 type Props = {
   formatedResolution: string;
-  successfullResolution: boolean;
+  successfullyResolved: boolean;
   unit?: string;
 };
 
 const QuestionResolutionChip: FC<Props> = ({
   formatedResolution,
-  successfullResolution,
+  successfullyResolved,
   unit,
 }) => {
   const t = useTranslations();
@@ -21,20 +21,20 @@ const QuestionResolutionChip: FC<Props> = ({
         className={cn(
           "flex w-fit flex-col items-center rounded bg-purple-100 px-4 py-2 dark:bg-purple-100-dark",
           {
-            "bg-gray-300 dark:bg-gray-300-dark": !successfullResolution,
+            "bg-gray-300 dark:bg-gray-300-dark": !successfullyResolved,
           }
         )}
       >
-        {successfullResolution && (
+        {successfullyResolved && (
           <span className="text-xs font-medium uppercase leading-4 text-purple-600 dark:text-purple-600-dark">
             {t("result")}
           </span>
         )}
         <span
           className={cn(
-            "text-base font-bold leading-6 text-purple-800 dark:text-purple-800-dark",
+            "text-center text-base font-bold leading-6 text-purple-800 dark:text-purple-800-dark",
             {
-              "text-gray-700 dark:text-gray-700-dark": !successfullResolution,
+              "text-gray-700 dark:text-gray-700-dark": !successfullyResolved,
             }
           )}
         >

--- a/front_end/src/components/consumer_post_card/time_series_chart/index.tsx
+++ b/front_end/src/components/consumer_post_card/time_series_chart/index.tsx
@@ -203,7 +203,7 @@ function buildChartData(
             questionType: question.type,
             locale: locale,
             scaling: question.scaling,
-            shortBounds: true,
+            completeBounds: true,
             actual_resolve_time: null,
           })
         : null;

--- a/front_end/src/utils/charts.ts
+++ b/front_end/src/utils/charts.ts
@@ -359,6 +359,7 @@ export function getDisplayValue({
   unit,
   adjustLabels = false,
   skipQuartilesBorders = false,
+  longBounds = false,
 }: {
   value: number | null | undefined;
   questionType: QuestionType;
@@ -371,13 +372,16 @@ export function getDisplayValue({
   unit?: string;
   adjustLabels?: boolean;
   skipQuartilesBorders?: boolean; // remove "<" or ">" from the formatted value if the value is out of the quartiles
+  longBounds?: boolean;
 }): string {
   if (value === undefined || value === null) {
     return "...";
   }
   const scaledValue = scaleInternalLocation(value, scaling);
   const centerDisplay =
-    checkQuartilesOutOfBorders(skipQuartilesBorders ? undefined : value) +
+    checkQuartilesOutOfBorders(skipQuartilesBorders ? undefined : value, {
+      longBounds,
+    }) +
     displayValue({
       value: scaledValue,
       questionType,
@@ -397,7 +401,9 @@ export function getDisplayValue({
     }
     const scaledLower = scaleInternalLocation(lowerX, scaling);
     const lowerDisplay =
-      checkQuartilesOutOfBorders(skipQuartilesBorders ? undefined : lowerX) +
+      checkQuartilesOutOfBorders(skipQuartilesBorders ? undefined : lowerX, {
+        longBounds,
+      }) +
       displayValue({
         value: scaledLower,
         questionType,
@@ -410,7 +416,9 @@ export function getDisplayValue({
       });
     const scaledUpper = scaleInternalLocation(upperX, scaling);
     const upperDisplay =
-      checkQuartilesOutOfBorders(skipQuartilesBorders ? undefined : upperX) +
+      checkQuartilesOutOfBorders(skipQuartilesBorders ? undefined : upperX, {
+        longBounds,
+      }) +
       displayValue({
         value: scaledUpper,
         questionType,
@@ -1167,7 +1175,7 @@ export function generateChoiceItemsFromGroupQuestions(
             scaling: question.scaling,
             unit: question.unit,
             actual_resolve_time: question.actual_resolve_time ?? null,
-            shortBounds: shortBounds,
+            completeBounds: shortBounds,
           })
         : null,
       closeTime,
@@ -1662,6 +1670,15 @@ export function getTruncatedLabel(label: string, maxLength: number): string {
   return label.slice(0, maxLength).trim() + "...";
 }
 
-export function checkQuartilesOutOfBorders(quartile: number | undefined) {
+export function checkQuartilesOutOfBorders(
+  quartile: number | undefined,
+  options?: { longBounds?: boolean }
+) {
+  const { longBounds = false } = options ?? {};
+
+  if (longBounds) {
+    return quartile === 0 ? "Less than " : quartile === 1 ? "More than " : "";
+  }
+
   return quartile === 0 ? "<" : quartile === 1 ? ">" : "";
 }

--- a/front_end/src/utils/questions.ts
+++ b/front_end/src/utils/questions.ts
@@ -188,7 +188,8 @@ export function formatResolution({
   actual_resolve_time,
   scaling,
   unit,
-  shortBounds = false,
+  completeBounds = false,
+  longBounds = false,
 }: {
   resolution: number | string | null | undefined;
   questionType: QuestionType;
@@ -196,7 +197,8 @@ export function formatResolution({
   actual_resolve_time: string | null;
   scaling?: Scaling;
   unit?: string;
-  shortBounds?: boolean;
+  completeBounds?: boolean;
+  longBounds?: boolean;
 }) {
   if (resolution === null || resolution === undefined) {
     return "-";
@@ -213,7 +215,7 @@ export function formatResolution({
   }
 
   if (resolution === "below_lower_bound") {
-    if (shortBounds && scaling) {
+    if (completeBounds && scaling) {
       return getDisplayValue({
         value: 0,
         questionType,
@@ -221,12 +223,13 @@ export function formatResolution({
         actual_resolve_time,
         unit,
         precision: 10,
+        longBounds,
       });
     }
     return "Below lower bound";
   }
   if (resolution === "above_upper_bound") {
-    if (shortBounds && scaling) {
+    if (completeBounds && scaling) {
       return getDisplayValue({
         value: 1,
         questionType,
@@ -234,6 +237,7 @@ export function formatResolution({
         actual_resolve_time,
         unit,
         precision: 10,
+        longBounds,
       });
     }
     return "Above upper bound";


### PR DESCRIPTION
Address some of the latest QA feedback on consumer views:

- updated labeling of continuous question resolution when it's outside of bounds

<img width="724" alt="image" src="https://github.com/user-attachments/assets/8b3c3e4f-9bab-419f-aa9b-8c86ef4636db" />

- remove unit rendering for posts/questions that resolved unsuccessfully:

<img width="742" alt="image" src="https://github.com/user-attachments/assets/1f0ceb65-c1a8-4b19-900e-4cc0990a7be4" />

- don't render group posts if all questions have "annulled" resolution