### PR TITLE
Reaffirm button is not working correctly, several unexpected behaviours

### DIFF
--- a/front_end/src/utils/forecasts/helpers.ts
+++ b/front_end/src/utils/forecasts/helpers.ts
@@ -141,9 +141,11 @@ export function isOpenQuestionPredicted(
     (treatClosedAsPredicted
       ? question.status !== QuestionStatus.OPEN
       : false) ||
-    (!isNil(question.my_forecasts?.latest) &&
+    (question.status === QuestionStatus.OPEN &&
+      !isNil(question.my_forecasts?.latest) &&
       isForecastActive(question.my_forecasts.latest)) ||
-    (!isNil(question.my_forecast?.latest) &&
+    (question.status === QuestionStatus.OPEN &&
+      !isNil(question.my_forecast?.latest) &&
       isForecastActive(question.my_forecast.latest))
   );
 }


### PR DESCRIPTION
Related to #2956

- adjusted calculation logic for predicted questions array for group forecast maker, as it could involve resolved questions and lead to BE error

Note: other issues, mentioned in the ticket seem to be resolved by the latest hot-fixes. Left a comment on the issue to confirm this with the user