### PR TITLE
Change hotness time decay from exponential to quadratic

### DIFF
--- a/posts/models.py
+++ b/posts/models.py
@@ -263,7 +263,11 @@ class PostQuerySet(models.QuerySet):
                         F("created_at"),
                         function="POWER",
                         template=(
-                            "POWER(2, ((CAST(NOW() AS date) - CAST(%(expressions)s AS date))::float/7))"
+                            "CASE "
+                            "WHEN ((CAST(NOW() AS date) - CAST(%(expressions)s AS date))::float) <= 3.5 "
+                            "THEN 1 "
+                            "ELSE POWER(((CAST(NOW() AS date) - CAST(%(expressions)s AS date))::float / 3.5), 2) "
+                            "END"
                         ),
                         output_field=FloatField(),
                     )

--- a/posts/services/hotness.py
+++ b/posts/services/hotness.py
@@ -17,7 +17,12 @@ logger = logging.getLogger(__name__)
 
 
 def decay(val: float, dt: datetime.datetime) -> float:
-    return val / 2 ** ((timezone.now() - dt).days / 7)
+    delta = (timezone.now() - dt).days
+
+    if delta <= 3.5:
+        return val
+
+    return val * ((delta / 3.5) ** -2)
 
 
 def compute_question_hotness(question: Question) -> float:

--- a/tests/unit/test_posts/test_services/test_hotness.py
+++ b/tests/unit/test_posts/test_services/test_hotness.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 
 from comments.services.common import create_comment
 from misc.models import PostArticle
-from posts.models import PostActivityBoost, Vote
+from posts.models import PostActivityBoost, Vote, Post
 from posts.services.common import vote_post
 from posts.services.hotness import (
     decay,
@@ -26,14 +26,16 @@ from tests.unit.test_questions.factories import (
     create_question,
     factory_group_of_questions,
 )
+from tests.unit.utils import datetime_aware, mock_psql_now
 
 
 @pytest.mark.parametrize(
     "dt,expected",
     [
         [make_aware(datetime.datetime(2025, 4, 18)), 10],
-        [make_aware(datetime.datetime(2025, 4, 11)), 5],
-        [make_aware(datetime.datetime(2025, 4, 4)), 2.5],
+        [make_aware(datetime.datetime(2025, 4, 14, 12)), 10],
+        [make_aware(datetime.datetime(2025, 4, 11)), 2.5],
+        [make_aware(datetime.datetime(2025, 4, 4)), 0.625],
     ],
 )
 @freeze_time("2025-04-18")
@@ -63,7 +65,7 @@ def test_decay(dt: datetime.datetime, expected: float):
                 "scheduled_close_time": make_aware(datetime.datetime(2025, 4, 25)),
                 "movement": 0.4,
             },
-            18,
+            13.0,
         ],
         # Resolved question
         [
@@ -75,7 +77,7 @@ def test_decay(dt: datetime.datetime, expected: float):
                 # Should be ignored
                 "movement": 0.4,
             },
-            15,
+            6.25,
         ],
     ],
 )
@@ -96,7 +98,7 @@ def test_compute_hotness_approval_score(post_binary_public):
     assert _compute_hotness_approval_score(post_binary_public) == 20
 
     post_binary_public.published_at = make_aware(datetime.datetime(2025, 4, 11))
-    assert _compute_hotness_approval_score(post_binary_public) == 10
+    assert _compute_hotness_approval_score(post_binary_public) == 5.0
 
 
 @freeze_time("2025-04-18")
@@ -110,7 +112,7 @@ def test_compute_hotness_post_votes(post_binary_public, user1, user2):
     with freeze_time("2025-04-4"):
         vote_post(post_binary_public, user2, -1)
 
-    assert _compute_hotness_post_votes(post_binary_public) == 0.75
+    assert _compute_hotness_post_votes(post_binary_public) == 0.9375
 
 
 @freeze_time("2025-04-18")
@@ -128,7 +130,7 @@ def test_compute_hotness_comments(post_binary_public, user1):
     with freeze_time("2025-04-4"):
         create_comment(user=user1, on_post=post_binary_public, text="yeah")
 
-    assert _compute_hotness_comments(post_binary_public) == 2.5
+    assert _compute_hotness_comments(post_binary_public) == 2.125
 
 
 @freeze_time("2025-04-18")
@@ -138,11 +140,11 @@ def test_compute_hotness_total_boosts(post_binary_public, user1):
     with freeze_time("2025-04-04"):
         PostActivityBoost.objects.create(user=user1, post=post_binary_public, score=-20)
 
-    assert compute_hotness_total_boosts(post_binary_public) == -5
+    assert compute_hotness_total_boosts(post_binary_public) == -1.25
 
     PostActivityBoost.objects.create(user=user1, post=post_binary_public, score=20)
 
-    assert compute_hotness_total_boosts(post_binary_public) == 15
+    assert compute_hotness_total_boosts(post_binary_public) == 18.75
 
 
 @freeze_time("2025-04-18")
@@ -159,7 +161,7 @@ def test_compute_hotness_relevant_news(post_binary_public):
             post=post_binary_public, article=factory_itn_article(), distance=0.1
         )
 
-    assert _compute_hotness_relevant_news(post_binary_public) == 5
+    assert _compute_hotness_relevant_news(post_binary_public) == 2.5
 
 
 @freeze_time("2025-04-18")
@@ -202,7 +204,7 @@ def test_compute_post_hotness(user1):
     # Add ITN article
     PostArticle.objects.create(post=post, article=factory_itn_article(), distance=0.1)
 
-    assert compute_post_hotness(post) == 131
+    assert compute_post_hotness(post) == 118.5
 
 
 @freeze_time("2025-04-18")
@@ -224,3 +226,35 @@ def test_handle_post_boost(user1):
     # Bury
     handle_post_boost(user1, post, Vote.VoteDirection.DOWN)
     assert post.hotness == 3
+
+
+@pytest.mark.parametrize(
+    "psql_now,expected_hotness",
+    [
+        [datetime_aware(2025, 4, 14, 12), 10],
+        # 7 days from now
+        [datetime_aware(2025, 4, 18), 2.5],
+        # 14 days from now
+        [datetime_aware(2025, 4, 25), 0.625],
+    ],
+)
+def test_post_annotate_news_hotness(post_binary_public, psql_now, expected_hotness):
+    with freeze_time("2025-04-11"):
+        PostArticle.objects.create(
+            post=post_binary_public,
+            article=factory_itn_article(),
+            distance=0.4,
+        )
+        PostArticle.objects.create(
+            post=post_binary_public, article=factory_itn_article(), distance=0.1
+        )
+
+    with mock_psql_now(psql_now):
+        hotness = (
+            Post.objects.filter(pk=post_binary_public.pk)
+            .annotate_news_hotness()
+            .get()
+            .news_hotness
+        )
+
+        assert hotness == expected_hotness

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,5 +1,9 @@
-from datetime import datetime
+import re
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from unittest import mock
 
+from django.db.backends.utils import CursorWrapper
 from django.utils.timezone import make_aware
 
 
@@ -9,3 +13,32 @@ def datetime_aware(*args, **kwargs):
     """
 
     return make_aware(datetime(*args, **kwargs))
+
+
+@contextmanager
+def mock_psql_now(fixed_dt: datetime):
+    """
+    Temporarily rewrite every SQL statement so that the literal token NOW()
+    (case‑insensitive, no schema prefix) is replaced with a constant
+    'YYYY‑MM‑DD hh:mm:ss+00'::timestamptz.
+
+    Works for the duration of the context only, inside the current test
+    process and connection pool.
+    """
+    if fixed_dt.tzinfo is None:
+        # always use an explicit timezone, PostgreSQL 'NOW()' returns timestamptz
+        fixed_dt = fixed_dt.replace(tzinfo=timezone.utc)
+
+    literal = fixed_dt.isoformat(sep=" ")  # 2025‑07‑23 12:00:00+00:00
+    literal_sql = f"'{literal}'::timestamptz"
+
+    pattern = re.compile(r"\bNOW\(\)", flags=re.I)  # matches bare NOW()
+
+    real_execute = CursorWrapper.execute
+
+    def _execute(self, sql, params=None):
+        sql = pattern.sub(literal_sql, sql)
+        return real_execute(self, sql, params)
+
+    with mock.patch.object(CursorWrapper, "execute", _execute):
+        yield


### PR DESCRIPTION
- Updated `decay` function logic
- Updated `annotate_news_hotness` logic to implement quadratic decay on psql level
- Added unit tests

closes #3142 