### PR TITLE
Bring back descriptions to the question details endpoint

### DIFF
--- a/questions/views.py
+++ b/questions/views.py
@@ -48,6 +48,7 @@ def question_detail_api_view(request, pk: int):
             aggregate_forecasts=question.aggregate_forecasts.all() if with_cp else None,
             current_user=request.user,
             minimize=minimize,
+            include_descriptions=True
         )
     )
 


### PR DESCRIPTION
Bring back descriptions to the `/api/questions/<question_id>` endpoint