### PR TITLE
New settings page: theme configuration

### DIFF
--- a/front_end/src/app/(main)/accounts/settings/(general)/components/display_preferences.tsx
+++ b/front_end/src/app/(main)/accounts/settings/(general)/components/display_preferences.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useTheme } from "next-themes";
 import { FC, useState } from "react";
 
 import { updateProfileAction } from "@/app/(main)/accounts/profile/actions";
+import ThemePreferences from "@/app/(main)/accounts/settings/(general)/components/theme_preferences";
 import PreferencesSection from "@/app/(main)/accounts/settings/components/preferences_section";
 import { APP_LANGUAGES } from "@/components/language_menu";
 import LoadingSpinner from "@/components/ui/loading_spiner";
@@ -13,7 +13,6 @@ import RadioButtonGroup, {
 } from "@/components/ui/radio_button_group";
 import Select from "@/components/ui/select";
 import { useServerAction } from "@/hooks/use_server_action";
-import { AppTheme } from "@/types/theme";
 import { CurrentUser, InterfaceType } from "@/types/users";
 
 type Props = {
@@ -22,7 +21,6 @@ type Props = {
 
 const DisplayPreferences: FC<Props> = ({ user }) => {
   const t = useTranslations();
-  const { theme, setTheme } = useTheme();
   const interfaceTypeOptions: RadioOption<InterfaceType>[] = [
     {
       value: InterfaceType.ConsumerView,
@@ -45,21 +43,6 @@ const DisplayPreferences: FC<Props> = ({ user }) => {
     }
   );
 
-  const themeTypeOptions: RadioOption<AppTheme>[] = [
-    {
-      value: "system",
-      label: t("settingsThemeSystemDefault"),
-    },
-    {
-      value: "light",
-      label: t("settingsThemeLightMode"),
-    },
-    {
-      value: "dark",
-      label: t("settingsThemeDarkMode"),
-    },
-  ];
-
   const [locale, setLocale] = useState<string>("en");
   const localeOptions = APP_LANGUAGES.map((obj) => ({
     value: obj.locale,
@@ -81,16 +64,7 @@ const DisplayPreferences: FC<Props> = ({ user }) => {
           className="mt-2.5"
         />
       </div>
-      {/* TODO: implement backend save strategy */}
-      <div hidden={true}>
-        <RadioButtonGroup
-          value={theme ?? "system"}
-          name="app_theme"
-          options={themeTypeOptions}
-          onChange={setTheme}
-          className="mt-2.5"
-        />
-      </div>
+      <ThemePreferences />
       {/* TODO: language switcher */}
       <div hidden={true}>
         <div className="text-gray-500 dark:text-gray-500-dark">

--- a/front_end/src/app/(main)/accounts/settings/(general)/components/prediction_preferences.tsx
+++ b/front_end/src/app/(main)/accounts/settings/(general)/components/prediction_preferences.tsx
@@ -14,7 +14,6 @@ import { Input } from "@/components/ui/form_field";
 import LoadingSpinner from "@/components/ui/loading_spiner";
 import { useServerAction } from "@/hooks/use_server_action";
 import { CurrentUser } from "@/types/users";
-import cn from "@/utils/core/cn";
 
 export type Props = {
   user: CurrentUser;

--- a/front_end/src/app/(main)/accounts/settings/(general)/components/theme_preferences.tsx
+++ b/front_end/src/app/(main)/accounts/settings/(general)/components/theme_preferences.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { FC, useMemo } from "react";
+
+import LoadingSpinner from "@/components/ui/loading_spiner";
+import RadioButtonGroup, {
+  RadioOption,
+} from "@/components/ui/radio_button_group";
+import { useAuth } from "@/contexts/auth_context";
+import useAppTheme from "@/hooks/use_app_theme";
+import useMounted from "@/hooks/use_mounted";
+import { AppTheme } from "@/types/theme";
+
+const ThemePreferences: FC = () => {
+  const t = useTranslations();
+  const { themeChoice, setTheme, isSyncing } = useAppTheme();
+  const { user } = useAuth();
+  const mounted = useMounted();
+
+  const currentTheme = useMemo(
+    () => user?.app_theme ?? (mounted ? themeChoice : AppTheme.System),
+    [user?.app_theme, themeChoice, mounted]
+  );
+
+  const themeTypeOptions: RadioOption<AppTheme>[] = [
+    {
+      value: AppTheme.System,
+      label: t("settingsThemeSystemDefault"),
+    },
+    {
+      value: AppTheme.Light,
+      label: t("settingsThemeLightMode"),
+    },
+    {
+      value: AppTheme.Dark,
+      label: t("settingsThemeDarkMode"),
+    },
+  ];
+
+  return (
+    <div>
+      <div className="flex gap-2.5 text-gray-500 dark:text-gray-500-dark">
+        <span>{t("settingsThemeSelection")}</span>
+        {isSyncing && <LoadingSpinner size="1x" />}
+      </div>
+      <RadioButtonGroup
+        value={currentTheme}
+        name="app_theme"
+        options={themeTypeOptions}
+        onChange={(value) => !isSyncing && setTheme(value)}
+        className="mt-2.5"
+      />
+    </div>
+  );
+};
+
+export default ThemePreferences;

--- a/front_end/src/app/(main)/accounts/settings/components/settings_header.tsx
+++ b/front_end/src/app/(main)/accounts/settings/components/settings_header.tsx
@@ -62,7 +62,7 @@ const TabItem: FC<{ icon: IconDefinition; label: string }> = ({
 }) => {
   return (
     <div className="flex gap-2">
-      <FontAwesomeIcon icon={icon} className="xxs:block hidden" />
+      <FontAwesomeIcon icon={icon} className="hidden xxs:block" />
       <span>{label}</span>
     </div>
   );

--- a/front_end/src/app/layout.tsx
+++ b/front_end/src/app/layout.tsx
@@ -102,9 +102,9 @@ export default async function RootLayout({
       <body className="min-h-screen w-full bg-blue-200 dark:bg-blue-50-dark">
         <PolyfillProvider>
           <CSPostHogProvider locale={locale}>
-            <AppThemeProvider>
-              <NextIntlClientProvider messages={messages}>
-                <AuthProvider user={user} locale={locale}>
+            <AuthProvider user={user} locale={locale}>
+              <AppThemeProvider>
+                <NextIntlClientProvider messages={messages}>
                   <PublicSettingsProvider settings={publicSettings}>
                     <ModalProvider>
                       <NavigationProvider>
@@ -122,9 +122,9 @@ export default async function RootLayout({
                       </NavigationProvider>
                     </ModalProvider>
                   </PublicSettingsProvider>
-                </AuthProvider>
-              </NextIntlClientProvider>
-            </AppThemeProvider>
+                </NextIntlClientProvider>
+              </AppThemeProvider>
+            </AuthProvider>
           </CSPostHogProvider>
         </PolyfillProvider>
       </body>

--- a/front_end/src/components/theme_provider.tsx
+++ b/front_end/src/components/theme_provider.tsx
@@ -4,18 +4,20 @@ import { ThemeProvider } from "next-themes";
 import { FC, PropsWithChildren } from "react";
 
 import { ENFORCED_THEME_PARAM } from "@/constants/global_search_params";
+import { useAuth } from "@/contexts/auth_context";
 import { AppTheme } from "@/types/theme";
 
 const AppThemeProvided: FC<PropsWithChildren> = ({ children }) => {
   const params = useSearchParams();
   const themeParam = params.get(ENFORCED_THEME_PARAM) as AppTheme | null;
+  const { user } = useAuth();
 
   return (
     <ThemeProvider
       attribute="class"
       defaultTheme="system"
       enableSystem
-      forcedTheme={themeParam ?? undefined}
+      forcedTheme={themeParam ?? user?.app_theme ?? undefined}
     >
       {children}
     </ThemeProvider>

--- a/front_end/src/components/theme_toggle.tsx
+++ b/front_end/src/components/theme_toggle.tsx
@@ -3,17 +3,18 @@ import { FC } from "react";
 
 import useAppTheme from "@/hooks/use_app_theme";
 import useMounted from "@/hooks/use_mounted";
+import { AppTheme } from "@/types/theme";
 import cn from "@/utils/core/cn";
 
 const ThemeToggle: FC = () => {
   const mounted = useMounted();
 
-  const { theme, setTheme } = useAppTheme();
+  const { theme, isSyncing, setTheme } = useAppTheme();
   const switchTheme = () => {
     if (theme === "dark") {
-      setTheme("light");
+      setTheme(AppTheme.Light);
     } else {
-      setTheme("dark");
+      setTheme(AppTheme.Dark);
     }
   };
 
@@ -27,6 +28,9 @@ const ThemeToggle: FC = () => {
     <button
       className="group/theme relative inline-block h-[15px] w-[35px] min-w-[2rem] rounded-full border border-white focus:outline-none"
       onClick={switchTheme}
+      // Optimistic update
+      // But don't allow to click until values is synced with backend
+      disabled={isSyncing}
     >
       <span
         className={cn(

--- a/front_end/src/hooks/use_app_theme.ts
+++ b/front_end/src/hooks/use_app_theme.ts
@@ -1,10 +1,42 @@
 import { useTheme } from "next-themes";
-import { Dispatch, SetStateAction, useCallback } from "react";
+import { Dispatch, SetStateAction, useCallback, useState } from "react";
 
+import { updateProfileAction } from "@/app/(main)/accounts/profile/actions";
+import { useAuth } from "@/contexts/auth_context";
 import { AppTheme, ThemeColor } from "@/types/theme";
+import { logError } from "@/utils/core/errors";
 
 const useAppTheme = () => {
-  const { resolvedTheme, setTheme, forcedTheme } = useTheme();
+  const {
+    theme: themeChoice,
+    resolvedTheme,
+    setTheme: setNextTheme,
+    forcedTheme,
+  } = useTheme();
+  const [isSyncing, setIsSyncing] = useState<boolean>();
+  const { user, setUser } = useAuth();
+
+  const setTheme = useCallback(
+    async (newTheme: AppTheme) => {
+      // Immediately update NextTheme for instant visual feedback
+      setNextTheme(newTheme);
+
+      // For authenticated users, also save to backend
+      if (user) {
+        setIsSyncing(true);
+        setUser({ ...user, app_theme: newTheme });
+
+        try {
+          await updateProfileAction({ app_theme: newTheme }, false);
+        } catch (error) {
+          logError(error);
+        } finally {
+          setIsSyncing(false);
+        }
+      }
+    },
+    [setNextTheme, user, setUser]
+  );
 
   const getThemeColor = useCallback(
     (color: ThemeColor) => {
@@ -18,7 +50,12 @@ const useAppTheme = () => {
   );
 
   return {
+    // Currently active theme respecting Forced selection
+    // Could be dark or light
     theme: (forcedTheme ?? resolvedTheme) as AppTheme,
+    // Currently selected theme. Could be dark, light or system
+    themeChoice: themeChoice ?? AppTheme.System,
+    isSyncing,
     setTheme: setTheme as Dispatch<SetStateAction<AppTheme>>,
     getThemeColor,
   };

--- a/front_end/src/types/theme.ts
+++ b/front_end/src/types/theme.ts
@@ -1,2 +1,6 @@
-export type AppTheme = "light" | "dark" | "system";
+export enum AppTheme {
+  System = "system",
+  Light = "light",
+  Dark = "dark",
+}
 export type ThemeColor = { DEFAULT: string; dark: string };

--- a/front_end/src/types/users.ts
+++ b/front_end/src/types/users.ts
@@ -62,7 +62,7 @@ export type CurrentUser = User & {
   registered_campaigns: { key: string; details: object }[];
   should_suggest_keyfactors: boolean;
   prediction_expiration_percent: number | null;
-  app_theme: AppTheme;
+  app_theme?: AppTheme | null;
   interface_type: InterfaceType;
 };
 


### PR DESCRIPTION
<img width="741" height="391" alt="image" src="https://github.com/user-attachments/assets/54c7e459-4fbb-45b1-a541-4db8035e29b1" />

- Enabled Theme switcher in profile
- Created a separate ThemePreferences component to managed stored theme config
- Moved AppThemeProvider inside AuthProvider to allow access to user object to force preselected theme from db
- Changed `AppTheme` to Enum
- Modified `AppThemeProvided` to respect `user.app_theme` config
- Expanded `useAppTheme` to save user theme to the profile
- Fixed linter issues