### PR TITLE
Wrap twitter previews in comments into two columns if enough horizontal space

### DIFF
--- a/front_end/src/components/markdown_editor/editor.css
+++ b/front_end/src/components/markdown_editor/editor.css
@@ -6,6 +6,22 @@
   --baseBgActive: theme("colors.gray.300.DEFAULT");
   --baseBorder: theme("colors.gray.500.DEFAULT");
   --baseBase: theme("colors.gray.100.DEFAULT");
+
+  .react-tweet-theme {
+    --tweet-container-margin: 0 !important;
+  }
+  .tweets-wrapper {
+    @apply grid auto-cols-fr grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-2.5;
+    & > p {
+      @apply m-0;
+    }
+    .react-tweet-theme {
+      @apply !max-w-full;
+    }
+    & > *:last-child:nth-child(2n + 1) {
+      @apply col-span-full;
+    }
+  }
 }
 
 .mdxeditor-popup-container {

--- a/front_end/src/components/markdown_editor/embedded_twitter/helpers.ts
+++ b/front_end/src/components/markdown_editor/embedded_twitter/helpers.ts
@@ -19,6 +19,6 @@ export const transformTwitterLinks = (markdown: string): string => {
   const tweetComponents = Array.from(uniqueTweetIds)
     .map((id) => `<Tweet id="${id}" />`)
     .join("\n");
-
-  return `${markdown}\n\n${tweetComponents}`;
+  const tweetsWrapper = `<div class="tweets-wrapper">${tweetComponents}</div>`;
+  return `${markdown}\n\n${tweetsWrapper}`;
 };


### PR DESCRIPTION
Closes #2921

- wrap twitter previews into two columns if there enough width