### PR TITLE
Proxy the favicon requests for the News Match articles

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/news_match/news_match_article.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/news_match/news_match_article.tsx
@@ -19,6 +19,11 @@ type Props = {
   questionId: number;
 };
 
+function getProxiedFaviconUrl(originalUrl: string): string {
+  if (!originalUrl) return "";
+  return `/newsmatch/favicon?url=${encodeURIComponent(originalUrl)}`;
+}
+
 const NewsMatchArticle: FC<Props> = ({ article }) => {
   const { user } = useAuth();
   const locale = useLocale();
@@ -58,7 +63,7 @@ const NewsMatchArticle: FC<Props> = ({ article }) => {
           {article.favicon_url ? (
             <ImageWithFallback
               className="mr-3 size-8 rounded-full"
-              src={article.favicon_url}
+              src={getProxiedFaviconUrl(article.favicon_url)}
               alt={`${article.media_label} logo`}
               aria-label={`${article.media_label} logo`}
             >

--- a/front_end/src/app/newsmatch/favicon/route.ts
+++ b/front_end/src/app/newsmatch/favicon/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const GET = async (request: NextRequest) => {
+  const { searchParams } = new URL(request.url);
+  const url = searchParams.get("url");
+
+  if (!url) {
+    return NextResponse.json(
+      { error: "URL parameter is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Cookie: "",
+        Accept: "image/*",
+      },
+      credentials: "omit",
+      cache: "force-cache",
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Failed to fetch favicon: ${response.statusText}` },
+        { status: response.status }
+      );
+    }
+
+    const contentType = response.headers.get("content-type") || "image/x-icon";
+
+    const buffer = await response.arrayBuffer();
+
+    return new NextResponse(buffer, {
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "public, max-age=86400",
+      },
+    });
+  } catch (error) {
+    console.error("Error proxying favicon:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch favicon" },
+      { status: 500 }
+    );
+  }
+};


### PR DESCRIPTION
If we let the frontend directly make these requests, various news sites are setting cookies even for the favicon requests. We want to avoid that and prevent these sites from tracking the users.