### PR TITLE
Add support to sort by "withdrawing soon" in my predictions feed

### DIFF
--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1,4 +1,5 @@
 {
+  "withdrawingSoon": "Withdrawing soon",
   "createArticle": "+ Create Article",
   "newsletterFormHeading": "Join Our Newsletter",
   "newsletterFormDescription": "Sign up for Metaculus news, special forecasting reports, and event invitations.",

--- a/front_end/src/app/(main)/questions/components/feed_filters/my_predictions.tsx
+++ b/front_end/src/app/(main)/questions/components/feed_filters/my_predictions.tsx
@@ -53,10 +53,6 @@ const MyPredictionsFilters: FC<Props> = ({ panelClassname }) => {
         label: t("divergence"),
       },
       {
-        value: QuestionOrder.LastPredictionTimeAsc,
-        label: t("stale"),
-      },
-      {
         value: QuestionOrder.UnreadCommentCountDesc,
         label: t("newComments"),
       },
@@ -69,6 +65,10 @@ const MyPredictionsFilters: FC<Props> = ({ panelClassname }) => {
       {
         value: QuestionOrder.LastPredictionTimeDesc,
         label: t("recentPredictions"),
+      },
+      {
+        value: QuestionOrder.UserNextWithdrawTimeAsc,
+        label: t("withdrawingSoon"),
       },
       { value: QuestionOrder.CloseTimeAsc, label: t("closingSoon") },
       { value: QuestionOrder.ScoreDesc, label: t("bestScores") },
@@ -130,6 +130,7 @@ const MyPredictionsFilters: FC<Props> = ({ panelClassname }) => {
         QuestionOrder.UnreadCommentCountDesc,
         QuestionOrder.CloseTimeAsc,
         QuestionOrder.LastPredictionTimeAsc,
+        QuestionOrder.UserNextWithdrawTimeAsc,
       ].includes(order)
     ) {
       setFilterParam(POST_STATUS_FILTER, "open", false);

--- a/front_end/src/types/question.ts
+++ b/front_end/src/types/question.ts
@@ -27,6 +27,7 @@ export enum QuestionOrder {
   OpenTimeDesc = "-open_time",
   LastPredictionTimeAsc = "user_last_forecasts_date",
   LastPredictionTimeDesc = "-user_last_forecasts_date",
+  UserNextWithdrawTimeAsc = "user_next_withdraw_time",
   DivergenceDesc = "-divergence",
   VotesDesc = "-vote_score",
   CommentCountDesc = "-comment_count",

--- a/posts/models.py
+++ b/posts/models.py
@@ -174,6 +174,24 @@ class PostQuerySet(models.QuerySet):
             )
         )
 
+    def annotate_next_withdraw_time(self, author_id: int):
+        """
+        Annotates with the earliest upcoming forecast end_time for the user on this post
+        """
+        next_withdraw_time_subquery = (
+            Forecast.objects.filter(
+                post_id=OuterRef("pk"),
+                author_id=author_id,
+                end_time__gt=timezone.now(),
+            )
+            .order_by("end_time")
+            .values("end_time")[:1]
+        )
+
+        return self.annotate(
+            user_next_withdraw_time=Subquery(next_withdraw_time_subquery)
+        )
+
     def annotate_user_is_following(self, user: User):
         """
         Annotate with a boolean flag representing whether the user

--- a/posts/serializers.py
+++ b/posts/serializers.py
@@ -171,6 +171,7 @@ class PostFilterSerializer(SerializerKeyLookupMixin, serializers.Serializer):
         SCHEDULED_CLOSE_TIME = "scheduled_close_time"
         SCHEDULED_RESOLVE_TIME = "scheduled_resolve_time"
         USER_LAST_FORECASTS_DATE = "user_last_forecasts_date"
+        USER_NEXT_WITHDRAW_TIME = "user_next_withdraw_time"
         UNREAD_COMMENT_COUNT = "unread_comment_count"
         WEEKLY_MOVEMENT = "weekly_movement"
         DIVERGENCE = "divergence"

--- a/posts/services/feed.py
+++ b/posts/services/feed.py
@@ -186,6 +186,10 @@ def get_posts_feed(
         qs = qs.annotate_user_last_forecasts_date(forecaster_id).filter(
             user_last_forecasts_date__isnull=False
         )
+
+        if order_by == PostFilterSerializer.Order.USER_NEXT_WITHDRAW_TIME:
+            qs = qs.annotate_next_withdraw_time(forecaster_id)
+
         if withdrawn is not None:
             qs = qs.annotate_has_active_forecast(forecaster_id).filter(
                 has_active_forecast=not withdrawn
@@ -245,8 +249,13 @@ def get_posts_feed(
     # Ordering
     order_desc, order_type = parse_order_by(order_by)
 
-    if order_type == PostFilterSerializer.Order.USER_LAST_FORECASTS_DATE and not (
-        forecaster_id
+    if (
+        order_type
+        in [
+            PostFilterSerializer.Order.USER_LAST_FORECASTS_DATE,
+            PostFilterSerializer.Order.USER_NEXT_WITHDRAW_TIME,
+        ]
+        and not forecaster_id
     ):
         order_type = "created_at"
 


### PR DESCRIPTION
In the My Predictions feed, “Stale” is moved to the drop down menu and replaced with “Withdrawing soon”. It filters by open+active-prediction, and sorts by expiration date ascending.