### PR TITLE
Iframe may reset markdown editor index when typing

### DIFF
--- a/front_end/src/components/ui/form_field.tsx
+++ b/front_end/src/components/ui/form_field.tsx
@@ -180,7 +180,6 @@ type MarkdownEditorFieldProps<T extends FieldValues = FieldValues> = {
   defaultValue?: PathValue<T, Path<T>>;
   errors?: ErrorResponse;
   className?: string;
-  onChange?: (markdown: string) => void;
 };
 
 export const MarkdownEditorField = <T extends FieldValues = FieldValues>({
@@ -189,14 +188,9 @@ export const MarkdownEditorField = <T extends FieldValues = FieldValues>({
   errors,
   defaultValue,
   className,
-  onChange,
 }: MarkdownEditorFieldProps<T>) => {
   const { field } = useController({ control, name, defaultValue });
   const editorRef = useRef<MDXEditorMethods>(null);
-
-  useEffect(() => {
-    editorRef.current?.setMarkdown(field.value ?? "");
-  }, [field.value]);
 
   return (
     <>
@@ -225,7 +219,6 @@ export const MarkdownEditorField = <T extends FieldValues = FieldValues>({
           markdown={field.value ?? ""}
           onChange={(markdown) => {
             field.onChange(markdown);
-            onChange?.(markdown);
           }}
           onBlur={field.onBlur}
           className="markdown-editor-form w-full"


### PR DESCRIPTION
Fixes #2774

- investigated the issue, found out that it is replicated only in `MarkdownEditorField` component
- removed `useEffect` that caused the bug with editor reset, as we handle draft update on the question form level
- also deprecated unused property inside `MarkdownEditorField`