### PR TITLE
add cronjob for overall ranks

### DIFF
--- a/misc/management/commands/cron.py
+++ b/misc/management/commands/cron.py
@@ -19,6 +19,7 @@ from posts.services.hotness import compute_feed_hotness
 from questions.jobs import job_check_question_open_event, job_close_question
 
 from questions.tasks import check_and_schedule_forecast_widrawal_due_notifications
+from scoring.utils import update_medal_points_and_ranks
 from scoring.jobs import (
     finalize_leaderboards,
     update_global_comment_and_question_leaderboards,
@@ -175,6 +176,13 @@ class Command(BaseCommand):
             close_old_connections(finalize_leaderboards),
             trigger=CronTrigger.from_crontab("0 3 * * *"),  # Every day at 03:00 UTC
             id="finalize_leaderboards",
+            max_instances=1,
+            replace_existing=True,
+        )
+        scheduler.add_job(
+            close_old_connections(update_medal_points_and_ranks),
+            trigger=CronTrigger.from_crontab("0 4 * * *"),  # Every day at 04:00 UTC
+            id="update_medal_points_and_ranks",
             max_instances=1,
             replace_existing=True,
         )


### PR DESCRIPTION
I've noticed that we don't have anything calling `update_medal_points_and_ranks` periodically.

I think there are multiple threads about this, but here is the latest: https://metaculus.slack.com/archives/C01Q9AQBVHB/p1752886800411459