### PR TITLE
Remove prediction flow when tournament is closed

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/components/navigation_block.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/components/navigation_block.tsx
@@ -18,10 +18,13 @@ const NavigationBlock: FC<Props> = ({ tournament }) => {
   const t = useTranslations();
   const { setCurrentModal } = useModal();
   const { user } = useAuth();
+  const isForecastsFlowEnabled =
+    tournament.forecasts_flow_enabled &&
+    !tournament.timeline.all_questions_closed;
 
   return (
     <div className="mx-4 mt-4 flex flex-row justify-between gap-2 lg:mx-0">
-      {tournament.forecasts_flow_enabled && (
+      {isForecastsFlowEnabled && (
         <Button
           onClick={() => {
             if (isNil(user)) {

--- a/front_end/src/app/(main)/(tournaments)/tournament/components/participation_block.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/components/participation_block.tsx
@@ -37,7 +37,11 @@ const ParticipationBlock: FC<Props> = ({ tournament, posts }) => {
   const { user } = useAuth();
   const t = useTranslations();
   const tournamentSlug = getProjectSlug(tournament);
-  if (isNil(user) || !tournament.forecasts_flow_enabled) {
+  if (
+    isNil(user) ||
+    !tournament.forecasts_flow_enabled ||
+    tournament.timeline.all_questions_closed
+  ) {
     return null;
   }
   const isParticipated = posts.some((post) =>

--- a/front_end/src/app/(prediction-flow)/tournament/[slug]/prediction-flow/page.tsx
+++ b/front_end/src/app/(prediction-flow)/tournament/[slug]/prediction-flow/page.tsx
@@ -30,7 +30,11 @@ export default async function PredictionFlow(props: Props) {
   if (!tournament) {
     return notFound();
   }
-  if (!user || !tournament.forecasts_flow_enabled) {
+  if (
+    !user ||
+    !tournament.forecasts_flow_enabled ||
+    tournament.timeline.all_questions_closed
+  ) {
     return redirect(`/tournament/${params.slug}`);
   }
 


### PR DESCRIPTION
Closes #2777

- restricted rendering of the prediction flow to open tournaments only
- added a safeguard to prevent access to `/prediction-flow` route for closed tournaments