### PR TITLE
Fixed Index Project admin

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
@@ -135,9 +135,13 @@ export default async function TournamentSlug(props: Props) {
         <div>
           <HtmlContent content={tournament.description} />
 
-          {indexWeights.length > 0 && (
-            <IndexSection indexWeights={indexWeights} tournament={tournament} />
-          )}
+          {indexWeights.length > 0 &&
+            tournament.type === TournamentType.Index && (
+              <IndexSection
+                indexWeights={indexWeights}
+                tournament={tournament}
+              />
+            )}
 
           {tournament.score_type && (
             <div className="mt-3 flex flex-col gap-3">

--- a/projects/admin.py
+++ b/projects/admin.py
@@ -342,10 +342,9 @@ class ProjectAdmin(CustomTranslationAdmin):
         ProjectDefaultPermissionFilter,
     ]
     search_fields = ["type", "name_original", "slug"]
-    autocomplete_fields = ["created_by"]
+    autocomplete_fields = ["created_by", "primary_leaderboard"]
     ordering = ["-created_at"]
     inlines = [
-        ProjectIndexQuestionsInline,
         ProjectUserPermissionInline,
         PostDefaultProjectInline,
         PostProjectInline,
@@ -366,6 +365,15 @@ class ProjectAdmin(CustomTranslationAdmin):
         if "delete_selected" in actions:
             del actions["delete_selected"]
         return actions
+
+    def get_inlines(self, request, obj=None):
+        inlines = list(self.inlines)
+
+        # Only show ProjectIndexQuestionsInline if project type is Index
+        if obj and obj.type == Project.ProjectTypes.INDEX:
+            inlines.insert(0, ProjectIndexQuestionsInline)
+
+        return inlines
 
     def save_model(self, request, obj: Project, form, change):
         # Force visibility states for such project types


### PR DESCRIPTION
- The index section configuration no longer appears during project editing unless the selected project_type is index.
- To access the index section, create a project with the index type.
- The frontend now correctly hides the index module for projects where project_type != index.
- The frontend also redirects projects to `/index/` or `/tournament/` if the original project URL doesn't match the project's type