### PR TITLE
Added `include_descriptions` option for feed

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1067,6 +1067,12 @@ paths:
             example: true
           description: "When this flag is enabled, each post with a group of questions will return community predictions for only the top 3 subquestions. To retrieve predictions for all subquestions, please use the post details endpoint."
         - in: query
+          name: include_descriptions
+          schema:
+            type: boolean
+            example: true
+          description: "With this flag enabled, each post question will include the description, fine_print, and resolution_criteria fields in its response."
+        - in: query
           name: not_forecaster_id
           schema:
             type: integer

--- a/posts/serializers.py
+++ b/posts/serializers.py
@@ -331,6 +331,7 @@ def serialize_post(
     aggregate_forecasts: dict[Question, AggregateForecast] = None,
     key_factors: list[dict] = None,
     projects: Iterable[Project] = None,
+    include_descriptions: bool = False,
 ) -> dict:
     current_user = (
         current_user if current_user and not current_user.is_anonymous else None
@@ -352,6 +353,7 @@ def serialize_post(
                 if aggregate_forecasts
                 else None
             ),
+            include_descriptions=include_descriptions,
         )
 
     if post.conditional:
@@ -360,6 +362,7 @@ def serialize_post(
             current_user=current_user,
             post=post,
             aggregate_forecasts=aggregate_forecasts,
+            include_descriptions=include_descriptions,
         )
 
     if post.group_of_questions:
@@ -368,6 +371,7 @@ def serialize_post(
             current_user=current_user,
             post=post,
             aggregate_forecasts=aggregate_forecasts,
+            include_descriptions=include_descriptions,
         )
 
     if post.notebook:
@@ -430,6 +434,7 @@ def serialize_post_many(
     with_subscriptions: bool = False,
     group_cutoff: int = None,
     with_key_factors: bool = False,
+    include_descriptions: bool = False,
 ) -> list[dict]:
     current_user = (
         current_user if current_user and not current_user.is_anonymous else None
@@ -497,6 +502,7 @@ def serialize_post_many(
             },
             key_factors=comment_key_factors_map.get(post.id),
             projects=projects_map.get(post.id),
+            include_descriptions=include_descriptions,
         )
         for post in posts
     ]

--- a/posts/views.py
+++ b/posts/views.py
@@ -50,8 +50,8 @@ from questions.serializers.common import QuestionApproveSerializer
 from utils.csv_utils import export_data_for_questions
 from utils.files import validate_and_upload_image
 from utils.paginator import CountlessLimitOffsetPagination, LimitOffsetPagination
-from utils.views import validate_data_request
 from utils.tasks import email_data_task
+from utils.views import validate_data_request
 
 spam_error = ValidationError(
     detail="This post seems to be spam. Please contact "
@@ -69,6 +69,9 @@ def posts_list_api_view(request):
     # Extra params
     with_cp = serializers.BooleanField(allow_null=True).run_validation(
         request.query_params.get("with_cp")
+    )
+    include_descriptions = serializers.BooleanField(allow_null=True).run_validation(
+        request.query_params.get("include_descriptions")
     )
     group_cutoff = (
         serializers.IntegerField(
@@ -91,6 +94,7 @@ def posts_list_api_view(request):
         current_user=request.user,
         group_cutoff=group_cutoff,
         with_key_factors=True,
+        include_descriptions=include_descriptions,
     )
 
     return paginator.get_paginated_response(data)
@@ -211,6 +215,7 @@ def post_detail(request: Request, pk):
         with_cp=with_cp,
         with_subscriptions=True,
         with_key_factors=True,
+        include_descriptions=True,
     )
 
     if not posts:


### PR DESCRIPTION
Now all posts & questions will be passed without description, fine_print and resolution criteria without `include_descriptions=true` flag. This will save some traffic and minimize json payload.

detailed `posts/<:post_id>` endpoint remains the same