### PR TITLE
Wrong multiple choice resolution diamond color

### DIFF
--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -322,7 +322,7 @@ const MultipleChoiceChart: FC<Props> = ({
                 style={{
                   data: {
                     stroke: getThemeColor(resolutionPoint.color ?? color),
-                    fill: getThemeColor(resolutionPoint.color ?? color),
+                    fill: "none",
                     strokeWidth: 2.5,
                   },
                 }}


### PR DESCRIPTION
Closes #3177

- Updated chart data generation to correctly assign the resolved choice color to the resolution diamond

<img width="1518" height="726" alt="image" src="https://github.com/user-attachments/assets/1230ebda-056a-4cb0-b144-7db6bb6769c2" />
