### PR TITLE
Optimize bundle size of profile page

### DIFF
--- a/front_end/src/app/(main)/accounts/profile/[id]/page.tsx
+++ b/front_end/src/app/(main)/accounts/profile/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
@@ -6,13 +7,7 @@ import { FC, PropsWithChildren, Suspense } from "react";
 import { remark } from "remark";
 import strip from "strip-markdown";
 
-import MedalsPage from "@/app/(main)/(leaderboards)/medals/components/medals_page";
-import { MedalsWidget } from "@/app/(main)/(leaderboards)/medals/components/medals_widget";
 import UserInfo from "@/app/(main)/accounts/profile/components/user_info";
-import CommentsFeedProvider from "@/app/(main)/components/comments_feed_provider";
-import CalibrationChart from "@/app/(main)/questions/track-record/components/charts/calibration_chart";
-import CommentFeed from "@/components/comment_feed";
-import AwaitedPostsFeed from "@/components/posts_feed";
 import Button from "@/components/ui/button";
 import LoadingIndicator from "@/components/ui/loading_indicator";
 import { defaultDescription } from "@/constants/metadata";
@@ -23,8 +18,27 @@ import { ProfilePageMode, UserProfile } from "@/types/users";
 import cn from "@/utils/core/cn";
 import { formatUsername } from "@/utils/formatters/users";
 
-import SoftDeleteButton from "../components/soft_delete_button";
-import TrackRecord from "../components/track_record";
+const CalibrationChart = dynamic(
+  () =>
+    import(
+      "@/app/(main)/questions/track-record/components/charts/calibration_chart"
+    )
+);
+const MedalsWidget = dynamic(
+  () => import("@/app/(main)/(leaderboards)/medals/components/medals_widget")
+);
+const MedalsPage = dynamic(
+  () => import("@/app/(main)/(leaderboards)/medals/components/medals_page")
+);
+const AwaitedPostsFeed = dynamic(() => import("@/components/posts_feed"));
+const TrackRecord = dynamic(() => import("../components/track_record"));
+const SoftDeleteButton = dynamic(
+  () => import("../components/soft_delete_button")
+);
+const CommentsFeedProvider = dynamic(
+  () => import("@/app/(main)/components/comments_feed_provider")
+);
+const CommentFeed = dynamic(() => import("@/components/comment_feed"));
 
 type Props = {
   params: Promise<{ id: number }>;


### PR DESCRIPTION
While analyzing "heap out of memory" error logs, I noticed that most of the requests before the app crash were to the profile page. This PR should streamline profile page loads by reducing bundle size. This change should also help to improve Web Vitals metrics on the mentioned page. 