### PR TITLE
Fixed content edition original lang

### DIFF
--- a/front_end/src/app/(main)/questions/create/[content_type]/page.tsx
+++ b/front_end/src/app/(main)/questions/create/[content_type]/page.tsx
@@ -32,9 +32,11 @@ export default async function QuestionCreator(props: Props) {
 
   invariant(content_type, "Question type is required");
   const post_id = numberOrUndefined(searchParams["post_id"]);
+
+  // We want to allow edition of original content only!
   const post = isNil(post_id)
     ? undefined
-    : await ServerPostsApi.getPost(Number(post_id));
+    : await ServerPostsApi.getPostOriginal(Number(post_id));
 
   // Edition mode
   const mode = extractMode(searchParams, post);

--- a/front_end/src/services/api/posts/posts.shared.ts
+++ b/front_end/src/services/api/posts/posts.shared.ts
@@ -63,6 +63,19 @@ class PostsApi extends ApiService {
     );
   }
 
+  /**
+   * Returns post in original content
+   */
+  async getPostOriginal(id: number): Promise<PostWithForecasts> {
+    return await this.get<PostWithForecasts>(
+      `/posts/${id}/${encodeQueryParams({ with_cp: false })}`,
+      undefined,
+      {
+        forceLocale: "original",
+      }
+    );
+  }
+
   async getQuestion(
     id: number,
     with_cp = true

--- a/front_end/src/types/fetch.ts
+++ b/front_end/src/types/fetch.ts
@@ -2,6 +2,7 @@ export type FetchConfig = {
   emptyContentType?: boolean;
   passAuthHeader?: boolean;
   includeLocale?: boolean;
+  forceLocale?: string;
 };
 
 export type Fetcher = {

--- a/front_end/src/utils/core/fetch/fetch.server.ts
+++ b/front_end/src/utils/core/fetch/fetch.server.ts
@@ -17,6 +17,7 @@ const serverAppFetch = async <T>(
     emptyContentType = false,
     passAuthHeader = true,
     includeLocale = true,
+    forceLocale,
   } = config ?? {};
 
   // Prevent token leaks when using cache
@@ -32,7 +33,11 @@ const serverAppFetch = async <T>(
       ? await getServerSession()
       : null;
   const alphaToken = await getAlphaTokenSession();
-  const locale = includeLocale ? await getLocale() : "en";
+  const locale = forceLocale
+    ? forceLocale
+    : includeLocale
+      ? await getLocale()
+      : "en";
 
   const finalUrl = `${PUBLIC_API_BASE_URL}/api${url}`;
   const finalOptions: FetchOptions = {

--- a/posts/services/common.py
+++ b/posts/services/common.py
@@ -127,6 +127,8 @@ def create_post(
     short_title: str = None,
     published_at: datetime = None,
 ) -> Post:
+    # We always want to create post & questions content in the original mode
+    activate(settings.ORIGINAL_LANGUAGE_CODE)
     site_main = get_site_main_project()
 
     categories = list(categories or [])

--- a/posts/services/common.py
+++ b/posts/services/common.py
@@ -2,10 +2,12 @@ import logging
 from collections.abc import Iterable
 from datetime import date, datetime
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.db.utils import IntegrityError
 from django.utils import timezone
+from django.utils.translation import activate
 from rest_framework.exceptions import ValidationError
 
 from comments.models import Comment
@@ -241,6 +243,10 @@ def update_post(
     notebook: dict = None,
     **kwargs,
 ):
+    # We need to edit post & questions content in the original mode
+    # To override _original fields instead of _<language> ones
+    activate(settings.ORIGINAL_LANGUAGE_CODE)
+
     # Content for embedding generation before update
     original_embedding_content = generate_post_content_for_embedding_vectorization(post)
 


### PR DESCRIPTION
Previously, we were overriding fields based on the language currently enabled in the interface (e.g editing content in Spanish interface will update `title_es` field). As a result, our translation generation module was overwriting your changes, since it uses the `_original` content to regenerate and overwrite all `_<lang>` fields.

Now we **always** render post edition in the original mode and save it only to the **original** mode fields