### PR TITLE
Forecaster views: post mobile dropdown menu

### DIFF
--- a/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page_compotent.tsx
+++ b/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page_compotent.tsx
@@ -114,9 +114,9 @@ const IndividualNotebookPage: FC<{
               })}
             </span>
           </div>
-          <div className="flex flex-col items-center justify-end gap-1 sm:flex-row">
+          <div className="flex items-center justify-end gap-1">
             <PostVoter
-              className="w-full justify-end sm:mr-3 sm:w-auto"
+              className="justify-end sm:mr-3 sm:w-auto"
               post={postData}
               questionPage
             />
@@ -127,12 +127,11 @@ const IndividualNotebookPage: FC<{
                     <div className="mr-2 hidden lg:block">
                       <PostSubscribeButton />
                     </div>
-                    <div className="lg:hidden">
-                      <PostSubscribeButton mini />
-                    </div>
                   </>
                 )}
-                <SharePostMenu questionTitle={questionTitle} />
+                <div className="hidden lg:block">
+                  <SharePostMenu questionTitle={questionTitle} />
+                </div>
                 <PostDropdownMenu post={postData} />
               </PostSubscriptionProvider>
             </div>

--- a/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page_compotent.tsx
+++ b/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page_compotent.tsx
@@ -16,11 +16,12 @@ import {
 } from "@/app/(main)/notebooks/constants/page_sections";
 import { PostStatusBox } from "@/app/(main)/questions/[id]/components/post_status_box";
 import CommentFeed from "@/components/comment_feed";
-import { SharePostMenu, PostDropdownMenu } from "@/components/post_actions";
+import { PostDropdownMenu, SharePostMenu } from "@/components/post_actions";
 import PostVoter from "@/components/post_card/basic_post_card/post_voter";
 import PostSubscribeButton from "@/components/post_subscribe/subscribe_button";
 import CircleDivider from "@/components/ui/circle_divider";
 import { POST_CATEGORIES_FILTER } from "@/constants/posts_feed";
+import { PostSubscriptionProvider } from "@/contexts/post_subscription_context";
 import ServerPostsApi from "@/services/api/posts/posts.server";
 import ServerProjectsApi from "@/services/api/projects/projects.server";
 import { PostStatus } from "@/types/post";
@@ -120,18 +121,20 @@ const IndividualNotebookPage: FC<{
               questionPage
             />
             <div className="flex items-center gap-1">
-              {postData.curation_status == PostStatus.APPROVED && (
-                <>
-                  <div className="mr-2 hidden lg:block">
-                    <PostSubscribeButton post={postData} />
-                  </div>
-                  <div className="lg:hidden">
-                    <PostSubscribeButton post={postData} mini />
-                  </div>
-                </>
-              )}
-              <SharePostMenu questionTitle={questionTitle} />
-              <PostDropdownMenu post={postData} />
+              <PostSubscriptionProvider post={postData}>
+                {postData.curation_status == PostStatus.APPROVED && (
+                  <>
+                    <div className="mr-2 hidden lg:block">
+                      <PostSubscribeButton />
+                    </div>
+                    <div className="lg:hidden">
+                      <PostSubscribeButton mini />
+                    </div>
+                  </>
+                )}
+                <SharePostMenu questionTitle={questionTitle} />
+                <PostDropdownMenu post={postData} />
+              </PostSubscriptionProvider>
             </div>
           </div>
         </div>

--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page_component.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page_component.tsx
@@ -13,6 +13,7 @@ import BackgroundInfo from "@/components/question/background_info";
 import ResolutionCriteria from "@/components/question/resolution_criteria";
 import HideCPProvider from "@/contexts/cp_context";
 import { EmbedModalContextProvider } from "@/contexts/embed_modal_context";
+import { PostSubscriptionProvider } from "@/contexts/post_subscription_context";
 import ServerProjectsApi from "@/services/api/projects/projects.server";
 import { SearchParams } from "@/types/navigation";
 import { GroupOfQuestionsGraphType } from "@/types/post";
@@ -65,95 +66,99 @@ const IndividualQuestionPage: FC<{
     <EmbedModalContextProvider>
       <CommentsFeedProvider postData={postData} rootCommentStructure={true}>
         <HideCPProvider post={postData}>
-          {isCommunityQuestion ? (
-            <CommunityHeader community={currentCommunity} />
-          ) : (
-            <Header />
-          )}
-          <main
-            className={cn(
-              "mx-auto flex w-full max-w-max flex-col scroll-smooth py-4 md:py-10",
-              {
-                "sm:mt-5": isCommunityQuestion,
-              }
+          <PostSubscriptionProvider post={postData}>
+            {isCommunityQuestion ? (
+              <CommunityHeader community={currentCommunity} />
+            ) : (
+              <Header />
             )}
-          >
-            <div className="flex gap-4">
-              <div className="relative w-full">
-                {isCommunityQuestion && (
-                  <div className="absolute z-0 -mt-[41px] hidden w-full sm:block">
-                    <CommunityDisclaimer
-                      project={postData.projects.default_project}
-                      variant="inline"
-                    />
-                  </div>
-                )}
-                <div className="relative z-10 flex w-full flex-col gap-4">
-                  <section className="flex w-[48rem] max-w-full flex-col gap-5 rounded border-transparent bg-gray-0 p-4 text-gray-900 after:mt-6 after:block after:w-full after:content-[''] dark:border-blue-200-dark dark:bg-gray-0-dark dark:text-gray-900-dark lg:gap-6 lg:border lg:p-8">
-                    {isCommunityQuestion && (
+            <main
+              className={cn(
+                "mx-auto flex w-full max-w-max flex-col scroll-smooth py-4 md:py-10",
+                {
+                  "sm:mt-5": isCommunityQuestion,
+                }
+              )}
+            >
+              <div className="flex gap-4">
+                <div className="relative w-full">
+                  {isCommunityQuestion && (
+                    <div className="absolute z-0 -mt-[41px] hidden w-full sm:block">
                       <CommunityDisclaimer
                         project={postData.projects.default_project}
-                        variant="standalone"
-                        className="block sm:hidden"
+                        variant="inline"
                       />
-                    )}
-                    <QuestionHeader post={postData} />
-                    {isQuestionPost(postData) && (
-                      <DetailedQuestionCard post={postData} />
-                    )}
-                    {isGroupOfQuestionsPost(postData) && (
-                      <DetailedGroupCard
-                        post={postData}
-                        preselectedQuestionId={preselectedGroupQuestionId}
-                      />
-                    )}
-                    <ForecastMaker post={postData} />
-                    <div>
-                      <div className="flex flex-col gap-2.5">
-                        <ResolutionCriteria post={postData} />
-                        {isConditionalPost(postData) && (
-                          <ConditionalTimeline post={postData} />
-                        )}
-
-                        <KeyFactorsSection
-                          postId={postData.id}
-                          postStatus={postData.status}
-                        />
-
-                        <BackgroundInfo post={postData} />
-                        {isGroupOfQuestionsPost(postData) &&
-                          postData.group_of_questions.graph_type ===
-                            GroupOfQuestionsGraphType.FanGraph && (
-                            <DetailedGroupCard
-                              post={postData}
-                              preselectedQuestionId={preselectedGroupQuestionId}
-                              groupPresentationOverride={
-                                GroupOfQuestionsGraphType.MultipleChoiceGraph
-                              }
-                              className="mt-2"
-                            />
-                          )}
-                        <HistogramDrawer post={postData} />
-                      </div>
                     </div>
-                  </section>
-                  <Sidebar
-                    postData={postData}
-                    layout="mobile"
-                    questionTitle={questionTitle}
-                  />
-                  <CommentFeed postData={postData} />
-                </div>
-              </div>
-              <Sidebar postData={postData} questionTitle={questionTitle} />
-            </div>
-          </main>
+                  )}
+                  <div className="relative z-10 flex w-full flex-col gap-4">
+                    <section className="flex w-[48rem] max-w-full flex-col gap-5 rounded border-transparent bg-gray-0 p-4 text-gray-900 after:mt-6 after:block after:w-full after:content-[''] dark:border-blue-200-dark dark:bg-gray-0-dark dark:text-gray-900-dark lg:gap-6 lg:border lg:p-8">
+                      {isCommunityQuestion && (
+                        <CommunityDisclaimer
+                          project={postData.projects.default_project}
+                          variant="standalone"
+                          className="block sm:hidden"
+                        />
+                      )}
+                      <QuestionHeader post={postData} />
+                      {isQuestionPost(postData) && (
+                        <DetailedQuestionCard post={postData} />
+                      )}
+                      {isGroupOfQuestionsPost(postData) && (
+                        <DetailedGroupCard
+                          post={postData}
+                          preselectedQuestionId={preselectedGroupQuestionId}
+                        />
+                      )}
+                      <ForecastMaker post={postData} />
+                      <div>
+                        <div className="flex flex-col gap-2.5">
+                          <ResolutionCriteria post={postData} />
+                          {isConditionalPost(postData) && (
+                            <ConditionalTimeline post={postData} />
+                          )}
 
-          <QuestionEmbedModal
-            postId={postData.id}
-            postTitle={postData.title}
-            questionType={postData.question?.type}
-          />
+                          <KeyFactorsSection
+                            postId={postData.id}
+                            postStatus={postData.status}
+                          />
+
+                          <BackgroundInfo post={postData} />
+                          {isGroupOfQuestionsPost(postData) &&
+                            postData.group_of_questions.graph_type ===
+                              GroupOfQuestionsGraphType.FanGraph && (
+                              <DetailedGroupCard
+                                post={postData}
+                                preselectedQuestionId={
+                                  preselectedGroupQuestionId
+                                }
+                                groupPresentationOverride={
+                                  GroupOfQuestionsGraphType.MultipleChoiceGraph
+                                }
+                                className="mt-2"
+                              />
+                            )}
+                          <HistogramDrawer post={postData} />
+                        </div>
+                      </div>
+                    </section>
+                    <Sidebar
+                      postData={postData}
+                      layout="mobile"
+                      questionTitle={questionTitle}
+                    />
+                    <CommentFeed postData={postData} />
+                  </div>
+                </div>
+                <Sidebar postData={postData} questionTitle={questionTitle} />
+              </div>
+            </main>
+
+            <QuestionEmbedModal
+              postId={postData.id}
+              postTitle={postData.title}
+              questionType={postData.question?.type}
+            />
+          </PostSubscriptionProvider>
         </HideCPProvider>
       </CommentsFeedProvider>
     </EmbedModalContextProvider>

--- a/front_end/src/app/(main)/questions/[id]/components/question_header_info.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_header_info.tsx
@@ -25,7 +25,7 @@ const QuestionHeaderInfo: FC<Props> = ({ post, className }) => {
   return (
     <div
       className={cn(
-        "mt-auto flex items-center justify-between gap-3 font-medium",
+        "mt-auto flex items-center justify-between gap-3",
         className
       )}
     >

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/index.tsx
@@ -53,7 +53,7 @@ const Sidebar: FC<Props> = ({
         <div className="mb-5 flex w-full items-center justify-between gap-2">
           <div className="flex gap-1">
             {postData.curation_status == PostStatus.APPROVED && (
-              <PostSubscribeButton post={postData} />
+              <PostSubscribeButton />
             )}
             <QuestionEmbedButton />
           </div>

--- a/front_end/src/components/forecast_maker/forecast_maker_question/prediction_success_box.tsx
+++ b/front_end/src/components/forecast_maker/forecast_maker_question/prediction_success_box.tsx
@@ -6,6 +6,7 @@ import { FC } from "react";
 
 import PostSubscribeButton from "@/components/post_subscribe/subscribe_button";
 import Button from "@/components/ui/button";
+import { PostSubscriptionProvider } from "@/contexts/post_subscription_context";
 import { PostWithForecasts } from "@/types/post";
 import cn from "@/utils/core/cn";
 
@@ -40,7 +41,9 @@ const PredictionSuccessBox: FC<PredictionSuccessBoxProps> = ({
         </span>
       </h4>
       <div className="mx-1 flex flex-wrap items-center justify-center gap-2">
-        <PostSubscribeButton post={post} />
+        <PostSubscriptionProvider post={post}>
+          <PostSubscribeButton />
+        </PostSubscriptionProvider>
 
         <Button variant="secondary" onClick={onCommentClick}>
           <FontAwesomeIcon

--- a/front_end/src/components/post_actions/post_dropdown_menu.tsx
+++ b/front_end/src/components/post_actions/post_dropdown_menu.tsx
@@ -110,6 +110,7 @@ export const PostDropdownMenu: FC<Props> = ({ post, button }) => {
   const menuItems: MenuItemProps[] = [
     // Mobile menu items
     // TODO: check for Notebooks
+    // TODO: notebooks mobile design voter
     ...(!isLargeScreen
       ? [
           {

--- a/front_end/src/components/post_actions/post_dropdown_menu.tsx
+++ b/front_end/src/components/post_actions/post_dropdown_menu.tsx
@@ -230,7 +230,11 @@ export const PostDropdownMenu: FC<Props> = ({ post, button }) => {
         onClose={closeDownloadModal}
         post={post}
       />
-      <DropdownMenu items={menuItems}>
+      <DropdownMenu
+        items={menuItems}
+        className="divide-y divide-gray-300 border-gray-300 dark:divide-gray-300-dark dark:border-gray-300-dark dark:bg-gray-0-dark"
+        itemClassName="px-3 py-2"
+      >
         {button ? (
           button
         ) : (

--- a/front_end/src/components/post_actions/post_dropdown_menu.tsx
+++ b/front_end/src/components/post_actions/post_dropdown_menu.tsx
@@ -14,6 +14,8 @@ import { changePostActivityBoost } from "@/app/(main)/questions/actions";
 import Button from "@/components/ui/button";
 import DropdownMenu, { MenuItemProps } from "@/components/ui/dropdown_menu";
 import { useAuth } from "@/contexts/auth_context";
+import { useBreakpoint } from "@/hooks/tailwind";
+import { useShareMenuItems } from "@/hooks/use_share_menu_items";
 import { BoostDirection } from "@/services/api/posts/posts.shared";
 import {
   Post,
@@ -42,6 +44,13 @@ export const PostDropdownMenu: FC<Props> = ({ post, button }) => {
       post.user_permission
     ) &&
       post.curation_status !== PostStatus.APPROVED);
+  const isLargeScreen = useBreakpoint("md");
+
+  const shareMenuItems = useShareMenuItems({
+    questionTitle: post.title,
+    questionId: post.question?.id,
+    includeEmbedOnSmallScreens: false, // Don't include embed on small screens in dropdown
+  });
 
   const [confirmModalOpen, setConfirmModalOpen] = useState<{
     open: boolean;
@@ -96,6 +105,19 @@ export const PostDropdownMenu: FC<Props> = ({ post, button }) => {
   };
 
   const menuItems: MenuItemProps[] = [
+    // Mobile menu items
+    // TODO: check for Notebooks
+    ...(!isLargeScreen
+      ? [
+          {
+            id: "share",
+            name: t("share"),
+            className: "capitalize",
+            items: shareMenuItems,
+          },
+        ]
+      : []),
+
     // Include if user has permissions to edit
     ...(allowEdit
       ? [

--- a/front_end/src/components/post_actions/post_dropdown_menu.tsx
+++ b/front_end/src/components/post_actions/post_dropdown_menu.tsx
@@ -109,8 +109,6 @@ export const PostDropdownMenu: FC<Props> = ({ post, button }) => {
 
   const menuItems: MenuItemProps[] = [
     // Mobile menu items
-    // TODO: check for Notebooks
-    // TODO: notebooks mobile design voter
     ...(!isLargeScreen
       ? [
           {

--- a/front_end/src/components/post_actions/post_dropdown_menu.tsx
+++ b/front_end/src/components/post_actions/post_dropdown_menu.tsx
@@ -14,6 +14,7 @@ import { changePostActivityBoost } from "@/app/(main)/questions/actions";
 import Button from "@/components/ui/button";
 import DropdownMenu, { MenuItemProps } from "@/components/ui/dropdown_menu";
 import { useAuth } from "@/contexts/auth_context";
+import { usePostSubscriptionContext } from "@/contexts/post_subscription_context";
 import { useBreakpoint } from "@/hooks/tailwind";
 import { useShareMenuItems } from "@/hooks/use_share_menu_items";
 import { BoostDirection } from "@/services/api/posts/posts.shared";
@@ -51,6 +52,8 @@ export const PostDropdownMenu: FC<Props> = ({ post, button }) => {
     questionId: post.question?.id,
     includeEmbedOnSmallScreens: false, // Don't include embed on small screens in dropdown
   });
+
+  const { isSubscribed, toggleSubscription } = usePostSubscriptionContext();
 
   const [confirmModalOpen, setConfirmModalOpen] = useState<{
     open: boolean;
@@ -114,6 +117,11 @@ export const PostDropdownMenu: FC<Props> = ({ post, button }) => {
             name: t("share"),
             className: "capitalize",
             items: shareMenuItems,
+          },
+          {
+            id: "subscription",
+            name: isSubscribed ? t("followingButton") : t("followButton"),
+            onClick: toggleSubscription,
           },
         ]
       : []),

--- a/front_end/src/components/post_actions/share_post_menu.tsx
+++ b/front_end/src/components/post_actions/share_post_menu.tsx
@@ -1,20 +1,11 @@
 "use client";
 import { faShareNodes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useTranslations } from "next-intl";
 import { FC } from "react";
 
 import Button from "@/components/ui/button";
 import DropdownMenu from "@/components/ui/dropdown_menu";
-import useEmbedModalContext from "@/contexts/embed_modal_context";
-import { usePublicSettings } from "@/contexts/public_settings_context";
-import {
-  useCopyUrl,
-  useShareOnFacebookLink,
-  useShareOnTwitterLink,
-} from "@/hooks/share";
-import { useBreakpoint } from "@/hooks/tailwind";
-import useAppTheme from "@/hooks/use_app_theme";
+import { useShareMenuItems } from "@/hooks/use_share_menu_items";
 import cn from "@/utils/core/cn";
 
 type Props = {
@@ -28,58 +19,14 @@ export const SharePostMenu: FC<Props> = ({
   questionId,
   btnClassName,
 }) => {
-  const isLargeScreen = useBreakpoint("md");
-  const t = useTranslations();
-  const { PUBLIC_SCREENSHOT_SERVICE_ENABLED } = usePublicSettings();
-  const { updateIsOpen } = useEmbedModalContext();
-  const copyUrl = useCopyUrl();
-  const shareOnTwitterLink = useShareOnTwitterLink(
-    `${questionTitle} #metaculus`
-  );
-  const shareOnFacebookLink = useShareOnFacebookLink();
-  const { theme } = useAppTheme();
+  const shareMenuItems = useShareMenuItems({
+    questionTitle,
+    questionId,
+    includeEmbedOnSmallScreens: true,
+  });
 
   return (
-    <DropdownMenu
-      items={[
-        ...(isLargeScreen
-          ? []
-          : [
-              {
-                id: "embed_menu",
-                name: "Embed",
-                onClick: () => updateIsOpen(true),
-              },
-            ]),
-        {
-          id: "share_fb",
-          name: t("facebook"),
-          link: shareOnFacebookLink,
-          openNewTab: true,
-        },
-        {
-          id: "share_twitter",
-          name: t("xTwitter"),
-          link: shareOnTwitterLink,
-          openNewTab: true,
-        },
-        ...(questionId && PUBLIC_SCREENSHOT_SERVICE_ENABLED
-          ? [
-              {
-                id: "image",
-                name: t("image"),
-                link: `/questions/${questionId}/image-preview/?theme=${theme}`,
-                openNewTab: true,
-              },
-            ]
-          : []),
-        {
-          id: "copy_link",
-          name: t("copyLink"),
-          onClick: copyUrl,
-        },
-      ]}
-    >
+    <DropdownMenu items={shareMenuItems}>
       <Button
         variant="secondary"
         className={cn("rounded border-0", btnClassName)}

--- a/front_end/src/components/ui/dropdown_menu.tsx
+++ b/front_end/src/components/ui/dropdown_menu.tsx
@@ -113,7 +113,7 @@ function InnerMenuContent({
                         setActiveItems(item.items);
                       }
 
-                      if (!isNil(item.onClick)) item.onClick();
+                      if (!isNil(item.onClick)) item.onClick(e);
                     }}
                   >
                     {item.name}

--- a/front_end/src/contexts/post_subscription_context.tsx
+++ b/front_end/src/contexts/post_subscription_context.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import React, {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+
+import { changePostSubscriptions } from "@/app/(main)/questions/actions";
+import PostSubscribeCustomizeModal from "@/components/post_subscribe/post_subscribe_customise_modal";
+import PostSubscribeSuccessModal from "@/components/post_subscribe/subscribe_button/post_subscribe_success_modal";
+import {
+  getInitialNotebookSubscriptions,
+  getInitialQuestionSubscriptions,
+} from "@/components/post_subscribe/subscribe_button/utils";
+import { useAuth } from "@/contexts/auth_context";
+import { useModal } from "@/contexts/modal_context";
+import { Post, PostSubscription } from "@/types/post";
+import { sendAnalyticsEvent } from "@/utils/analytics";
+
+type PostSubscriptionContextType = {
+  isSubscribed: boolean;
+  isLoading: boolean;
+  toggleSubscription: () => Promise<void>;
+  handleSubscribe: () => Promise<void>;
+  handleCustomize: () => void;
+};
+
+const PostSubscriptionContext =
+  createContext<PostSubscriptionContextType | null>(null);
+
+type PostSubscriptionProviderProps = {
+  post: Post;
+  children: ReactNode;
+};
+
+type FollowModalType = "success" | "customisation";
+
+export const PostSubscriptionProvider: React.FC<
+  PostSubscriptionProviderProps
+> = ({ post, children }) => {
+  const { user } = useAuth();
+  const { setCurrentModal } = useModal();
+
+  const [postSubscriptions, setPostSubscriptions] = useState<
+    PostSubscription[]
+  >(post.subscriptions || []);
+  const [isLoading, setIsLoading] = useState(false);
+  const [activeModal, setActiveModal] = useState<FollowModalType | undefined>();
+
+  const isSubscribed = postSubscriptions.length > 0;
+
+  const updateSubscriptions = useCallback(
+    (newSubscriptions: PostSubscription[]) => {
+      setPostSubscriptions(newSubscriptions);
+    },
+    []
+  );
+
+  const handleSubscribe = useCallback(async () => {
+    if (!user) {
+      setCurrentModal({ type: "signup" });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const newSubscriptions = await changePostSubscriptions(
+        post.id,
+        post.notebook
+          ? getInitialNotebookSubscriptions()
+          : getInitialQuestionSubscriptions()
+      );
+      sendAnalyticsEvent("questionFollowed");
+      updateSubscriptions(newSubscriptions);
+      // Show success modal after subscribing
+      setActiveModal("success");
+      return newSubscriptions;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [post.id, post.notebook, setCurrentModal, user, updateSubscriptions]);
+
+  const handleCustomize = useCallback(() => {
+    setActiveModal("customisation");
+  }, []);
+
+  const toggleSubscription = useCallback(async () => {
+    if (isSubscribed) {
+      // If subscribed, show customization modal instead of unsubscribing
+      setActiveModal("customisation");
+    } else {
+      await handleSubscribe();
+    }
+  }, [isSubscribed, handleSubscribe]);
+
+  const closeModal = useCallback(() => {
+    setActiveModal(undefined);
+  }, []);
+
+  const contextValue: PostSubscriptionContextType = {
+    isSubscribed,
+    isLoading,
+    toggleSubscription: async () => {
+      await toggleSubscription();
+    },
+    handleSubscribe: async () => {
+      await handleSubscribe();
+    },
+    handleCustomize,
+  };
+
+  return (
+    <PostSubscriptionContext.Provider value={contextValue}>
+      {children}
+
+      {/* Modals are automatically included and managed */}
+      <PostSubscribeSuccessModal
+        isOpen={activeModal === "success"}
+        onClose={closeModal}
+        post={post}
+        onCustomiseClick={() => setActiveModal("customisation")}
+        onPostSubscriptionChange={updateSubscriptions}
+      />
+
+      <PostSubscribeCustomizeModal
+        isOpen={activeModal === "customisation"}
+        onClose={closeModal}
+        post={post}
+        subscriptions={postSubscriptions}
+        onPostSubscriptionChange={updateSubscriptions}
+      />
+    </PostSubscriptionContext.Provider>
+  );
+};
+
+export const usePostSubscriptionContext = (): PostSubscriptionContextType => {
+  const context = useContext(PostSubscriptionContext);
+  if (!context) {
+    throw new Error(
+      "usePostSubscriptionContext must be used within a PostSubscriptionProvider"
+    );
+  }
+  return context;
+};

--- a/front_end/src/hooks/use_share_menu_items.ts
+++ b/front_end/src/hooks/use_share_menu_items.ts
@@ -1,0 +1,74 @@
+import { useTranslations } from "next-intl";
+
+import { MenuItemProps } from "@/components/ui/dropdown_menu";
+import useEmbedModalContext from "@/contexts/embed_modal_context";
+import { usePublicSettings } from "@/contexts/public_settings_context";
+import {
+  useCopyUrl,
+  useShareOnFacebookLink,
+  useShareOnTwitterLink,
+} from "@/hooks/share";
+import { useBreakpoint } from "@/hooks/tailwind";
+import useAppTheme from "@/hooks/use_app_theme";
+
+type UseShareMenuItemsProps = {
+  questionTitle: string;
+  questionId?: number;
+  includeEmbedOnSmallScreens?: boolean;
+};
+
+export const useShareMenuItems = ({
+  questionTitle,
+  questionId,
+  includeEmbedOnSmallScreens = true,
+}: UseShareMenuItemsProps): MenuItemProps[] => {
+  const isLargeScreen = useBreakpoint("md");
+  const t = useTranslations();
+  const { PUBLIC_SCREENSHOT_SERVICE_ENABLED } = usePublicSettings();
+  const { updateIsOpen } = useEmbedModalContext();
+  const copyUrl = useCopyUrl();
+  const shareOnTwitterLink = useShareOnTwitterLink(
+    `${questionTitle} #metaculus`
+  );
+  const shareOnFacebookLink = useShareOnFacebookLink();
+  const { theme } = useAppTheme();
+
+  return [
+    ...(includeEmbedOnSmallScreens && !isLargeScreen
+      ? [
+          {
+            id: "embed_menu",
+            name: "Embed",
+            onClick: () => updateIsOpen(true),
+          },
+        ]
+      : []),
+    {
+      id: "share_fb",
+      name: t("facebook"),
+      link: shareOnFacebookLink,
+      openNewTab: true,
+    },
+    {
+      id: "share_twitter",
+      name: t("xTwitter"),
+      link: shareOnTwitterLink,
+      openNewTab: true,
+    },
+    ...(questionId && PUBLIC_SCREENSHOT_SERVICE_ENABLED
+      ? [
+          {
+            id: "image",
+            name: t("image"),
+            link: `/questions/${questionId}/image-preview/?theme=${theme}`,
+            openNewTab: true,
+          },
+        ]
+      : []),
+    {
+      id: "copy_link",
+      name: t("copyLink"),
+      onClick: copyUrl,
+    },
+  ];
+};


### PR DESCRIPTION
<img width="336" height="155" alt="image" src="https://github.com/user-attachments/assets/f024d90f-7cc7-4008-bd5a-18f654b14f45" />

- Refactored DropdownMenu to allow nested items usage 
- Moved share post menu to the separate hook 
- Post page: added share menu item
- Moved post subscriptions modals and conditions into separate `PostSubscriptionProvider` for convenience 
- Propagated `PostSubscriptionProvider` to notebook and questions pages 
- Added Subscribe button to post dropdown
- Small notebooks adjustment

part of #3081 