### PR TITLE
Post with group of questions does not have browser tab title

### DIFF
--- a/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page.tsx
@@ -4,6 +4,7 @@ import strip from "strip-markdown";
 
 import { defaultDescription } from "@/constants/metadata";
 import ServerPostsApi from "@/services/api/posts/posts.server";
+import { getValidString } from "@/utils/formatters/string";
 
 import IndividualNotebookPage from "./page_compotent";
 
@@ -24,11 +25,11 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title:
-      postData.html_metadata_json?.title ??
-      postData.short_title ??
+      getValidString(postData.html_metadata_json?.title) ??
+      getValidString(postData.short_title) ??
       postData.title,
     description:
-      postData.html_metadata_json?.description ??
+      getValidString(postData.html_metadata_json?.description) ??
       (!!parsedDescription ? parsedDescription : defaultDescription),
   };
 }

--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from "next";
 
+import { defaultDescription } from "@/constants/metadata";
 import { SearchParams } from "@/types/navigation";
+import { getValidString } from "@/utils/formatters/string";
 import { getPostTitle } from "@/utils/questions/helpers";
 
 import IndividualQuestionPage from "./page_component";
@@ -18,14 +20,15 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   if (!postData) {
     return {};
   }
-
   const questionTitle = getPostTitle(postData);
   return {
     title:
-      postData.html_metadata_json?.title ??
-      postData.short_title ??
+      getValidString(postData.html_metadata_json?.title) ??
+      getValidString(postData.short_title) ??
       questionTitle,
-    description: postData.html_metadata_json?.description,
+    description:
+      getValidString(postData.html_metadata_json?.description) ??
+      defaultDescription,
     openGraph: {
       type: "article",
       images: {

--- a/front_end/src/utils/formatters/string.ts
+++ b/front_end/src/utils/formatters/string.ts
@@ -4,3 +4,9 @@ export function truncateLabel(label: string, maxLength: number): string {
   }
   return label.slice(0, maxLength).trim() + "...";
 }
+
+export function getValidString(
+  str: string | null | undefined
+): string | undefined {
+  return str && str.trim() !== "" ? str : undefined;
+}


### PR DESCRIPTION
part of #2944

- implemented `getValidString` helper to eliminate empty strings from tab title