### PR TITLE
No button to copy forecast in group questions

### DIFF
--- a/front_end/src/components/forecast_maker/continuous_group_accordion/group_forecast_accordion.tsx
+++ b/front_end/src/components/forecast_maker/continuous_group_accordion/group_forecast_accordion.tsx
@@ -172,8 +172,7 @@ const GroupForecastAccordion: FC<Props> = ({
             <ContinuousInputWrapper
               option={option}
               copyMenu={
-                openOptions.length > 1 &&
-                option.question.status === QuestionStatus.OPEN ? (
+                openOptions.length > 0 ? (
                   <ForecastMakerGroupCopyMenu
                     option={option}
                     options={openOptions}
@@ -215,6 +214,16 @@ const GroupForecastAccordion: FC<Props> = ({
           >
             <ContinuousInputWrapper
               option={option}
+              copyMenu={
+                openOptions.length > 0 ? (
+                  <ForecastMakerGroupCopyMenu
+                    option={option}
+                    options={openOptions}
+                    handleCopy={handleCopy}
+                    setForcedOpenId={setForcedOpenId}
+                  />
+                ) : undefined
+              }
               canPredict={false}
               isPending={isPending}
               handleChange={handleChange}
@@ -247,6 +256,16 @@ const GroupForecastAccordion: FC<Props> = ({
           >
             <ContinuousInputWrapper
               option={option}
+              copyMenu={
+                openOptions.length > 0 ? (
+                  <ForecastMakerGroupCopyMenu
+                    option={option}
+                    options={openOptions}
+                    handleCopy={handleCopy}
+                    setForcedOpenId={setForcedOpenId}
+                  />
+                ) : undefined
+              }
               canPredict={false}
               isPending={isPending}
               handleChange={handleChange}


### PR DESCRIPTION
Fixes #3053

- enabled render of copy menu if there is at least one open question in a group