### PR TITLE
Feed tiles storybook followup

### DIFF
--- a/front_end/src/stories/feed_card/binary_question/binary_question.stories.tsx
+++ b/front_end/src/stories/feed_card/binary_question/binary_question.stories.tsx
@@ -4,6 +4,10 @@ import ConsumerPostCard from "@/components/consumer_post_card";
 import PostCard from "@/components/post_card";
 import { createConditionalRenderer } from "@/stories/utils/renderer/conditional-renderer";
 import { stripUserPredictions } from "@/stories/utils/transforms/strip_user_predictions";
+import {
+  CpMovementState,
+  withCpMovement,
+} from "@/stories/utils/transforms/with_cp_movement";
 import { PostWithForecasts } from "@/types/post";
 
 import { getMockData } from "./mock_data";
@@ -15,6 +19,7 @@ type StoryProps = {
   forCommunityFeed?: boolean;
   isConsumer?: boolean;
   hideUserPredictions?: boolean;
+  cpMovement?: CpMovementState;
 };
 
 const meta = {
@@ -29,6 +34,11 @@ const meta = {
     hideUserPredictions: {
       control: { type: "boolean" },
       description: "Hide user predictions in graph cards",
+    },
+    cpMovement: {
+      control: { type: "radio" },
+      options: ["up", "down", "none"],
+      description: "Toggle CP Movement (up, down, none)",
     },
     forCommunityFeed: {
       table: {
@@ -46,6 +56,14 @@ const render = createConditionalRenderer<StoryProps>({
   componentSelector: (args) => (args.isConsumer ? ConsumerPostCard : PostCard),
   transformRules: [
     {
+      key: "cpMovement",
+      when: (args) => args.cpMovement !== undefined,
+      transform: (args) => ({
+        ...args,
+        post: withCpMovement(args.post, args.cpMovement ?? "none"),
+      }),
+    },
+    {
       key: "hideUserPredictions",
       when: (args) => !!args.hideUserPredictions,
       transform: (args) => ({
@@ -54,8 +72,8 @@ const render = createConditionalRenderer<StoryProps>({
       }),
     },
   ],
-  buildKey: (_args, appliedKeys) =>
-    appliedKeys.length > 0 ? appliedKeys.join("-") : "default",
+  buildKey: (args, appliedKeys) =>
+    `${appliedKeys.join("-")}-${args.cpMovement ?? "none"}`,
 });
 
 export const Ongoing: Story = {

--- a/front_end/src/stories/feed_card/continuous_question/continuous_question.stories.tsx
+++ b/front_end/src/stories/feed_card/continuous_question/continuous_question.stories.tsx
@@ -4,6 +4,10 @@ import ConsumerPostCard from "@/components/consumer_post_card";
 import PostCard from "@/components/post_card";
 import { createConditionalRenderer } from "@/stories/utils/renderer/conditional-renderer";
 import { stripUserPredictions } from "@/stories/utils/transforms/strip_user_predictions";
+import {
+  CpMovementState,
+  withCpMovement,
+} from "@/stories/utils/transforms/with_cp_movement";
 import { PostWithForecasts } from "@/types/post";
 
 import { getMockData } from "./mock_data";
@@ -16,6 +20,7 @@ type StoryProps = {
   forCommunityFeed?: boolean;
   isConsumer?: boolean;
   hideUserPredictions?: boolean;
+  cpMovement?: CpMovementState;
 };
 
 const meta = {
@@ -23,18 +28,19 @@ const meta = {
   component: PostCard,
   argTypes: {
     isConsumer: {
-      control: {
-        type: "boolean",
-      },
+      control: { type: "boolean" },
     },
     hideUserPredictions: {
       control: { type: "boolean" },
       description: "Hide user predictions in graph cards",
     },
+    cpMovement: {
+      control: { type: "radio" },
+      options: ["up", "down", "none"],
+      description: "Toggle CP Movement (up, down, none)",
+    },
     forCommunityFeed: {
-      table: {
-        disable: true,
-      },
+      table: { disable: true },
     },
   },
 } satisfies Meta<StoryProps>;
@@ -47,6 +53,14 @@ const render = createConditionalRenderer<StoryProps>({
   componentSelector: (args) => (args.isConsumer ? ConsumerPostCard : PostCard),
   transformRules: [
     {
+      key: "cpMovement",
+      when: () => true,
+      transform: (args) => ({
+        ...args,
+        post: withCpMovement(args.post, args.cpMovement ?? "none"),
+      }),
+    },
+    {
       key: "hideUserPredictions",
       when: (args) => !!args.hideUserPredictions,
       transform: (args) => ({
@@ -55,8 +69,8 @@ const render = createConditionalRenderer<StoryProps>({
       }),
     },
   ],
-  buildKey: (_args, appliedKeys) =>
-    appliedKeys.length > 0 ? appliedKeys.join("-") : "default",
+  buildKey: (args, appliedKeys) =>
+    `${appliedKeys.join("-")}-${args.cpMovement ?? "none"}`,
 });
 
 export const Ongoing: Story = {
@@ -65,6 +79,7 @@ export const Ongoing: Story = {
     post: ongoingArgs as unknown as PostWithForecasts,
     isConsumer: false,
     hideUserPredictions: false,
+    cpMovement: "none",
   },
 };
 
@@ -80,16 +95,13 @@ export const CpHidden: Story = {
         status: "open",
         resolution: null,
         aggregations: {
-          recency_weighted: {
-            history: [],
-          },
+          recency_weighted: { history: [] },
         },
-        my_forecasts: {
-          history: [],
-        },
+        my_forecasts: { history: [] },
       },
     } as unknown as PostWithForecasts,
     hideUserPredictions: false,
+    cpMovement: "none",
   },
 };
 
@@ -106,6 +118,7 @@ export const Closed: Story = {
       },
     } as unknown as PostWithForecasts,
     hideUserPredictions: false,
+    cpMovement: "none",
   },
 };
 
@@ -115,10 +128,9 @@ export const Resolved: Story = {
     post: {
       ...closedArgs,
       status: "resolved",
-      question: {
-        ...closedArgs.question,
-      },
+      question: { ...closedArgs.question },
     } as unknown as PostWithForecasts,
     hideUserPredictions: false,
+    cpMovement: "none",
   },
 };

--- a/front_end/src/stories/feed_card/date_question/date_question.stories.tsx
+++ b/front_end/src/stories/feed_card/date_question/date_question.stories.tsx
@@ -4,6 +4,10 @@ import ConsumerPostCard from "@/components/consumer_post_card";
 import PostCard from "@/components/post_card";
 import { createConditionalRenderer } from "@/stories/utils/renderer/conditional-renderer";
 import { stripUserPredictions } from "@/stories/utils/transforms/strip_user_predictions";
+import {
+  CpMovementState,
+  withCpMovement,
+} from "@/stories/utils/transforms/with_cp_movement";
 import { PostWithForecasts } from "@/types/post";
 
 import { getMockData } from "./mock_data";
@@ -16,6 +20,7 @@ type StoryProps = {
   forCommunityFeed?: boolean;
   isConsumer?: boolean;
   hideUserPredictions?: boolean;
+  cpMovement?: CpMovementState;
 };
 
 const meta = {
@@ -29,10 +34,13 @@ const meta = {
       control: { type: "boolean" },
       description: "Hide user predictions in graph cards",
     },
+    cpMovement: {
+      control: { type: "radio" },
+      options: ["up", "down", "none"],
+      description: "Toggle CP Movement (up, down, none)",
+    },
     forCommunityFeed: {
-      table: {
-        disable: true,
-      },
+      table: { disable: true },
     },
   },
 } satisfies Meta<StoryProps>;
@@ -45,6 +53,14 @@ const render = createConditionalRenderer<StoryProps>({
   componentSelector: (args) => (args.isConsumer ? ConsumerPostCard : PostCard),
   transformRules: [
     {
+      key: "cpMovement",
+      when: () => true,
+      transform: (args) => ({
+        ...args,
+        post: withCpMovement(args.post, args.cpMovement ?? "none"),
+      }),
+    },
+    {
       key: "hideUserPredictions",
       when: (args) => args.hideUserPredictions === true,
       transform: (args) => ({
@@ -53,6 +69,8 @@ const render = createConditionalRenderer<StoryProps>({
       }),
     },
   ],
+  buildKey: (args, appliedKeys) =>
+    `${appliedKeys.join("-")}-${args.cpMovement ?? "none"}`,
 });
 
 export const Ongoing: Story = {
@@ -61,6 +79,7 @@ export const Ongoing: Story = {
     post: ongoingArgs as unknown as PostWithForecasts,
     isConsumer: false,
     hideUserPredictions: false,
+    cpMovement: "none",
   },
 };
 
@@ -82,6 +101,7 @@ export const CpHidden: Story = {
       },
     } as unknown as PostWithForecasts,
     hideUserPredictions: false,
+    cpMovement: "none",
   },
 };
 
@@ -96,6 +116,7 @@ export const Closed: Story = {
       },
     } as unknown as PostWithForecasts,
     hideUserPredictions: false,
+    cpMovement: "none",
   },
 };
 
@@ -111,5 +132,6 @@ export const Resolved: Story = {
       },
     } as unknown as PostWithForecasts,
     hideUserPredictions: false,
+    cpMovement: "none",
   },
 };

--- a/front_end/src/stories/utils/transforms/with_cp_movement.ts
+++ b/front_end/src/stories/utils/transforms/with_cp_movement.ts
@@ -1,0 +1,50 @@
+import { PostWithForecasts } from "@/types/post";
+import { MovementDirection } from "@/types/question";
+
+export type CpMovementState = "up" | "down" | "none";
+
+export const withCpMovement = (
+  post: PostWithForecasts,
+  state: CpMovementState
+): PostWithForecasts => {
+  const movementValue =
+    state === "none"
+      ? null
+      : {
+          divergence: 1,
+          direction:
+            state === "up" ? MovementDirection.UP : MovementDirection.DOWN,
+          movement: state === "up" ? 0.058 : -0.058,
+          period: "604800.0",
+        };
+
+  const applyToQuestion = (q: any) => ({
+    ...q,
+    aggregations: {
+      ...q.aggregations,
+      recency_weighted: {
+        ...q.aggregations?.recency_weighted,
+        movement: movementValue,
+      },
+    },
+  });
+
+  if (post.group_of_questions) {
+    return {
+      ...post,
+      group_of_questions: {
+        ...post.group_of_questions,
+        questions: post.group_of_questions.questions.map((q) =>
+          applyToQuestion(q)
+        ),
+      },
+    };
+  }
+  if (post.question) {
+    return {
+      ...post,
+      question: applyToQuestion(post.question),
+    };
+  }
+  return post;
+};


### PR DESCRIPTION
Address a [followup](https://github.com/Metaculus/metaculus/pull/3181#issuecomment-3135763021) from previous PR

This PR introduces a radio group control to the feed card storybook configuration, allowing selection of community prediction (CP) movements (up, down, none) for easier testing and visualization in Storybook.

<img width="1000" height="268" alt="image" src="https://github.com/user-attachments/assets/029d44d9-e427-493a-8984-a16b636d7507" />

<img width="1044" height="482" alt="image" src="https://github.com/user-attachments/assets/3aad1e05-f96b-4dce-8717-5d9da224fa08" />

<img width="1178" height="498" alt="image" src="https://github.com/user-attachments/assets/cbddd81d-b82f-4ad2-9e97-7057ec8fda7d" />
