### PR TITLE
Mixed Sentry fixes

### DIFF
--- a/front_end/src/app/(main)/accounts/settings/components/question_notifications.tsx
+++ b/front_end/src/app/(main)/accounts/settings/components/question_notifications.tsx
@@ -66,7 +66,9 @@ const QuestionNotifications: FC<Props> = ({
 
   const handleUnfollow = useCallback(async () => {
     if (!activeModal) {
-      logError(new Error("Active modal is not set"), "Couldn't unfollow post");
+      logError(new Error("Active modal is not set"), {
+        message: "Couldn't unfollow post",
+      });
       return;
     }
 

--- a/front_end/src/app/(main)/components/comments_feed_provider.tsx
+++ b/front_end/src/app/(main)/components/comments_feed_provider.tsx
@@ -201,7 +201,7 @@ const CommentsFeedProvider: FC<
         ...params,
       });
       if (!!response && "errors" in response) {
-        logError(response.errors, "Error fetching comments:");
+        logError(response.errors, { message: "Error fetching comments:" });
       } else {
         setTotalCount(response.total_count ?? response.count);
 
@@ -226,7 +226,7 @@ const CommentsFeedProvider: FC<
     } catch (err) {
       const error = err as Error & { digest?: string };
       setError(error);
-      logError(err, `Error fetching comments: ${err}`);
+      logError(err, { message: `Error fetching comments: ${err}` });
     } finally {
       setIsLoading(false);
     }

--- a/front_end/src/app/(main)/components/cookies_banner/index.tsx
+++ b/front_end/src/app/(main)/components/cookies_banner/index.tsx
@@ -110,9 +110,13 @@ const CookiesBanner: FC = () => {
 };
 
 export function getAnalyticsCookieConsentGiven(): ConsentGiven {
-  const consentGiven = localStorage.getItem(STORAGE_KEY);
+  try {
+    const consentGiven = localStorage.getItem(STORAGE_KEY);
 
-  return consentGiven ? (consentGiven as ConsentGiven) : "undecided";
+    return consentGiven ? (consentGiven as ConsentGiven) : "undecided";
+  } catch {
+    return "undecided";
+  }
 }
 
 export default CookiesBanner;

--- a/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_menu.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/forecast_maker/forecast_maker_group/forecast_maker_group_menu.tsx
@@ -47,7 +47,7 @@ const ForecastMakerGroupControls: FC<Props> = ({
     try {
       await navigator.clipboard.writeText(text);
     } catch (err) {
-      logError(err, `${t("failedToCopyText")} ${err}`);
+      logError(err, { message: `failed to copy text: ${err}` });
     }
   };
 

--- a/front_end/src/app/(main)/questions/components/conditional_form.tsx
+++ b/front_end/src/app/(main)/questions/components/conditional_form.tsx
@@ -20,7 +20,7 @@ import {
   TournamentType,
 } from "@/types/projects";
 import { QuestionType, QuestionWithForecasts } from "@/types/question";
-import { logErrorWithScope } from "@/utils/core/errors";
+import { logError } from "@/utils/core/errors";
 import { getPostLink } from "@/utils/navigation";
 import { getQuestionStatus } from "@/utils/questions/helpers";
 
@@ -119,7 +119,7 @@ const ConditionalForm: React.FC<{
       }
     } catch (e) {
       const error = e as Error & { digest?: string };
-      logErrorWithScope(error, post_data);
+      logError(error, { payload: post_data });
       setError(error);
     } finally {
       setIsLoading(false);

--- a/front_end/src/app/(main)/questions/components/group_form.tsx
+++ b/front_end/src/app/(main)/questions/components/group_form.tsx
@@ -46,7 +46,7 @@ import {
   TournamentType,
 } from "@/types/projects";
 import { QuestionType, QuestionWithNumericForecasts } from "@/types/question";
-import { logErrorWithScope } from "@/utils/core/errors";
+import { logError } from "@/utils/core/errors";
 import { getPostLink } from "@/utils/navigation";
 import { sortGroupPredictionOptions } from "@/utils/questions/groupOrdering";
 
@@ -259,7 +259,7 @@ const GroupForm: React.FC<Props> = ({
       router.push(getPostLink(resp.post));
     } catch (e) {
       const error = e as Error & { digest?: string };
-      logErrorWithScope(error, post_data);
+      logError(error, { payload: post_data });
       setError(error);
     } finally {
       setIsLoading(false);

--- a/front_end/src/app/(main)/questions/components/notebook_form.tsx
+++ b/front_end/src/app/(main)/questions/components/notebook_form.tsx
@@ -24,7 +24,7 @@ import {
   TournamentPreview,
   TournamentType,
 } from "@/types/projects";
-import { logErrorWithScope } from "@/utils/core/errors";
+import { logError } from "@/utils/core/errors";
 import { getPostLink } from "@/utils/navigation";
 
 import BacktoCreate from "./back_to_create";
@@ -141,7 +141,7 @@ const NotebookForm: React.FC<Props> = ({
       router.push(getPostLink(resp.post));
     } catch (e) {
       const error = e as Error & { digest?: string };
-      logErrorWithScope(error, post_data);
+      logError(error, { payload: post_data });
       setError(error);
     } finally {
       setIsLoading(false);

--- a/front_end/src/app/(main)/questions/components/question_form.tsx
+++ b/front_end/src/app/(main)/questions/components/question_form.tsx
@@ -31,7 +31,7 @@ import {
   TournamentType,
 } from "@/types/projects";
 import { QuestionType } from "@/types/question";
-import { logErrorWithScope } from "@/utils/core/errors";
+import { logError } from "@/utils/core/errors";
 import { getPostLink } from "@/utils/navigation";
 import { getQuestionStatus } from "@/utils/questions/helpers";
 
@@ -343,7 +343,7 @@ const QuestionForm: FC<Props> = ({
       router.push(getPostLink(resp.post));
     } catch (e) {
       const error = e as Error & { digest?: string };
-      logErrorWithScope(error, post_data);
+      logError(error, { payload: post_data });
       setError(error);
     } finally {
       setIsLoading(false);

--- a/front_end/src/app/global-error.tsx
+++ b/front_end/src/app/global-error.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
 import NextError from "next/error";
 import { useEffect } from "react";
+
+import { logError } from "@/utils/core/errors";
 
 export default function GlobalError({
   error,
@@ -10,7 +11,7 @@ export default function GlobalError({
   error: Error & { digest?: string };
 }) {
   useEffect(() => {
-    Sentry.captureException(error);
+    logError(error);
   }, [error]);
 
   return (

--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -281,7 +281,7 @@ const Comment: FC<CommentProps> = ({
     try {
       await navigator.clipboard.writeText(text);
     } catch (err) {
-      logError(err, `${t("failedToCopyText")} ${err}`);
+      logError(err, { message: `failed to copy text: ${err}` });
     }
   };
   const handleSaveComment = useCallback(async () => {

--- a/front_end/src/components/comment_feed/comment_cmm.tsx
+++ b/front_end/src/components/comment_feed/comment_cmm.tsx
@@ -78,10 +78,9 @@ const CmmMakeForecast: FC<{
 
   const onUpdateVal = (step: number | undefined) => {
     if (isNil(step)) {
-      logError(
-        new Error("Step is undefined"),
-        "Error updating comment forecast"
-      );
+      logError(new Error("Step is undefined"), {
+        message: "Error updating comment forecast",
+      });
       return;
     }
 

--- a/front_end/src/components/markdown_editor/initialized_editor.tsx
+++ b/front_end/src/components/markdown_editor/initialized_editor.tsx
@@ -37,7 +37,6 @@ import useAppTheme from "@/hooks/use_app_theme";
 import useConfirmPageLeave from "@/hooks/use_confirm_page_leave";
 import { useDebouncedCallback } from "@/hooks/use_debounce";
 import cn from "@/utils/core/cn";
-import { logErrorWithScope } from "@/utils/core/errors";
 
 import EditorToolbar from "./editor_toolbar";
 import { embeddedQuestionDescriptor } from "./embedded_question";
@@ -226,7 +225,7 @@ const InitializedMarkdownEditor: FC<
       onChange={debouncedHandleEditorChange}
       onBlur={onBlur}
       onError={(err) => {
-        logErrorWithScope(err.error, err.source);
+        console.warn(err);
         if (mode === "read") {
           requestAnimationFrame(() => {
             setErrorMarkdown(markdown);

--- a/front_end/src/components/markdown_editor/plugins/equation/equation_node.tsx
+++ b/front_end/src/components/markdown_editor/plugins/equation/equation_node.tsx
@@ -110,7 +110,7 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
   exportDOM(): DOMExportOutput {
     const element = document.createElement(this.__inline ? "span" : "div");
     // Encode the equation as base64 to avoid issues with special characters
-    const equation = btoa(this.__equation);
+    const equation = bytesToBase64(new TextEncoder().encode(this.__equation));
     element.setAttribute("data-lexical-equation", equation);
     element.setAttribute("data-lexical-inline", `${this.__inline}`);
     katex.render(this.__equation, element, {
@@ -180,6 +180,14 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
   select() {
     this.__focusEmitter.publish();
   }
+}
+
+function bytesToBase64(bytes: Uint8Array) {
+  const binString = Array.from(bytes, (byte) =>
+    String.fromCodePoint(byte)
+  ).join("");
+
+  return btoa(binString);
 }
 
 /**

--- a/front_end/src/components/onboarding/steps/step_5.tsx
+++ b/front_end/src/components/onboarding/steps/step_5.tsx
@@ -123,24 +123,21 @@ const Step5: React.FC<OnboardingStep> = ({
 
   const handleSubmit = async ({ post, forecast }: ForecastedPost) => {
     if (isNil(post)) {
-      logError(
-        new Error("Post not found"),
-        "Error submitting onboarding forecast"
-      );
+      logError(new Error("Post not found"), {
+        message: "Error submitting onboarding forecast",
+      });
       return;
     }
     if (isNil(post.question)) {
-      logError(
-        new Error("Question not found"),
-        "Error submitting onboarding forecast"
-      );
+      logError(new Error("Question not found"), {
+        message: "Error submitting onboarding forecast",
+      });
       return;
     }
     if (isNil(forecast)) {
-      logError(
-        new Error("Forecast not found"),
-        "Error submitting onboarding forecast"
-      );
+      logError(new Error("Forecast not found"), {
+        message: "Error submitting onboarding forecast",
+      });
       return;
     }
 
@@ -163,9 +160,7 @@ const Step5: React.FC<OnboardingStep> = ({
         false
       );
 
-      if (response && "errors" in response && !!response.errors) {
-        logError(response, "Error submitting onboarding forecast");
-      } else {
+      if (!!response && !response.errors) {
         updateForecastedPostState(post.id, { isSubmitted: true });
       }
     } finally {

--- a/front_end/src/components/ui/datetime_utc.tsx
+++ b/front_end/src/components/ui/datetime_utc.tsx
@@ -69,7 +69,7 @@ const DatetimeUtc = forwardRef<HTMLInputElement, DatetimeUtcProps>(
           return;
         }
 
-        logError(e);
+        logError(e, { payload: localDateString });
         onError && onError(e);
       }
     };

--- a/front_end/src/hooks/use_search_input_state.ts
+++ b/front_end/src/hooks/use_search_input_state.ts
@@ -25,7 +25,7 @@ const useSearchInputState = (paramName: string, config?: Config) => {
 
   const [search, setSearch] = useState(() => {
     const search = params.get(paramName);
-    return search ? decodeURIComponent(search) : "";
+    return search ?? "";
   });
   const debouncedSearch = useDebouncedValue(search, debounceTime);
   const prevDebouncedSearch = usePrevious(debouncedSearch);

--- a/front_end/src/utils/comments.ts
+++ b/front_end/src/utils/comments.ts
@@ -132,7 +132,7 @@ export function saveCommentDraft(draft: CommentDraft): void {
     const draftKey = getDraftKey({ ...draft });
     localStorage.setItem(draftKey, JSON.stringify(draft));
   } catch (error) {
-    logError(error, "Failed to save comment draft");
+    logError(error, { message: "Failed to save comment draft" });
   }
 }
 export function getCommentDraft(
@@ -148,7 +148,7 @@ export function getCommentDraft(
     const draftJson = localStorage.getItem(draftKey);
     return draftJson ? JSON.parse(draftJson) : null;
   } catch (error) {
-    logError(error, "Failed to get comment draft");
+    logError(error, { message: "Failed to get comment draft" });
     return null;
   }
 }
@@ -169,7 +169,7 @@ export const deleteCommentDraft = ({
     if (!draftKey) return;
     localStorage.removeItem(draftKey);
   } catch (error) {
-    logError(error, "Failed to delete comment draft");
+    logError(error, { message: "Failed to delete comment draft" });
   }
 };
 
@@ -211,11 +211,11 @@ export const cleanupDrafts = (maxAgeDays = 14): void => {
           localStorage.removeItem(draft.key);
           totalSizeMB -= draft.size / BYTES_IN_MB;
         } catch (error) {
-          logError(error, `Failed to remove draft: ${draft.key}`);
+          logError(error, { message: `Failed to remove draft: ${draft.key}` });
         }
       }
     });
   } catch (error) {
-    logError(error, "Failed to cleanup old drafts");
+    logError(error, { message: "Failed to cleanup old drafts" });
   }
 };


### PR DESCRIPTION
- deprecate `logErrorWithScope` and instead use `logError` so we wouldn't get unexpected logs for errors with status code < 500
- fixed an issue with MDX editor when using cyrillic characters in math expression could result in error
- disabled Sentry logs when error occurs while parsing markdown editor content
  - these logs cause more noise than benefit: most of existing alerts are caused by users entering unsupported or wrong values. Especially on span account when writing a description. I think it makes more sense to ignore these and apply a fix only when actual bug is reported by user. 
- skipped redundant Sentry logs when submitting a forecast during onboarding (that log will already be triggered server-side)
- removed double decoding when initializing search input state that could result in error when percentages are used
- added fallback for analytic_cookies_consent if local storage is unavailable (e.g. when reading inside iframe)
- found and fixed another edge case when unexpected API-driven error were captured in Sentry