### PR TITLE
Update key factor link icon

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factor_item/key_factor_text.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factor_item/key_factor_text.tsx
@@ -1,4 +1,4 @@
-import { faArrowTurnUp } from "@fortawesome/free-solid-svg-icons";
+import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC } from "react";
 
@@ -46,11 +46,8 @@ const KeyFactorText: FC<Props> = ({
         className="target visible ml-1 inline-flex items-center overflow-visible rounded-full p-2 text-blue-600 hover:bg-blue-400 hover:font-bold hover:text-blue-700 can-hover:invisible dark:text-blue-600 dark:hover:bg-blue-400-dark"
       >
         <FontAwesomeIcon
-          icon={faArrowTurnUp}
-          className={cn(
-            "size-3 scale-110",
-            linkToComment && "rotate-180 scale-x-[-1]"
-          )}
+          icon={faArrowUpRightFromSquare}
+          className="size-3 scale-110"
         />
       </a>
     </div>


### PR DESCRIPTION
Switched to a more common hyperlink icon 
<img width="115" height="99" alt="image" src="https://github.com/user-attachments/assets/502ce110-e067-4be7-8360-1db10fe39c9e" />
