### PR TITLE
Fan graph y axis zoom

### DIFF
--- a/front_end/src/components/charts/fan_chart.tsx
+++ b/front_end/src/components/charts/fan_chart.tsx
@@ -2,6 +2,7 @@
 import { isNil, merge } from "lodash";
 import React, { FC, useMemo, useState } from "react";
 import {
+  Tuple,
   VictoryArea,
   VictoryAxis,
   VictoryChart,
@@ -25,6 +26,7 @@ import {
   ContinuousForecastInputType,
   FanOption,
   Line,
+  YDomain,
 } from "@/types/charts";
 import { PostGroupOfQuestions } from "@/types/post";
 import {
@@ -35,6 +37,7 @@ import {
 } from "@/types/question";
 import {
   generateScale,
+  generateYDomain,
   getAxisLeftPadding,
   getTickLabelFontSize,
 } from "@/utils/charts/axis";
@@ -104,18 +107,11 @@ const FanChart: FC<Props> = ({
     communityPoints,
     userPoints,
     resolutionPoints,
-    scaling,
-  } = useMemo(() => buildChartData(options), [options]);
+    yScale,
+    yDomain,
+  } = useMemo(() => buildChartData({ options, height }), [height, options]);
 
   const labels = adjustLabelsForDisplay(options, chartWidth, actualTheme);
-  const yScale = generateScale({
-    // we expect fan graph to be rendered only for group questions, that expect some options
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    displayType: options[0]!.question.type,
-    axisLength: height,
-    direction: "vertical",
-    scaling: scaling,
-  });
   const { ticks, tickFormat } = yScale;
   const { leftPadding, MIN_LEFT_PADDING } = useMemo(() => {
     return getAxisLeftPadding(yScale, tickLabelFontSize as number, yLabel);
@@ -135,7 +131,7 @@ const FanChart: FC<Props> = ({
           height={height}
           theme={actualTheme}
           domain={{
-            y: [0, 1],
+            y: yDomain,
           }}
           domainPadding={{
             x: TOOLTIP_WIDTH / 2,
@@ -310,7 +306,18 @@ const FanChart: FC<Props> = ({
 
 type FanGraphPoint = { x: string; y: number; resolved: boolean };
 
-function buildChartData(options: FanOption[]) {
+function buildChartData({
+  options,
+  height,
+}: {
+  options: FanOption[];
+  height: number;
+}) {
+  // we expect fan graph to be rendered only for group questions, that expect some options
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const groupType = options[0]!.question.type;
+  const isBinaryGroup = groupType === QuestionType.Binary;
+
   const communityLine: Line<string> = [];
   const userLine: Line<string> = [];
   const communityArea: Area<string> = [];
@@ -318,19 +325,96 @@ function buildChartData(options: FanOption[]) {
   const communityPoints: Array<FanGraphPoint> = [];
   const userPoints: Array<FanGraphPoint> = [];
   const resolutionPoints: Array<FanGraphPoint> = [];
+
+  const scaling = getFanGraphScaling(options);
+
+  for (const option of options) {
+    if (option.communityQuartiles) {
+      const {
+        linePoint: communityLinePoint,
+        areaPoint: communityAreaPoint,
+        point: communityPoint,
+      } = getOptionGraphData({
+        name: option.name,
+        quartiles: option.communityQuartiles,
+        optionScaling: option.question.scaling,
+        scaling,
+        withoutScaling: isBinaryGroup,
+      });
+      communityLine.push(communityLinePoint);
+      communityArea.push(communityAreaPoint);
+      communityPoints.push(communityPoint);
+    }
+    if (option.resolved) {
+      resolutionPoints.push({
+        x: option.name,
+        y: getResolutionPosition({
+          question: option.question,
+          scaling,
+        }),
+        resolved: true,
+      });
+    }
+    if (option.userQuartiles) {
+      const {
+        linePoint: userLinePoint,
+        areaPoint: userAreaPoint,
+        point: userPoint,
+      } = getOptionGraphData({
+        name: option.name,
+        quartiles: option.userQuartiles,
+        optionScaling: option.question.scaling,
+        scaling,
+        withoutScaling: isBinaryGroup,
+      });
+      userLine.push(userLinePoint);
+      if (!isBinaryGroup) {
+        userArea.push(userAreaPoint);
+      }
+      userPoints.push(userPoint);
+    }
+  }
+
+  const { originalYDomain, zoomedYDomain } = generateFanGraphYDomain({
+    communityArea,
+    userArea,
+    resolutionPoints,
+    includeClosestBoundOnZoom: isBinaryGroup,
+  });
+  const yScale = generateScale({
+    displayType: groupType,
+    axisLength: height,
+    direction: "vertical",
+    scaling: scaling,
+    domain: originalYDomain,
+    zoomedDomain: zoomedYDomain,
+  });
+
+  return {
+    communityLine,
+    userLine,
+    communityArea,
+    userArea,
+    communityPoints,
+    userPoints,
+    resolutionPoints,
+    yScale,
+    yDomain: zoomedYDomain,
+  };
+}
+
+function getFanGraphScaling(options: FanOption[]): Scaling {
   const zeroPoints: number[] = [];
-  options.forEach((option) => {
+  const rangeMaxValues: number[] = [];
+  const rangeMinValues: number[] = [];
+  for (const option of options) {
     if (
-      option.question.scaling.zero_point !== null &&
+      !isNil(option.question.scaling.zero_point) &&
       !!option.communityQuartiles
     ) {
       zeroPoints.push(option.question.scaling.zero_point);
     }
-  });
 
-  const rangeMaxValues: number[] = [];
-  const rangeMinValues: number[] = [];
-  for (const option of options) {
     if (!isNil(option.question.scaling.range_max)) {
       rangeMaxValues.push(option.question.scaling.range_max);
     }
@@ -362,84 +446,67 @@ function buildChartData(options: FanOption[]) {
     scaling.zero_point = null;
   }
 
-  const isBinaryGroup = options[0]?.question.type === QuestionType.Binary;
-  for (const option of options) {
-    if (option.communityQuartiles) {
-      const {
-        linePoint: communityLinePoint,
-        areaPoint: communityAreaPoint,
-        point: communityPoint,
-      } = getOptionGraphData(
-        {
-          name: option.name,
-          quartiles: option.communityQuartiles,
-          optionScaling: option.question.scaling,
-          scaling,
-        },
-        isBinaryGroup
-      );
-      communityLine.push(communityLinePoint);
-      communityArea.push(communityAreaPoint);
-      communityPoints.push(communityPoint);
-    }
-    if (option.resolved) {
-      resolutionPoints.push({
-        x: option.name,
-        y: getResolutionPosition({
-          question: option.question,
-          scaling,
-        }),
-        resolved: true,
-      });
-    }
-    if (option.userQuartiles) {
-      const {
-        linePoint: userLinePoint,
-        areaPoint: userAreaPoint,
-        point: userPoint,
-      } = getOptionGraphData(
-        {
-          name: option.name,
-          quartiles: option.userQuartiles,
-          optionScaling: option.question.scaling,
-          scaling,
-        },
-        isBinaryGroup
-      );
-      userLine.push(userLinePoint);
-      if (!isBinaryGroup) {
-        userArea.push(userAreaPoint);
-      }
-      userPoints.push(userPoint);
-    }
-  }
-
-  return {
-    communityLine,
-    userLine,
-    communityArea,
-    userArea,
-    communityPoints,
-    userPoints,
-    resolutionPoints,
-    scaling,
-  };
+  return scaling;
 }
 
-function getOptionGraphData(
-  {
-    name,
-    quartiles,
-    scaling,
-    optionScaling,
-  }: {
-    name: string;
-    quartiles: Quartiles;
-    optionScaling: Scaling;
-    scaling: Scaling;
-  },
-  withoutScaling = true
-) {
+function generateFanGraphYDomain({
+  communityArea,
+  resolutionPoints,
+  userArea,
+  includeClosestBoundOnZoom,
+}: {
+  communityArea: Area<string>;
+  userArea: Area<string>;
+  resolutionPoints: Array<FanGraphPoint>;
+  includeClosestBoundOnZoom?: boolean;
+}): YDomain {
+  const originalYDomain: Tuple<number> = [0, 1];
+  const fallback = { originalYDomain, zoomedYDomain: originalYDomain };
+
+  const combinedAreaData = [...communityArea, ...userArea];
+  const minValues: number[] = [];
+  const maxValues: number[] = [];
+  for (const areaPoint of combinedAreaData) {
+    if (!isNil(areaPoint.y0)) {
+      minValues.push(areaPoint.y0);
+    }
+    if (!isNil(areaPoint.y)) {
+      maxValues.push(areaPoint.y);
+    }
+  }
+  for (const resolutionPoint of resolutionPoints) {
+    if (!isNil(resolutionPoint.y)) {
+      minValues.push(resolutionPoint.y);
+      maxValues.push(resolutionPoint.y);
+    }
+  }
+  const minValue = minValues.length ? Math.min(...minValues) : null;
+  const maxValue = maxValues.length ? Math.max(...maxValues) : null;
+
+  if (isNil(minValue) || isNil(maxValue)) {
+    return fallback;
+  }
+
+  return generateYDomain({
+    minValue,
+    maxValue,
+    includeClosestBoundOnZoom,
+  });
+}
+
+function getOptionGraphData({
+  name,
+  quartiles,
+  scaling,
+  optionScaling,
+  withoutScaling,
+}: {
+  name: string;
+  quartiles: Quartiles;
+  optionScaling: Scaling;
+  scaling: Scaling;
+  withoutScaling: boolean;
+}) {
   if (withoutScaling) {
     return {
       linePoint: {

--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -39,7 +39,7 @@ import {
   generateNumericXDomain,
   generateScale,
   generateTimestampXScale,
-  generateYDomain,
+  generateTimeSeriesYDomain,
   getAxisLeftPadding,
   getTickLabelFontSize,
 } from "@/utils/charts/axis";
@@ -639,7 +639,7 @@ function buildChartData({
   const areas: Area = graphs
     .filter((g) => !isNil(g.area) && g.active)
     .flatMap((g) => g.area);
-  const { originalYDomain, zoomedYDomain } = generateYDomain({
+  const { originalYDomain, zoomedYDomain } = generateTimeSeriesYDomain({
     zoom,
     minTimestamp: xDomain[0],
     isChartEmpty: !domainTimestamps.length,

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -44,7 +44,7 @@ import {
   generateNumericXDomain,
   generateScale,
   generateTimestampXScale,
-  generateYDomain,
+  generateTimeSeriesYDomain,
   getAxisLeftPadding,
   getTickLabelFontSize,
 } from "@/utils/charts/axis";
@@ -550,7 +550,7 @@ function buildChartData({
   //   domain: xDomain,
   // });
 
-  const { originalYDomain, zoomedYDomain } = generateYDomain({
+  const { originalYDomain, zoomedYDomain } = generateTimeSeriesYDomain({
     zoom,
     minTimestamp: xDomain[0],
     isChartEmpty: !domainTimestamps.length,

--- a/front_end/src/types/charts.ts
+++ b/front_end/src/types/charts.ts
@@ -1,3 +1,5 @@
+import { Tuple } from "victory";
+
 import {
   Bounds,
   Quartiles,
@@ -33,7 +35,10 @@ export type LinePoint<X = number, Y = number | null> = {
 export type Line<X = number, Y = number | null> = Array<LinePoint<X, Y>>;
 export type Area<X = number, Y = number | null> = Array<{ x: X; y: Y; y0?: Y }>;
 
-export type NumericChartType = "date" | "numeric" | "binary";
+export type YDomain = {
+  originalYDomain: Tuple<number>;
+  zoomedYDomain: Tuple<number>;
+};
 
 export type FanOption = {
   name: string;

--- a/front_end/src/utils/charts/axis.ts
+++ b/front_end/src/utils/charts/axis.ts
@@ -9,7 +9,7 @@ import {
 import { isNil, range, uniq } from "lodash";
 import { Tuple, VictoryThemeDefinition } from "victory";
 
-import { Scale, TimelineChartZoomOption } from "@/types/charts";
+import { Scale, TimelineChartZoomOption, YDomain } from "@/types/charts";
 import { QuestionType, Scaling } from "@/types/question";
 import { getPredictionDisplayValue } from "@/utils/formatters/prediction";
 import { unscaleNominalLocation } from "@/utils/math";
@@ -95,18 +95,15 @@ type GenerateYDomainParams = {
   includeClosestBoundOnZoom?: boolean;
 };
 
-export function generateYDomain({
+export function generateTimeSeriesYDomain({
   zoom,
   isChartEmpty,
   minValues,
   maxValues,
   minTimestamp,
-  zoomDomainPadding = 0.05,
-  includeClosestBoundOnZoom = false,
-}: GenerateYDomainParams): {
-  originalYDomain: Tuple<number>;
-  zoomedYDomain: Tuple<number>;
-} {
+  zoomDomainPadding,
+  includeClosestBoundOnZoom,
+}: GenerateYDomainParams): YDomain {
   const originalYDomain: Tuple<number> = [0, 1];
   const fallback = { originalYDomain, zoomedYDomain: originalYDomain };
 
@@ -128,6 +125,28 @@ export function generateYDomain({
   if (isNil(minValue) || isNil(maxValue)) {
     return fallback;
   }
+
+  return generateYDomain({
+    minValue,
+    maxValue,
+    zoomDomainPadding,
+    includeClosestBoundOnZoom,
+  });
+}
+
+export function generateYDomain({
+  minValue,
+  maxValue,
+  zoomDomainPadding = 0.05,
+  includeClosestBoundOnZoom = false,
+}: {
+  minValue: number;
+  maxValue: number;
+  zoomDomainPadding?: number;
+  includeClosestBoundOnZoom?: boolean;
+}): YDomain {
+  const originalYDomain: Tuple<number> = [0, 1];
+
   let zoomedYDomain: Tuple<number> = [0, 1];
   const distanceToZero = Math.abs(minValue - zoomDomainPadding);
   const distanceToOne = Math.abs(1 - (maxValue + zoomDomainPadding));


### PR DESCRIPTION
Related to #2666

- refactored y-domain generation logic to allow integrating zoom-related logic with any x-scale data
- implemented fan graph helper to handle graph zoom based on existing dataset
- debugged and fixed a bug with horizontal scale generation which caused all ticks to be “minor” (no label) on specific zoom scales