### PR TITLE
Fixed translations original field override

### DIFF
--- a/utils/models.py
+++ b/utils/models.py
@@ -162,7 +162,10 @@ class TranslatedModel(models.Model):
 
         all_update_fields_localised = []
         for field_name in all_update_fields:
-            val = getattr(self, field_name)
+            # Using getattr(self, field_name) will return you the content not from field_name,
+            # but from the field_name of the current language selected.
+            # The proper way of getting "original" field value is through the __dict__
+            val = self.__dict__[field_name]
             if val is not None:
                 default_field_name = build_supported_localized_fieldname(
                     field_name, default_language


### PR DESCRIPTION
We initially encountered an issue where your original content was unintentionally overridden by the translated version — something that should never happen.

Here’s how it happened:
- You created a post with the title "Title". All content was created and updated in "untranslated" mode.
- The system then automatically translated the content and set `original_language` to `"en"`.
- You later updated the title to "Title Updated". At this point, `title_original` changed to "Title Updated", while `title_en` still remained "Title".
- During automatic translation, the backend mistakenly copied `title_en` into the `title_original` field, which caused the translated content to overwrite the original one.

After investigating, I found the root cause was in the original code’s use of `getattr(self, field_name)` to access the `title` field — which was assumed to contain the original content. However, `getattr` doesn’t fetch the raw database field. Instead, it returns the value in the language of the current client session. Since our admin panel was in English, it was actually fetching `field_name_en`.

To fix this, I replaced the `getattr` call with `model.__dict__`, which directly accesses the underlying, language-neutral field value.
