### PR TITLE
The source markdown editor doesn't follow dark mode

### DIFF
--- a/front_end/src/components/markdown_editor/editor.css
+++ b/front_end/src/components/markdown_editor/editor.css
@@ -28,6 +28,9 @@
   .ͼ16 {
     @apply dark:text-white;
   }
+  .cm-activeLine {
+    @apply dark:!caret-white;
+  }
 }
 
 /* user mentions menu */


### PR DESCRIPTION
Fixes #934