### PR TITLE
pin last timestep for minimize_history to no later than now

### DIFF
--- a/utils/the_math/aggregations.py
+++ b/utils/the_math/aggregations.py
@@ -361,11 +361,12 @@ def minimize_history(
     # start with smallest interval, populating it with timestamps up to it's size. If
     # interval isn't saturated, distribute the remaining allotment to smaller intervals.
 
+    now_or_last = min(h[-1], django_timezone.now().timestamp())
     # Day interval
     day_history = []
     day_interval = []
     if day_size > 0:
-        first_index = bisect_left(h, h[-1] - day)
+        first_index = bisect_left(h, now_or_last - day)
         day_interval = h[first_index:]
         day_history = summarize_array(day_interval, day_size)
         remainder = day_size - len(day_history)
@@ -377,8 +378,8 @@ def minimize_history(
     week_history = []
     week_interval = []
     if week_size > 0:
-        first_index = bisect_left(h, h[-1] - day * 7)
-        last_index = bisect_right(h, h[-1] - day)
+        first_index = bisect_left(h, now_or_last - day * 7)
+        last_index = bisect_right(h, now_or_last - day)
         week_interval = h[first_index:last_index]
         week_history = summarize_array(week_interval, week_size)
         remainder = week_size - len(week_history)
@@ -389,8 +390,8 @@ def minimize_history(
     month_history = []
     month_interval = []
     if month_size > 0:
-        first_index = bisect_left(h, h[-1] - day * 60)
-        last_index = bisect_right(h, h[-1] - day * 7)
+        first_index = bisect_left(h, now_or_last - day * 60)
+        last_index = bisect_right(h, now_or_last - day * 7)
         month_interval = h[first_index:last_index]
         month_history = summarize_array(month_interval, month_size)
         remainder = month_size - len(month_history)
@@ -400,7 +401,7 @@ def minimize_history(
     all_history = []
     all_interval = []
     if all_size > 0:
-        last_index = bisect_right(h, h[-1] - day * 60)
+        last_index = bisect_right(h, now_or_last - day * 60)
         all_interval = h[:last_index]
         all_history = summarize_array(all_interval, all_size)
         remainder = all_size - len(all_history)


### PR DESCRIPTION
Hot fix for bug introduced by CP withdrawal where the minimize_history algorithm uses the last forecast timestamp as if it is now. This pins that value to no later than now, meaning that we get no more than 100 forecasts for the interval [1 day ago, forever]
instead of [1 day before last timestamp which might be in the distant future, forever]

related slack thread: https://metaculus.slack.com/archives/C04TNF7NJKV/p1751583660802969

before:
![image](https://github.com/user-attachments/assets/3afe31ad-cf0e-405e-8b4f-7a5726d5a1ae)

after:
![image](https://github.com/user-attachments/assets/780623d7-9c7b-4154-822d-8a3dec712035)
