### PR TITLE
Wrong error message when posting key factors without a comment

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -1248,5 +1248,6 @@
   "indexTimeline": "Časová osa indexu",
   "inTheNews": "Ve zprávách",
   "fileSizeExceedsLimit": "Velikost souboru překračuje limit {value}MB",
-  "errorUploadingImage": "Nepodařilo se nahrát obrázek"
+  "errorUploadingImage": "Nepodařilo se nahrát obrázek",
+  "emptyCommentField": "Pole pro komentář nesmí být prázdné"
 }

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1244,5 +1244,6 @@
   "metadata": "Metadata",
   "indexTimeline": "Index Timeline",
   "fileSizeExceedsLimit": "File size exceeds {value}MB limit",
-  "errorUploadingImage": "Failed to upload image"
+  "errorUploadingImage": "Failed to upload image",
+  "emptyCommentField": "Comment field might not be empty"
 }

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -1248,5 +1248,6 @@
   "indexTimeline": "Cronología del índice",
   "inTheNews": "En las Noticias",
   "fileSizeExceedsLimit": "El tamaño del archivo supera el límite de {value}MB",
-  "errorUploadingImage": "Error al subir la imagen"
+  "errorUploadingImage": "Error al subir la imagen",
+  "emptyCommentField": "El campo de comentarios no debe estar vacío"
 }

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -1246,5 +1246,6 @@
   "indexTimeline": "Cronologia do índice",
   "inTheNews": "Nas Notícias",
   "fileSizeExceedsLimit": "O tamanho do arquivo excede o limite de {value}MB",
-  "errorUploadingImage": "Falha ao fazer o upload da imagem"
+  "errorUploadingImage": "Falha ao fazer o upload da imagem",
+  "emptyCommentField": "O campo de comentário não pode estar vazio"
 }

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -1246,5 +1246,6 @@
   "indexTimeline": "指數時間表",
   "inTheNews": "新聞摘要",
   "fileSizeExceedsLimit": "檔案大小超過 {value}MB 限制",
-  "errorUploadingImage": "上傳圖片失敗"
+  "errorUploadingImage": "上傳圖片失敗",
+  "emptyCommentField": "評論欄不能為空"
 }

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -1251,5 +1251,6 @@
   "indexTimeline": "指数时间线",
   "inTheNews": "新闻报道",
   "fileSizeExceedsLimit": "文件大小超出{value}MB限制",
-  "errorUploadingImage": "上传图片失败"
+  "errorUploadingImage": "上传图片失败",
+  "emptyCommentField": "评论字段不应为空"
 }

--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/add_key_factors_modal.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/add_key_factors_modal.tsx
@@ -243,11 +243,16 @@ const AddKeyFactorsModal: FC<Props> = ({
   });
 
   const handleOnClose = () => {
+    setCurrentStep(1);
     clearState();
     onClose(true);
   };
 
   const handleSubmit = async () => {
+    if (isNil(commentId) && !markdown) {
+      setErrorMessage(t("emptyCommentField"));
+      return;
+    }
     const result = await submit(keyFactors, suggestedKeyFactors, markdown);
     if (result?.error) {
       setErrorMessage(result.error);
@@ -328,7 +333,7 @@ const AddKeyFactorsModal: FC<Props> = ({
                 variant="primary"
                 size="sm"
                 onClick={handleSubmit}
-                disabled={isPending}
+                disabled={isPending || (isNil(commentId) && !markdown)}
               >
                 {t("submit")}
               </Button>

--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/hooks.ts
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/hooks.ts
@@ -129,6 +129,7 @@ export const useKeyFactors = ({
       return {
         error:
           errors?.message ??
+          errors?.text ??
           errors?.non_field_errors?.[0] ??
           "" + comment.errors,
       };


### PR DESCRIPTION
Fixes https://metaculus.slack.com/archives/C01Q9AQBVHB/p1747932330001709

- disabled the submit button until the comment contains at least 1 character
- added validation and error message for empty comment markdown on FE
- investigated an issue with the error response object: the message is returned in the text `field`, while we typically expect it in `message` or `non_field_errors`; applied FE fix for now