### PR TITLE
Fix Play dramatiq ConcurrentRateLimiter

### DIFF
--- a/metaculus_web/settings.py
+++ b/metaculus_web/settings.py
@@ -302,10 +302,7 @@ DRAMATIQ_BROKER = {
         "django_dramatiq.middleware.DbConnectionsMiddleware",
     ],
 }
-DRAMATIQ_RATE_LIMITER_BACKEND_OPTIONS = {
-    # Setting redis db to 1 for the MQ storage
-    "url": f"{REDIS_URL}/2?{REDIS_URL_CONFIG}",
-}
+
 
 # Setting StubBroker broker for unit tests environment
 # Integration tests should run as the real env

--- a/utils/dramatiq.py
+++ b/utils/dramatiq.py
@@ -8,7 +8,11 @@ from dramatiq.rate_limits.backends import RedisBackend
 
 
 def get_redis_backend():
-    return RedisBackend(**settings.DRAMATIQ_RATE_LIMITER_BACKEND_OPTIONS)
+    """
+    ConcurrentRateLimiter uses the same Redis db index as redis queue
+    """
+
+    return RedisBackend(**settings.DRAMATIQ_BROKER["OPTIONS"])
 
 
 def concurrency_retries(max_retries=20):


### PR DESCRIPTION
Currently, our play workers do not work because of redis db absence -- https://metaculus.sentry.io/issues/6600528321/?environment=play&project=4507883238129664&query=is%3Aunresolved&referrer=issue-stream