### PR TITLE
Auth middleware tweaks

### DIFF
--- a/authentication/auth.py
+++ b/authentication/auth.py
@@ -13,7 +13,7 @@ class FallbackTokenAuthentication(TokenAuthentication):
         if not auth:
             return None
 
-        # single part → assume it's the raw token
+        # single part -> assume it's the raw token
         if len(auth) == 1:
             try:
                 token = auth[0].decode()

--- a/authentication/auth.py
+++ b/authentication/auth.py
@@ -1,0 +1,26 @@
+from rest_framework.authentication import TokenAuthentication, get_authorization_header
+from rest_framework.exceptions import AuthenticationFailed
+
+
+class FallbackTokenAuthentication(TokenAuthentication):
+    """
+    TokenAuthentication, but also accepts an Authorization header with no 'Token' prefix.
+    """
+
+    def authenticate(self, request):
+        auth = get_authorization_header(request).split()
+
+        if not auth:
+            return None
+
+        # single part → assume it's the raw token
+        if len(auth) == 1:
+            try:
+                token = auth[0].decode()
+            except UnicodeError:
+                msg = "Invalid token header. Token string should not contain invalid characters."
+                raise AuthenticationFailed(msg)
+
+            return self.authenticate_credentials(token)
+
+        return super().authenticate(request)

--- a/metaculus_web/settings.py
+++ b/metaculus_web/settings.py
@@ -159,7 +159,7 @@ if not IS_TEST_ENV:
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",
-        "rest_framework.authentication.TokenAuthentication",
+        "authentication.auth.FallbackTokenAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",


### PR DESCRIPTION
- Added `FallbackTokenAuthentication` auth method to use optional `Token` prefix
- Added `authenticate_request` util for middlewares