### PR TITLE
The case of the disappearing resolution criteria

### DIFF
--- a/front_end/src/components/html_content/html_content.tsx
+++ b/front_end/src/components/html_content/html_content.tsx
@@ -15,7 +15,10 @@ type Props = {
 
 const HtmlContent: FC<Props> = ({ content, className }) => {
   const toggleKey = useRef<string | null>(null);
-  const clearContent = DOMPurify.sanitize(content);
+  const clearContent = DOMPurify.sanitize(content, {
+    ADD_ATTR: ["toggle-details", "ng-show"],
+  });
+
   const transform = (node: any, index: number) => {
     if (!node.attribs) return undefined;
 


### PR DESCRIPTION
Fixes #2674
Fixes #2671

- fixed a regression related to markdown handling in the MDX editor
  - used regular parser (html), which is less strict and applied an alternative solution to support JSX embeds
- added custom attributes to the allowed list in the HtmlContent component