### PR TITLE
Fixed race condition during Forecasting Flow movement calculation

### DIFF
--- a/utils/db.py
+++ b/utils/db.py
@@ -1,3 +1,8 @@
+from contextlib import contextmanager
+
+from django.db import connections, transaction
+
+
 def paginate_cursor(
     cursor,
     query,
@@ -32,3 +37,16 @@ def paginate_cursor(
                     yield row
         else:
             break
+
+
+@contextmanager
+def transaction_repeatable_read(using: str = "default"):
+    """
+    Creates an atomic transaction that works in REPEATABLE READ isolation mode
+    """
+
+    with transaction.atomic():
+        with connections[using].cursor() as cursor:
+            cursor.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;")
+
+            yield


### PR DESCRIPTION
Our `calculate_user_forecast_movement_for_questions` routine does a two‐phase fetch of `AggregateForecast` rows for performance: 
- Lightweight pass: we .only("id","start_time","question_id","end_time") to identify the first and last snapshots relevant to each user’s forecast.
- Full fetch: we bulk‐load the full AggregateForecast objects for those IDs to compute per‐question movements.

Our parallel CP recalculation job may delete or rotate out old `AggregateForecast` rows in between those two queries. That leads to missing IDs in the bulk fetch, causing `KeyErrors`

Added `REPEATABLE READ` transaction isolation to fix it here

fixes https://metaculus.sentry.io/issues/6589533098/?alert_rule_id=15420910&alert_type=issue&end=2025-05-14T11%3A25%3A00&environment=prod&notification_uuid=98b2f234-22a9-4742-b0b2-3ded2346283e&project=4507883238129664&referrer=slack&start=2025-05-14T11%3A16%3A00