### PR TITLE
Fixed api-proxy Accept-Locale header propagation

### DIFF
--- a/front_end/src/app/api-proxy/[...path]/route.ts
+++ b/front_end/src/app/api-proxy/[...path]/route.ts
@@ -57,24 +57,26 @@ async function handleProxyRequest(request: NextRequest, method: string) {
     "x-pass-auth",
     "x-include-locale",
   ];
-  const requestHeaders: HeadersInit = {
+
+  const requestHeaders: HeadersInit = new Headers({
     ...Object.fromEntries(
       Array.from(request.headers.entries()).filter(
         ([key]) => !blocklistHeaders.includes(key.toLowerCase())
       )
     ),
-    "Accept-Language": locale,
-  };
+  });
 
-  if (emptyContentType && "Content-Type" in requestHeaders) {
-    delete requestHeaders["Content-Type"];
+  requestHeaders.set("Accept-Language", locale);
+
+  if (emptyContentType && requestHeaders.has("Content-Type")) {
+    requestHeaders.delete("Content-Type");
   }
 
   if (authToken) {
-    requestHeaders["Authorization"] = `Token ${authToken}`;
+    requestHeaders.set("Authorization", `Token ${authToken}`);
   }
   if (alphaToken) {
-    requestHeaders["x-alpha-auth-token"] = alphaToken;
+    requestHeaders.set("x-alpha-auth-token", alphaToken);
   }
 
   const response = await fetch(targetUrl, {


### PR DESCRIPTION
Turns out the `api-proxy` header object can contain mixed-case headers, and when there are duplicate headers, they get concatenated into a single string. 

Replaced the header initialization with a `new Headers()` object to normalize and handle them correctly.

related #2779 