### PR TITLE
make sure histogram is calculated

### DIFF
--- a/questions/views.py
+++ b/questions/views.py
@@ -45,10 +45,12 @@ def question_detail_api_view(request, pk: int):
         serialize_question(
             question,
             post=question.get_post(),
-            aggregate_forecasts=question.aggregate_forecasts.all() if with_cp else None,
+            aggregate_forecasts=(
+                question.aggregate_forecasts.order_by("start_time") if with_cp else None
+            ),
             current_user=request.user,
             minimize=minimize,
-            include_descriptions=True
+            include_descriptions=True,
         )
     )
 

--- a/utils/the_math/aggregations.py
+++ b/utils/the_math/aggregations.py
@@ -550,6 +550,13 @@ def get_aggregation_history(
                 )
                 continue
 
+        last_historical_entry_index = -1
+        now = datetime.now(timezone.utc)
+        for entry in forecast_history:
+            if entry.timestep < now:
+                last_historical_entry_index += 1
+            else:
+                break
         for i, forecast_set in enumerate(forecast_history):
             weights = get_weights(forecast_set)
             include_histogram = (
@@ -558,7 +565,7 @@ def get_aggregation_history(
                 and histogram
                 if histogram is not None
                 else question.type == Question.QuestionType.BINARY
-                and i == (len(forecast_history) - 1)
+                and i >= last_historical_entry_index
             )
 
             if forecast_set.forecasts_values:


### PR DESCRIPTION
closes #2975

Histograms were only calculated for the latest entry, but now the latest entry can be in the future.
This makes sure that the histogram data is available for the current and all future aggregations.