### PR TITLE
cdf validation - 2-step rounding error

### DIFF
--- a/front_end/src/utils/forecasts/dataset.ts
+++ b/front_end/src/utils/forecasts/dataset.ts
@@ -62,7 +62,7 @@ export function getSliderNumericForecastDataset(
           : (F: number, x: number) => 0.99 * F + 0.01 * x;
   cdf = cdf.map(
     (F, index) =>
-      Math.round(cdfOffset(F, index / (cdf.length - 1)) * 1e11) / 1e11
+      Math.round(cdfOffset(F, index / (cdf.length - 1)) * 1e10) / 1e10
   );
 
   return {

--- a/front_end/src/utils/forecasts/dataset.ts
+++ b/front_end/src/utils/forecasts/dataset.ts
@@ -62,7 +62,7 @@ export function getSliderNumericForecastDataset(
           : (F: number, x: number) => 0.99 * F + 0.01 * x;
   cdf = cdf.map(
     (F, index) =>
-      Math.round(cdfOffset(F, index / (cdf.length - 1)) * 1e10) / 1e10
+      Math.round(cdfOffset(F, index / (cdf.length - 1)) * 1e11) / 1e11
   );
 
   return {

--- a/questions/serializers/common.py
+++ b/questions/serializers/common.py
@@ -448,7 +448,7 @@ class ForecastWriteSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 "continuous_cdf is required for continuous questions"
             )
-        continuous_cdf = np.round(continuous_cdf, 10).tolist()
+        continuous_cdf = np.round(continuous_cdf, 11).tolist()
         errors = ""
         inbound_pmf = np.round(
             [

--- a/questions/serializers/common.py
+++ b/questions/serializers/common.py
@@ -448,14 +448,14 @@ class ForecastWriteSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 "continuous_cdf is required for continuous questions"
             )
-        continuous_cdf = np.round(continuous_cdf, 11).tolist()
+        continuous_cdf = np.round(continuous_cdf, 10).tolist()
         errors = ""
         inbound_pmf = np.round(
             [
                 continuous_cdf[i + 1] - continuous_cdf[i]
                 for i in range(len(continuous_cdf) - 1)
             ],
-            10,
+            9,
         )
         inbound_outcome_count = (
             question.inbound_outcome_count
@@ -469,7 +469,7 @@ class ForecastWriteSerializer(serializers.ModelSerializer):
             )
         min_diff = np.round(
             0.01 / inbound_outcome_count,
-            10,
+            9,
         )  # 0.00005 by default
         if not all(inbound_pmf >= min_diff):
             errors += (


### PR DESCRIPTION
closes #3055 
which found a scenario where prediction using the sliders could create an invalid CDF due to a rounding issue.
1. the CDF would be first rounded to 10 decimals
2. then the PMF is calculated as the difference between consecutive CDF values
3.  the PMF is rounded also to 10 decimals

reducing PMF precision to 9 solves the error without lifting the mathematical restriction by much.
