### PR TITLE
Nodejs runner tune

### DIFF
--- a/scripts/prod/startapp.sh
+++ b/scripts/prod/startapp.sh
@@ -33,12 +33,12 @@ source venv/bin/activate
 
 # 2) Next.js Frontend
 export NODE_ENV=production
-export NODE_OPTIONS="--max-old-space-size=512"
+export NODE_OPTIONS="--max-old-space-size=1024"
 export UV_THREADPOOL_SIZE=2
 
 (
   cd front_end &&
-  PORT=3000 pm2-runtime npm -- start \
+  npm run start \
   2>&1 | sed 's/^/[Frontend]: /'
 ) &
 

--- a/scripts/prod/startapp.sh
+++ b/scripts/prod/startapp.sh
@@ -38,7 +38,7 @@ export UV_THREADPOOL_SIZE=2
 
 (
   cd front_end &&
-  npm run start \
+  PORT=3000 npm run start \
   2>&1 | sed 's/^/[Frontend]: /'
 ) &
 


### PR DESCRIPTION
I'm observing periodic nextjs server crashes:
```
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]:     },
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]:     body: undefined,
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]:     bodyUsed: true,
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]:     ok: false,
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]:     redirected: false,
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]:     type: 'default',
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]:     url: 'http://localhost:8000/api/users/me/'
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]:   },
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]:   data: [Object]
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]: }
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]: <--- Last few GCs --->
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]: [1125:0x7f5d2215d660]    91654 ms: Scavenge (reduce) 505.1 (509.7) -> 504.2 (509.7) MB, 0.93 / 0.00 ms  (average mu = 0.323, current mu = 0.302) allocation failure; 
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]: [1125:0x7f5d2215d660]    91777 ms: Mark-Compact (reduce) 515.3 (520.2) -> 499.1 (504.8) MB, 31.13 / 0.01 ms  (+ 59.0 ms in 10 steps since start of marking, biggest step 15.9 ms, walltime since start of marking 124 ms) (average mu = 0.365, current mu = 0.4
Jun 2 23:05:09 metaculus-web app[web] info [Frontend]: <--- JS stacktrace --->
Jun 2 23:05:09 metaculus-web app[web] FATAL [Frontend]: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
Jun 2 23:05:09 metaculus-web app[web] trace [Frontend]: ----- Native stack trace -----
```

This PR deprecates pm2 (to save some memory) and bumps max-old-space-size to 1gb