### PR TITLE
Fixed locked range inputs for groups

### DIFF
--- a/front_end/src/app/(main)/questions/components/group_form.tsx
+++ b/front_end/src/app/(main)/questions/components/group_form.tsx
@@ -839,6 +839,7 @@ const GroupForm: React.FC<Props> = ({
                     ...subQuestions,
                     {
                       ...subQuestions[subQuestions.length - 1],
+                      has_forecasts: false,
                       id: undefined,
                       label: "",
                     },

--- a/front_end/src/components/ui/form_field.tsx
+++ b/front_end/src/components/ui/form_field.tsx
@@ -109,7 +109,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <>
         <input
           type={type}
-          className={`rounded-s border p-1 ${className}`}
+          className={cn("rounded-s border p-1", className)}
           ref={ref}
           name={name}
           {...props}


### PR DESCRIPTION
Fixed Range inputs were locked when adding new subquestions to groups

fixes #2645 