### PR TITLE
Adjusted startapp script to wait the upstream

### DIFF
--- a/scripts/prod/startapp.sh
+++ b/scripts/prod/startapp.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# -----------------------------------------------------------------------------
+# Wait for upstream services before starting Nginx
+#
+# Heroku considers a dyno "ready" as soon as any process binds to $PORT,
+# so if Nginx starts first it will receive and proxy traffic before
+# Gunicorn and Next.js are up, leading to 502/504 errors.
+# This script ensures both the Python API (Gunicorn) and Next.js
+# are listening before Nginx binds and begins accepting requests.
+# -----------------------------------------------------------------------------
+
 # If this script gets SIGINT/TERM/EXIT, kill all its children too
 trap 'pkill -P $$; exit' INT TERM EXIT
 
@@ -32,7 +42,34 @@ export UV_THREADPOOL_SIZE=2
   2>&1 | sed 's/^/[Frontend]: /'
 ) &
 
-# 3) Render Nginx config & launch it
+# 3) Wait for Gunicorn and Next.js before starting Nginx
+# wait for Gunicorn socket to appear
+timeout=15
+echo "Waiting for Gunicorn socket…"
+while [ $timeout -gt 0 ] && [ ! -S ./gunicorn.sock ]; do
+  sleep 1
+  timeout=$((timeout - 1))
+done
+if [ ! -S ./gunicorn.sock ]; then
+  echo "Gunicorn socket never appeared; aborting."
+  exit 1
+fi
+
+# wait for Next.js
+timeout=15
+echo "Waiting for Next.js on localhost:3000…"
+while [ $timeout -gt 0 ] && ! nc -z localhost 3000; do
+  sleep 1
+  timeout=$((timeout - 1))
+done
+if ! nc -z localhost 3000; then
+  echo "Next.js never started; aborting."
+  exit 1
+fi
+
+echo "All upstreams are ready—starting Nginx."
+
+# 4) Render Nginx config & launch it
 PORT="${PORT:-8080}" \
 envsubst '${PORT}' \
   < /etc/nginx/http.d/app_nginx.template \
@@ -43,7 +80,7 @@ rm -f /etc/nginx/http.d/default.conf
 
 nginx &
 
-# 4) If *any* child process exits, kill the rest and crash the dyno
+# 5) If *any* child process exits, kill the rest and crash the dyno
 wait -n
 echo "[Supervisor]: one of the services has exited, shutting down"
 exit 1

--- a/scripts/prod/startapp.sh
+++ b/scripts/prod/startapp.sh
@@ -67,7 +67,7 @@ if ! nc -z localhost 3000; then
   exit 1
 fi
 
-echo "All upstreams are ready—starting Nginx."
+echo "All upstreams are ready. Starting Nginx..."
 
 # 4) Render Nginx config & launch it
 PORT="${PORT:-8080}" \


### PR DESCRIPTION
Improves autoscaling warmup: heroku considers a dyno "ready" as soon as any process binds to $PORT,so if Nginx starts first it will receive and proxy traffic before Gunicorn and Next.js are up, leading to 502/504 errors.