### PR TITLE
Truncate Project Tag on Question Tiles

### DIFF
--- a/front_end/src/components/post_default_project.tsx
+++ b/front_end/src/components/post_default_project.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { FC } from "react";
 
+import TruncatedTextTooltip from "@/components/truncated_text_tooltip";
 import { Tournament, TournamentType } from "@/types/projects";
 import { getProjectLink } from "@/utils/navigation";
 
@@ -23,10 +24,13 @@ const PostDefaultProject: FC<Props> = ({ defaultProject }) => {
 
   return (
     <Link
-      className="inline-flex items-center justify-center gap-1 rounded-l rounded-r border-inherit bg-orange-100 p-1.5 text-sm font-medium leading-4 text-orange-900 no-underline hover:bg-orange-200 dark:bg-orange-100-dark dark:text-orange-900-dark hover:dark:bg-orange-200-dark"
+      className="inline-flex items-center justify-center gap-1 rounded-l rounded-r border-inherit bg-orange-100 text-sm font-medium leading-4 text-orange-900 no-underline hover:bg-orange-200 dark:bg-orange-100-dark dark:text-orange-900-dark hover:dark:bg-orange-200-dark"
       href={getProjectLink(defaultProject)}
     >
-      {defaultProject.name}
+      <TruncatedTextTooltip
+        text={defaultProject.name}
+        className="block max-w-64 truncate p-1.5"
+      />
     </Link>
   );
 };

--- a/front_end/src/components/truncated_text_tooltip.tsx
+++ b/front_end/src/components/truncated_text_tooltip.tsx
@@ -26,17 +26,14 @@ const TruncatedTextTooltip: FC<Props> = ({
 
   useEffect(() => {
     if (ref.current) {
-      const temp = ref.current.cloneNode(true) as HTMLElement;
-      temp.style.position = "fixed";
-      temp.style.overflow = "scroll";
-      temp.style.visibility = "hidden";
-      temp.style.width = width.toString() + "px";
-      ref.current.parentElement?.appendChild(temp);
-      const scrollHeight = temp.scrollHeight;
-      const displayHeight = ref.current.clientHeight;
-
-      setIsTextTruncated(scrollHeight > displayHeight);
-      ref.current.parentElement?.removeChild(temp);
+      const element = ref.current;
+      const elementStyle = getComputedStyle(element);
+      if (isStyledWithEllipsis(elementStyle)) {
+        setIsTextTruncated(isOverflowX(element));
+      }
+      if (isStyledWithClamp(elementStyle)) {
+        setIsTextTruncated(isOverflowY(element));
+      }
     }
   }, [width, ref]);
 
@@ -67,5 +64,21 @@ const TruncatedTextTooltip: FC<Props> = ({
     </Tooltip>
   );
 };
+
+const isStyledWithEllipsis = (style: CSSStyleDeclaration) =>
+  style.overflowX === "hidden" &&
+  style.textOverflow === "ellipsis" &&
+  style.whiteSpace === "nowrap";
+
+const isStyledWithClamp = (style: CSSStyleDeclaration) => {
+  const lineClamp = style.getPropertyValue("-webkit-line-clamp");
+  return lineClamp !== "" && parseInt(lineClamp, 10) > 0;
+};
+
+const isOverflowX = (element: HTMLSpanElement) =>
+  element.offsetWidth < element.scrollWidth;
+
+const isOverflowY = (element: HTMLSpanElement) =>
+  element.offsetHeight < element.scrollHeight;
 
 export default TruncatedTextTooltip;

--- a/front_end/src/components/ui/tooltip.tsx
+++ b/front_end/src/components/ui/tooltip.tsx
@@ -75,6 +75,8 @@ const Tooltip: FC<PropsWithChildren<Props>> = ({
       {isOpen && (
         <FloatingPortal>
           <div
+            onClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.preventDefault()}
             className={cn(
               "z-10 w-max max-w-[300px] rounded border bg-blue-900-dark p-2 text-sm open:block dark:border-gray-100 dark:bg-blue-900 dark:text-gray-100 sm:max-w-sm md:max-w-md",
               tooltipClassName


### PR DESCRIPTION
Closes #2638

* updated `TruncatedTextTooltip` component to support both vertical and horizontal truncation
* updated project rendering on post card 
* fixed clicking the tooltip (e.g. to copy project name) triggered navigation to underlying post card