### PR TITLE
Lists behave weirdly when including nested items

### DIFF
--- a/front_end/src/components/markdown_editor/editor.css
+++ b/front_end/src/components/markdown_editor/editor.css
@@ -72,41 +72,22 @@
 }
 
 /* Remove bullet/number from parent li if it contains a nested list */
-.prose li > ul,
-.prose li > ol {
+.mdx-content-editable li > ul,
+.mdx-content-editable li > ol {
   margin-top: 0.25em;
   margin-bottom: 0.25em;
 }
-.prose li > ul,
-.prose li > ol {
+.mdx-content-editable li > ul,
+.mdx-content-editable li > ol {
   /* Remove marker from parent li */
   position: relative;
 }
-.prose li > ul:before,
-.prose li > ol:before {
+.mdx-content-editable li > ul:before,
+.mdx-content-editable li > ol:before {
   content: none !important;
 }
-.prose li:has(> ul), 
-.prose li:has(> ol) {
+.mdx-content-editable li:has(> ul), 
+.mdx-content-editable li:has(> ol) {
   list-style-type: none !important;
   padding-left: 0 !important;
-}
-
-/* Visual adjustment for nested lists in MDXEditor without relying on the 'prose' class */
-[class^="_contentEditable_"] li > ul,
-[class^="_contentEditable_"] li > ol {
-  margin-top: 0.25em;
-  margin-bottom: 0.25em;
-}
-
-[class^="_contentEditable_"] li:has(> ul),
-[class^="_contentEditable_"] li:has(> ol) {
-  list-style-type: none !important;
-  padding-left: 0 !important;
-}
-
-/* Fallback for browsers without :has support */
-[class^="_contentEditable_"] li > ul,
-[class^="_contentEditable_"] li > ol {
-  margin-left: -1.5em;
 }

--- a/front_end/src/components/markdown_editor/initialized_editor.tsx
+++ b/front_end/src/components/markdown_editor/initialized_editor.tsx
@@ -221,6 +221,7 @@ const InitializedMarkdownEditor: FC<
       )}
       contentEditableClassName={cn(
         { "!p-0": mode === "read" },
+        "mdx-content-editable",
         contentEditableClassName
       )}
       markdown={formattedMarkdown}


### PR DESCRIPTION
Fixes #2710

This is Lexical bug. Applied a workaround using css to fix the issue:

<img width="756" alt="image" src="https://github.com/user-attachments/assets/fa174785-7235-4cad-a4c3-c635a13a3b69" />

<img width="754" alt="image" src="https://github.com/user-attachments/assets/8b7e2f73-6af3-4d66-a1ef-c67cd21a4ed9" />

<img width="774" alt="image" src="https://github.com/user-attachments/assets/3f13923f-0fe6-4936-921a-f998ce7eb4e1" />

<img width="763" alt="image" src="https://github.com/user-attachments/assets/df46e1dd-fa4a-47db-94c1-5a473fad78bb" />

