### PR TITLE
New x-axis labels for binary timelines appear on top of feed sidebar

### DIFF
--- a/front_end/src/app/(main)/(home)/components/feedback_float.tsx
+++ b/front_end/src/app/(main)/(home)/components/feedback_float.tsx
@@ -6,7 +6,7 @@ const FeedbackFloat: React.FC = () => (
     href="https://github.com/metaculus/metaculus"
     target="_blank"
     rel="noopener noreferrer"
-    className="fixed bottom-4 right-4 z-50 flex h-8 w-8 items-center justify-center rounded-full border border border-transparent bg-blue-800 p-2 text-base text-blue-800 text-white no-underline shadow-lg transition-colors hover:bg-blue-900 hover:text-blue-900 active:text-blue-700 disabled:text-blue-800 disabled:opacity-30 dark:text-blue-800-dark dark:hover:text-blue-900-dark dark:active:text-blue-700-dark disabled:dark:text-blue-800-dark"
+    className="fixed bottom-4 right-4 z-100 flex h-8 w-8 items-center justify-center rounded-full border border-transparent bg-blue-800 p-2 text-base text-white no-underline shadow-lg transition-colors hover:bg-blue-900 hover:text-blue-900 active:text-blue-700 disabled:text-blue-800 disabled:opacity-30 dark:text-blue-800-dark dark:hover:text-blue-900-dark dark:active:text-blue-700-dark disabled:dark:text-blue-800-dark"
     aria-label="View on GitHub"
   >
     <FontAwesomeIcon icon={faPaperPlane} />

--- a/front_end/src/app/(main)/components/headers/header.tsx
+++ b/front_end/src/app/(main)/components/headers/header.tsx
@@ -32,7 +32,7 @@ const Header: FC = () => {
 
   return (
     <>
-      <header className="fixed left-0 top-0 z-100 flex h-header w-full flex-auto items-stretch justify-between bg-blue-900 text-gray-0">
+      <header className="fixed left-0 top-0 z-[200] flex h-header w-full flex-auto items-stretch justify-between bg-blue-900 text-gray-0">
         <NavbarLogo />
 
         {/* Global Search */}

--- a/front_end/src/components/ui/listbox.tsx
+++ b/front_end/src/components/ui/listbox.tsx
@@ -90,7 +90,7 @@ const Listbox = <T extends string>(props: Props<T>) => {
       </ListboxButton>
       <ListboxOptions
         className={cn(
-          "absolute top-10 z-50 divide-y divide-gray-300 rounded border border-gray-300 bg-gray-0 shadow-lg outline-none dark:divide-gray-300-dark dark:border-gray-300-dark dark:bg-gray-0-dark",
+          "absolute top-10 z-100 divide-y divide-gray-300 rounded border border-gray-300 bg-gray-0 shadow-lg outline-none dark:divide-gray-300-dark dark:border-gray-300-dark dark:bg-gray-0-dark",
           {
             "right-0": menuPosition === "right",
             "left-0": menuPosition === "left",


### PR DESCRIPTION
Fixes #2808

- fixed new binary questions label overlaps
- fixed sidebar filters overlap with header