### PR TITLE
.

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -648,7 +648,7 @@ components:
 
             At least 1% of the probability mass must be assigned uniformly within 
             bounds, which means that the CDF must be strictly increasing by at 
-            least 0.01/200 = 0.0005 per step. No two adjacent values of the CDF 
+            least 0.01/200 = 0.00005 per step. No two adjacent values of the CDF 
             can differ by more than 0.59, which is the largest number obtainable 
             via the sliders.
           type: array


### PR DESCRIPTION
fix typo in api doc: `0.01/200 = 0.0005` not `0.01/200 = 0.005`
