### PR TITLE
Question form draft is not populated after navigation

### DIFF
--- a/front_end/src/components/ui/form_field.tsx
+++ b/front_end/src/components/ui/form_field.tsx
@@ -191,6 +191,16 @@ export const MarkdownEditorField = <T extends FieldValues = FieldValues>({
 }: MarkdownEditorFieldProps<T>) => {
   const { field } = useController({ control, name, defaultValue });
   const editorRef = useRef<MDXEditorMethods>(null);
+  const isMounted = useRef(false);
+
+  // populate the editor with draft form value when
+  useEffect(() => {
+    const editorValue = editorRef.current?.getMarkdown();
+    if (!editorValue && !isMounted.current && field.value) {
+      editorRef.current?.setMarkdown(field.value);
+      isMounted.current = true;
+    }
+  }, [field.value]);
 
   return (
     <>


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/Metaculus/metaculus/pull/2781, where the draft value was not populated after client-side navigation (while still working properly on initial page load, e.g. after refresh)