### PR TITLE
Y-axis ticks are missing on some questions when zooming

### DIFF
--- a/front_end/src/components/charts/helpers.ts
+++ b/front_end/src/components/charts/helpers.ts
@@ -46,6 +46,7 @@ export function buildNumericChartData({
   forceYTickCount,
   inboundOutcomeCount,
   alwaysShowYTicks,
+  skipHoursFormatting,
 }: {
   questionType: QuestionType;
   actualCloseTime?: number | null;
@@ -63,6 +64,7 @@ export function buildNumericChartData({
   forceYTickCount?: number;
   inboundOutcomeCount?: number | null;
   alwaysShowYTicks?: boolean;
+  skipHoursFormatting?: boolean;
 }): ChartData {
   const line: Line = [];
   const area: Area = [];
@@ -235,6 +237,7 @@ export function buildNumericChartData({
     forceTickCount: forceYTickCount,
     inboundOutcomeCount,
     alwaysShowTicks: alwaysShowYTicks,
+    skipHoursFormatting,
   });
 
   return {

--- a/front_end/src/components/charts/new_numeric_chart.tsx
+++ b/front_end/src/components/charts/new_numeric_chart.tsx
@@ -329,7 +329,7 @@ const NewNumericChart: FC<Props> = ({
                 grid: {
                   stroke: getThemeColor(METAC_COLORS.gray["300"]),
                   strokeWidth: 1,
-                  strokeDasharray: "2, 5",
+                  strokeDasharray: "3, 5",
                 },
               }}
               tickValues={yScale.ticks}

--- a/front_end/src/utils/formatters/prediction.ts
+++ b/front_end/src/utils/formatters/prediction.ts
@@ -70,10 +70,16 @@ export function getForecastDateDisplayValue(
     actual_resolve_time?: string | null;
     dateFormatString?: string;
     adjustLabels?: boolean;
+    skipHoursFormatting?: boolean;
   }
 ) {
-  const { scaling, actual_resolve_time, dateFormatString, adjustLabels } =
-    params ?? {};
+  const {
+    scaling,
+    actual_resolve_time,
+    dateFormatString,
+    adjustLabels,
+    skipHoursFormatting,
+  } = params ?? {};
 
   if (dateFormatString) {
     return format(fromUnixTime(value), dateFormatString);
@@ -85,6 +91,7 @@ export function getForecastDateDisplayValue(
         actual_resolve_time,
         valueTimestamp: value,
         includeRefTime: adjustLabels,
+        skipHoursFormatting,
       })
     : "d MMM yyyy";
 
@@ -102,6 +109,7 @@ function formatPredictionDisplayValue(
     unit,
     adjustLabels = false,
     discreteValueOptions,
+    skipHoursFormatting = false,
   }: {
     questionType: QuestionType;
     actual_resolve_time: string | null;
@@ -112,6 +120,7 @@ function formatPredictionDisplayValue(
     unit?: string;
     adjustLabels?: boolean;
     discreteValueOptions?: number[];
+    skipHoursFormatting?: boolean;
   }
 ): string {
   precision = precision ?? 3;
@@ -121,6 +130,7 @@ function formatPredictionDisplayValue(
       actual_resolve_time,
       scaling,
       adjustLabels,
+      skipHoursFormatting,
     });
   } else if (
     questionType === QuestionType.Numeric ||
@@ -165,6 +175,7 @@ type PredictionDisplayValueParams = {
   longBounds?: boolean;
   emptyLabel?: string;
   discreteValueOptions?: number[];
+  skipHoursFormatting?: boolean;
 };
 
 function displayValue(
@@ -181,6 +192,7 @@ function displayValue(
     longBounds = false,
     emptyLabel = "...",
     discreteValueOptions,
+    skipHoursFormatting = false,
   }: Omit<PredictionDisplayValueParams, "range">
 ) {
   if (isNil(value)) {
@@ -210,6 +222,7 @@ function displayValue(
       dateFormatString,
       unit,
       adjustLabels,
+      skipHoursFormatting,
     })
   );
 }
@@ -302,11 +315,13 @@ export function getQuestionDateFormatString({
   actual_resolve_time,
   valueTimestamp,
   includeRefTime = false,
+  skipHoursFormatting = false,
 }: {
   scaling: Scaling;
   actual_resolve_time: string | null | undefined;
   valueTimestamp: number;
   includeRefTime?: boolean;
+  skipHoursFormatting?: boolean;
 }) {
   const { range_min, range_max } = scaling;
   let dateFormat = "dd MMM yyyy HH:mm";
@@ -326,7 +341,7 @@ export function getQuestionDateFormatString({
       scaleDiffInSeconds,
       includeRefTime ? scaleDiffInSeconds : refDiffInSeconds
     );
-    if (diffInSeconds < oneWeek) {
+    if (diffInSeconds < oneWeek && !skipHoursFormatting) {
       dateFormat = "dd MMM yyyy HH:mm";
     } else if (diffInSeconds < 5 * oneYear) {
       dateFormat = "dd MMM yyyy";


### PR DESCRIPTION
Fixes #2913

Some questions (e.g. [this one](https://www.metaculus.com/questions/36894/)) are missing ticks when zooming is applied:

<img width="796" alt="image" src="https://github.com/user-attachments/assets/e3f2191c-f028-4769-b4a5-ca47ced1450d" />

* fixed issue with missing yAxis labels and ticks
* adjusted major tick array generation to always include some of the minor ticks
* adjusted formatting of date question yAxis label to exclude hours and minutes from it