### PR TITLE
Fixed predicted question resolution email

### DIFF
--- a/notifications/templates/emails/predicted_question_resolved.html
+++ b/notifications/templates/emails/predicted_question_resolved.html
@@ -167,7 +167,7 @@
                             {{ notification.question.title }}
                           </a> {% if IS_SCREENSHOT_SERVICE_ENABLED %} <a href="{% post_url notification.post.post_id notification.post.post_title %}" style="color: rgba(47, 65, 85, 1); font-weight: bold; text-decoration: underline;">
                             <img class="question_graph_img" src="{% build_question_graph_image_url notification.post.post_id %}" style="border: none; display: block; outline: none; width: 100%; height: auto;" height="auto">
-                          </a> {% endif %} {% blocktrans with resolution=notification.resolution coverage=notification.format_coverage peer_score=notification.format_peer_score baseline_score=notification.format_baseline_score %} Just resolved to <b>{{resolution}}</b>. You made {{notification.forecasts_count}} predictions, covering {{coverage}}% of the question lifetime. You received a Peer score of {{peer_score}} and a baseline score of {{baseline_score}}. {% endblocktrans %}</div>
+                          </a> {% endif %} {% blocktrans with resolution=notification.resolution coverage=notification.format_coverage peer_score=notification.format_peer_score baseline_score=notification.format_baseline_score forecasts_count=notification.forecasts_count %} Just resolved to <b>{{resolution}}</b>. You made {{forecasts_count}} predictions, covering {{coverage}}% of the question lifetime. You received a Peer score of {{peer_score}} and a baseline score of {{baseline_score}}. {% endblocktrans %}</div>
                       </td>
                     </tr> {% endfor %}
                   </tbody>

--- a/notifications/templates/emails/predicted_question_resolved.mjml
+++ b/notifications/templates/emails/predicted_question_resolved.mjml
@@ -33,9 +33,9 @@
                     </a>
                     {% endif %}
 
-                    {% blocktrans with resolution=notification.resolution coverage=notification.format_coverage peer_score=notification.format_peer_score baseline_score=notification.format_baseline_score %}
+                    {% blocktrans with resolution=notification.resolution coverage=notification.format_coverage peer_score=notification.format_peer_score baseline_score=notification.format_baseline_score forecasts_count=notification.forecasts_count %}
                     Just resolved to <b>{{resolution}}</b>.
-                    You made {{notification.forecasts_count}} predictions,
+                    You made {{forecasts_count}} predictions,
                     covering {{coverage}}% of the question lifetime.
                     You received a Peer score of {{peer_score}} and a baseline score of {{baseline_score}}.
                     {% endblocktrans %}

--- a/questions/services.py
+++ b/questions/services.py
@@ -5,7 +5,7 @@ from typing import cast, Iterable
 
 import sentry_sdk
 from django.db import transaction
-from django.db.models import Q, QuerySet, Subquery, OuterRef
+from django.db.models import Q, QuerySet, Subquery, OuterRef, Count
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
@@ -1166,3 +1166,18 @@ def handle_question_open(question: Question):
 
     # Handle question on followed projects subscriptions
     notify_project_subscriptions_question_open(question)
+
+
+def get_forecasts_per_user(question: Question) -> dict[int, int]:
+    """
+    Return a mapping of user_id -> number-of-forecasts for question,
+    restricted to forecasts that were live during the question’s active period
+    """
+    qs = (
+        Forecast.objects.filter(question=question)
+        .filter_within_question_period()
+        .values("author_id")
+        .annotate(ct=Count("id"))
+    )
+
+    return {row["author_id"]: row["ct"] for row in qs}

--- a/tests/unit/test_questions/test_tasks.py
+++ b/tests/unit/test_questions/test_tasks.py
@@ -1,0 +1,66 @@
+from freezegun import freeze_time
+
+from notifications.models import Notification
+from questions.models import Question
+from questions.services import create_question
+from questions.tasks import resolve_question_and_send_notifications
+from scoring.constants import ScoreTypes
+from tests.unit.test_posts.factories import factory_post
+from tests.unit.test_questions.factories import factory_forecast
+from tests.unit.test_scoring.factories import factory_score
+from tests.unit.utils import datetime_aware
+
+
+@freeze_time("2025-01-10")
+def test_resolve_question_and_send_notifications(mocker, user1):
+    mocker.patch("questions.tasks.score_question")
+    mocker.patch("questions.tasks.build_question_forecasts")
+
+    question_binary = create_question(
+        title="Question Title",
+        type=Question.QuestionType.BINARY,
+        open_time=datetime_aware(2025, 1, 1),
+        scheduled_close_time=datetime_aware(2025, 1, 9),
+        actual_close_time=datetime_aware(2025, 1, 9),
+        resolution="yes",
+    )
+    factory_post(question=question_binary)
+
+    factory_forecast(
+        author=user1,
+        question=question_binary,
+        start_time=datetime_aware(2025, 1, 1),
+        end_time=datetime_aware(2025, 1, 5),
+    )
+    factory_forecast(
+        author=user1,
+        question=question_binary,
+        start_time=datetime_aware(2025, 1, 5),
+        end_time=datetime_aware(2025, 1, 8),
+    )
+    factory_forecast(
+        author=user1,
+        question=question_binary,
+        start_time=datetime_aware(2025, 1, 9, 10),
+        end_time=None,
+    )
+
+    factory_score(
+        question=question_binary,
+        user=user1,
+        score_type=ScoreTypes.PEER,
+        score=10,
+        coverage=0.75,
+    )
+
+    resolve_question_and_send_notifications(question_id=question_binary.id)
+
+    notification = Notification.objects.get(
+        recipient=user1, type="predicted_question_resolved"
+    )
+
+    assert notification.params["baseline_score"] == 0
+    assert notification.params["coverage"] == 0.75
+    assert notification.params["peer_score"] == 10.0
+    assert notification.params["forecasts_count"] == 2
+    assert notification.params["resolution"] == "yes"

--- a/tests/unit/test_scoring/factories.py
+++ b/tests/unit/test_scoring/factories.py
@@ -1,0 +1,19 @@
+from django_dynamic_fixture import G
+
+from questions.models import Question
+from scoring.models import Score
+from users.models import User
+from utils.dtypes import setdefaults_not_null
+
+
+def factory_score(*, user: User = None, question: Question = None, **kwargs):
+    f = G(
+        Score,
+        **setdefaults_not_null(
+            kwargs,
+            user=user,
+            question=question,
+        )
+    )
+
+    return f


### PR DESCRIPTION
- Adjusted forecasts_count logic for emails. Now we only include records within question lifetime
- Fixed forecasts_count rendering in the email template
- Added tests

fixes #3108 