### PR TITLE
Remove "Learn More" link from the indicator for community questions

### DIFF
--- a/front_end/src/components/post_card/community_disclaimer.tsx
+++ b/front_end/src/components/post_card/community_disclaimer.tsx
@@ -31,11 +31,13 @@ const getDisclaimerCopy = (
           {project.name}
         </Button>
       ),
-      learnMore: (child) => (
-        <Button href="/faq/" variant="link" className="text-xs">
-          {child}
-        </Button>
-      ),
+      learnMore: () => "",
+      // TODO: uncomment when we have a FAQ section for that
+      // learnMore: (child) => (
+      //   <Button href="/faq/" variant="link" className="text-xs">
+      //     {child}
+      //   </Button>
+      // ),
     });
   }
   if (project.type === TournamentType.SiteMain) {


### PR DESCRIPTION
Closes #2849

- commented out “Learn more” link until we have a dedicated section on the FAQ page