### PR TITLE
Fixed hotness boost for unsuccessfully resolved questions

### DIFF
--- a/posts/services/hotness.py
+++ b/posts/services/hotness.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from comments.models import Comment
 from misc.models import PostArticle
 from posts.models import Post, Vote, PostActivityBoost
-from questions.constants import QuestionStatus
+from questions.constants import QuestionStatus, UnsuccessfulResolutionType
 from questions.models import Question
 from users.models import User
 from utils.models import ModelBatchUpdater
@@ -29,6 +29,9 @@ def compute_question_hotness(question: Question) -> float:
     """
     Compute the hotness of post subquestion.
     """
+
+    if question.resolution in UnsuccessfulResolutionType:
+        return 0
 
     now = timezone.now()
     hotness = 0

--- a/posts/services/hotness.py
+++ b/posts/services/hotness.py
@@ -30,9 +30,6 @@ def compute_question_hotness(question: Question) -> float:
     Compute the hotness of post subquestion.
     """
 
-    if question.resolution in UnsuccessfulResolutionType:
-        return 0
-
     now = timezone.now()
     hotness = 0
 
@@ -49,11 +46,13 @@ def compute_question_hotness(question: Question) -> float:
     )
 
     # Resolution time
-    hotness += (
-        decay(20, question.resolution_set_time)
-        if question.resolution_set_time and now > question.resolution_set_time
-        else 0
-    )
+    if (
+        question.resolution_set_time
+        and now > question.resolution_set_time
+        and question.resolution
+        and question.resolution not in UnsuccessfulResolutionType
+    ):
+        hotness += decay(20, question.resolution_set_time)
 
     return hotness
 

--- a/projects/models.py
+++ b/projects/models.py
@@ -14,7 +14,7 @@ from django.utils import timezone as django_timezone
 from sql_util.aggregates import SubqueryAggregate
 
 from projects.permissions import ObjectPermission
-from questions.constants import ResolutionType
+from questions.constants import UnsuccessfulResolutionType
 from questions.models import Question
 from scoring.constants import LeaderboardScoreTypes
 from users.models import User
@@ -80,8 +80,8 @@ class ProjectsQuerySet(models.QuerySet):
                 )
                 & ~Q(
                     posts__related_questions__question__resolution__in=[
-                        ResolutionType.AMBIGUOUS,
-                        ResolutionType.ANNULLED,
+                        UnsuccessfulResolutionType.AMBIGUOUS,
+                        UnsuccessfulResolutionType.ANNULLED,
                     ]
                 ),
                 distinct=True,
@@ -94,8 +94,8 @@ class ProjectsQuerySet(models.QuerySet):
                 )
                 & ~Q(
                     default_posts__related_questions__question__resolution__in=[
-                        ResolutionType.AMBIGUOUS,
-                        ResolutionType.ANNULLED,
+                        UnsuccessfulResolutionType.AMBIGUOUS,
+                        UnsuccessfulResolutionType.ANNULLED,
                     ]
                 ),
                 distinct=True,

--- a/questions/admin.py
+++ b/questions/admin.py
@@ -7,7 +7,7 @@ from django.utils.html import format_html
 from django_better_admin_arrayfield.admin.mixins import DynamicArrayMixin
 
 from posts.models import Post
-from questions.constants import ResolutionType
+from questions.constants import UnsuccessfulResolutionType
 from questions.models import (
     AggregateForecast,
     Conditional,
@@ -140,8 +140,8 @@ class QuestionAdmin(CustomTranslationAdmin, DynamicArrayMixin):
 
         for question in queryset:
             if not question.resolution or question.resolution in (
-                ResolutionType.AMBIGUOUS,
-                ResolutionType.ANNULLED,
+                UnsuccessfulResolutionType.AMBIGUOUS,
+                UnsuccessfulResolutionType.ANNULLED,
             ):
                 continue
             score_question(
@@ -158,8 +158,8 @@ class QuestionAdmin(CustomTranslationAdmin, DynamicArrayMixin):
 
         for question in queryset:
             if not question.resolution or question.resolution in (
-                ResolutionType.AMBIGUOUS,
-                ResolutionType.ANNULLED,
+                UnsuccessfulResolutionType.AMBIGUOUS,
+                UnsuccessfulResolutionType.ANNULLED,
             ):
                 continue
             score_question(

--- a/questions/constants.py
+++ b/questions/constants.py
@@ -1,7 +1,7 @@
 from django.db import models
 
 
-class ResolutionType(models.TextChoices):
+class UnsuccessfulResolutionType(models.TextChoices):
     AMBIGUOUS = "ambiguous"
     ANNULLED = "annulled"
 

--- a/questions/serializers/common.py
+++ b/questions/serializers/common.py
@@ -7,7 +7,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
 from posts.models import Post
-from questions.constants import ResolutionType
+from questions.constants import UnsuccessfulResolutionType
 from questions.models import (
     DEFAULT_INBOUND_OUTCOME_COUNT,
     QUESTION_CONTINUOUS_TYPES,
@@ -755,7 +755,7 @@ def serialize_group(
 
 
 def validate_question_resolution(question: Question, resolution: str) -> str:
-    if resolution in ResolutionType:
+    if resolution in UnsuccessfulResolutionType:
         return resolution
 
     if question.type == Question.QuestionType.BINARY:

--- a/questions/services.py
+++ b/questions/services.py
@@ -19,7 +19,7 @@ from posts.tasks import run_on_post_forecast
 from projects.models import Project
 from projects.services.cache import invalidate_projects_questions_count_cache
 from projects.services.common import notify_project_subscriptions_question_open
-from questions.constants import ResolutionType
+from questions.constants import UnsuccessfulResolutionType
 from questions.models import (
     QUESTION_CONTINUOUS_TYPES,
     Question,
@@ -415,24 +415,24 @@ def resolve_question(
         if question == condition:
             # handle annulment
             if question.resolution in [
-                ResolutionType.ANNULLED,
-                ResolutionType.AMBIGUOUS,
+                UnsuccessfulResolutionType.ANNULLED,
+                UnsuccessfulResolutionType.AMBIGUOUS,
             ]:
                 resolve_question(
                     conditional.question_no,
-                    ResolutionType.ANNULLED,
+                    UnsuccessfulResolutionType.ANNULLED,
                     actual_resolve_time,
                 )
                 resolve_question(
                     conditional.question_yes,
-                    ResolutionType.ANNULLED,
+                    UnsuccessfulResolutionType.ANNULLED,
                     actual_resolve_time,
                 )
             if child.resolution is None:
                 if question.resolution == "yes":
                     resolve_question(
                         conditional.question_no,
-                        ResolutionType.ANNULLED,
+                        UnsuccessfulResolutionType.ANNULLED,
                         actual_resolve_time,
                     )
                     close_question(
@@ -442,7 +442,7 @@ def resolve_question(
                 if question.resolution == "no":
                     resolve_question(
                         conditional.question_yes,
-                        ResolutionType.ANNULLED,
+                        UnsuccessfulResolutionType.ANNULLED,
                         actual_resolve_time,
                     )
                     close_question(
@@ -453,8 +453,8 @@ def resolve_question(
             # we resolve the active branch and annull the other
             if child.resolution not in [
                 None,
-                ResolutionType.ANNULLED,
-                ResolutionType.AMBIGUOUS,
+                UnsuccessfulResolutionType.ANNULLED,
+                UnsuccessfulResolutionType.AMBIGUOUS,
             ]:
                 if question.resolution == "yes":
                     resolve_question(
@@ -464,7 +464,7 @@ def resolve_question(
                     )
                     resolve_question(
                         conditional.question_no,
-                        ResolutionType.ANNULLED,
+                        UnsuccessfulResolutionType.ANNULLED,
                         conditional.question_no.actual_close_time,
                     )
                 if question.resolution == "no":
@@ -475,23 +475,23 @@ def resolve_question(
                     )
                     resolve_question(
                         conditional.question_yes,
-                        ResolutionType.ANNULLED,
+                        UnsuccessfulResolutionType.ANNULLED,
                         conditional.question_yes.actual_close_time,
                     )
         else:  # question == child
             # handle annulment / ambiguity
             if question.resolution in [
-                ResolutionType.ANNULLED,
-                ResolutionType.AMBIGUOUS,
+                UnsuccessfulResolutionType.ANNULLED,
+                UnsuccessfulResolutionType.AMBIGUOUS,
             ]:
                 resolve_question(
                     conditional.question_yes,
-                    ResolutionType.ANNULLED,
+                    UnsuccessfulResolutionType.ANNULLED,
                     actual_resolve_time,
                 )
                 resolve_question(
                     conditional.question_no,
-                    ResolutionType.ANNULLED,
+                    UnsuccessfulResolutionType.ANNULLED,
                     actual_resolve_time,
                 )
             else:  # child is successfully resolved
@@ -559,16 +559,16 @@ def unresolve_question(question: Question):
         child = conditional.condition_child
         if question == condition:
             if child.resolution not in [
-                ResolutionType.ANNULLED,
-                ResolutionType.AMBIGUOUS,
+                UnsuccessfulResolutionType.ANNULLED,
+                UnsuccessfulResolutionType.AMBIGUOUS,
             ]:
                 # unresolve both branches (handles annulment / ambiguity automatically)
                 unresolve_question(conditional.question_yes)
                 unresolve_question(conditional.question_no)
             if child.resolution not in [
                 None,
-                ResolutionType.ANNULLED,
-                ResolutionType.AMBIGUOUS,
+                UnsuccessfulResolutionType.ANNULLED,
+                UnsuccessfulResolutionType.AMBIGUOUS,
             ]:
                 # both branches should still be closed though
                 close_question(

--- a/scoring/serializers.py
+++ b/scoring/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from questions.constants import ResolutionType
+from questions.constants import UnsuccessfulResolutionType
 from scoring.models import Leaderboard, LeaderboardEntry
 from users.serializers import BaseUserSerializer
 
@@ -76,7 +76,12 @@ class LeaderboardSerializer(serializers.Serializer):
         return (
             obj.get_questions()
             .filter(resolution__isnull=False)
-            .exclude(resolution__in=[ResolutionType.ANNULLED, ResolutionType.AMBIGUOUS])
+            .exclude(
+                resolution__in=[
+                    UnsuccessfulResolutionType.ANNULLED,
+                    UnsuccessfulResolutionType.AMBIGUOUS,
+                ]
+            )
             .count()
         )
 

--- a/scoring/utils.py
+++ b/scoring/utils.py
@@ -32,6 +32,7 @@ from comments.models import Comment
 from posts.models import Post
 from projects.models import Project
 from projects.permissions import ObjectPermission
+from questions.constants import UnsuccessfulResolutionType
 from questions.models import Question, Forecast, QuestionPost
 from questions.types import AggregationMethod
 from scoring.constants import ScoreTypes, LeaderboardScoreTypes
@@ -161,7 +162,7 @@ def generate_scoring_leaderboard_entries(
     maximum_coverage = sum(
         q.question_weight
         for q in questions
-        if q.resolution and q.resolution not in ["annulled", "ambiguous"]
+        if q.resolution and q.resolution not in UnsuccessfulResolutionType
     )
     for score in scores:
         identifier = score.user_id or score.aggregation_method

--- a/tests/unit/test_posts/test_services/test_hotness.py
+++ b/tests/unit/test_posts/test_services/test_hotness.py
@@ -74,10 +74,22 @@ def test_decay(dt: datetime.datetime, expected: float):
                 "open_time": make_aware(datetime.datetime(2025, 4, 4)),
                 "scheduled_close_time": make_aware(datetime.datetime(2025, 4, 10)),
                 "resolution_set_time": make_aware(datetime.datetime(2025, 4, 11)),
+                "resolution": "no",
                 # Should be ignored
                 "movement": 0.4,
             },
             6.25,
+        ],
+        # Unsuccessfully resolved question
+        [
+            {
+                # 1W from now
+                "open_time": make_aware(datetime.datetime(2025, 4, 4)),
+                "scheduled_close_time": make_aware(datetime.datetime(2025, 4, 10)),
+                "resolution_set_time": make_aware(datetime.datetime(2025, 4, 11)),
+                "resolution": "annulled",
+            },
+            1.25,
         ],
     ],
 )
@@ -181,6 +193,7 @@ def test_compute_post_hotness(user1):
                     open_time=make_aware(datetime.datetime(2025, 4, 4)),
                     scheduled_close_time=make_aware(datetime.datetime(2025, 4, 10)),
                     resolution_set_time=make_aware(datetime.datetime(2025, 4, 11)),
+                    resolution="yes"
                 ),
                 # Will be scored as 18
                 create_question(

--- a/tests/unit/test_questions/test_services.py
+++ b/tests/unit/test_questions/test_services.py
@@ -6,7 +6,7 @@ from django.utils.timezone import make_aware
 
 from posts.models import Post
 from posts.services.common import create_post, approve_post
-from questions.constants import QuestionStatus, ResolutionType
+from questions.constants import QuestionStatus, UnsuccessfulResolutionType
 from questions.jobs import job_close_question
 from questions.models import Question
 from questions.services import resolve_question, unresolve_question
@@ -525,7 +525,7 @@ class TestResolveConditionalQuestion:
         # conditional branch questions status
         assert question_yes.status == QuestionStatus.CLOSED
         assert question_no.status == QuestionStatus.RESOLVED
-        assert question_no.resolution == ResolutionType.ANNULLED
+        assert question_no.resolution == UnsuccessfulResolutionType.ANNULLED
 
     def test_case_12_parent_resolved_child_closed(
         self,
@@ -563,7 +563,7 @@ class TestResolveConditionalQuestion:
         # conditional branch questions status
         assert question_yes.status == QuestionStatus.CLOSED
         assert question_no.status == QuestionStatus.RESOLVED
-        assert question_no.resolution == ResolutionType.ANNULLED
+        assert question_no.resolution == UnsuccessfulResolutionType.ANNULLED
 
     def test_case_13_parent_resolved_child_resolved(
         self,
@@ -607,7 +607,7 @@ class TestResolveConditionalQuestion:
         assert question_yes.status == QuestionStatus.RESOLVED
         assert question_yes.resolution == "no"
         assert question_no.status == QuestionStatus.RESOLVED
-        assert question_no.resolution == ResolutionType.ANNULLED
+        assert question_no.resolution == UnsuccessfulResolutionType.ANNULLED
 
     def test_case_14_parent_resolved_child_unresolved_to_open(
         self,
@@ -653,7 +653,7 @@ class TestResolveConditionalQuestion:
         # conditional branch questions status
         assert question_yes.status == QuestionStatus.CLOSED
         assert question_no.status == QuestionStatus.RESOLVED
-        assert question_no.resolution == ResolutionType.ANNULLED
+        assert question_no.resolution == UnsuccessfulResolutionType.ANNULLED
 
     def test_case_15_parent_resolved_child_unresolved_to_closed(
         self,
@@ -699,7 +699,7 @@ class TestResolveConditionalQuestion:
         # conditional branch questions status
         assert question_yes.status == QuestionStatus.CLOSED
         assert question_no.status == QuestionStatus.RESOLVED
-        assert question_no.resolution == ResolutionType.ANNULLED
+        assert question_no.resolution == UnsuccessfulResolutionType.ANNULLED
 
     def test_case_16_parent_unresolved_to_open_child_open(
         self,

--- a/utils/the_math/formulas.py
+++ b/utils/the_math/formulas.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 
 import numpy as np
 
+from questions.constants import UnsuccessfulResolutionType
 from questions.models import Question
 from utils.typing import ForecastValues
 
@@ -27,7 +28,7 @@ logger = logging.getLogger(__name__)
 def string_location_to_scaled_location(
     string_location: str, question: Question
 ) -> float:
-    if string_location in ["ambiguous", "annulled"]:
+    if string_location in UnsuccessfulResolutionType:
         raise ValueError("Cannot convert ambiguous or annulled to any real locations")
     if question.type == Question.QuestionType.BINARY:
         return 1.0 if string_location == "yes" else 0.0
@@ -160,9 +161,10 @@ def bucket_index_to_unscaled_location(bucket_index: int, question: Question) -> 
 
 def string_location_to_unscaled_location(
     string_location: str, question: Question
-) -> float:
-    if string_location in ["", None, "ambiguous", "annulled"]:
-        return None
+) -> float | None:
+    if not string_location or string_location in UnsuccessfulResolutionType:
+        return
+
     scaled_location = string_location_to_scaled_location(string_location, question)
     return scaled_location_to_unscaled_location(scaled_location, question)
 
@@ -170,8 +172,9 @@ def string_location_to_unscaled_location(
 def string_location_to_bucket_index(
     string_location: str, question: Question
 ) -> int | None:
-    if string_location in ["", None, "ambiguous", "annulled"]:
-        return None
+    if not string_location or string_location in UnsuccessfulResolutionType:
+        return
+
     unscaled_location = string_location_to_unscaled_location(string_location, question)
     return unscaled_location_to_bucket_index(unscaled_location, question)
 


### PR DESCRIPTION
- Renamed `ResolutionType` enum to `UnsuccessfulResolutionType` for convenience
- Don't calculate hotness for unsuccessfully resolved post subquestions

fixes #3213 