### PR TITLE
Ampersand is rendered as & in markdown block

### DIFF
--- a/front_end/src/components/markdown_editor/helpers.ts
+++ b/front_end/src/components/markdown_editor/helpers.ts
@@ -252,7 +252,8 @@ function sanitizeHtml(markdown: string) {
   // decode gt and lt to < and >, so MDXEditor can render it properly
   markdown = markdown.replace(/&lt;/g, "<");
   markdown = markdown.replace(/&gt;/g, ">");
-
+  // also decode &amp; to &
+  markdown = markdown.replace(/\\&amp;/g, "&");
   return markdown;
 }
 


### PR DESCRIPTION
Fixes https://metaculus.slack.com/archives/C01Q9AQBVHB/p1751496014782229

- added decoding of ampersand so the editor can correctly render it

