### PR TITLE
Auto compact mode question header info

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_info.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_info.tsx
@@ -1,6 +1,6 @@
 import { faEllipsis } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import React, { FC, useEffect, useRef, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 
 import ForecastersCounter from "@/app/(main)/questions/components/forecaster_counter";
 import { PostDropdownMenu } from "@/components/post_actions";
@@ -8,6 +8,7 @@ import CommentStatus from "@/components/post_card/basic_post_card/comment_status
 import PostVoter from "@/components/post_card/basic_post_card/post_voter";
 import PostStatus from "@/components/post_status";
 import Button from "@/components/ui/button";
+import useContainerSize from "@/hooks/use_container_size";
 import { PostWithForecasts } from "@/types/post";
 import cn from "@/utils/core/cn";
 import { getPostLink } from "@/utils/navigation";
@@ -20,29 +21,15 @@ type Props = {
 
 const QuestionHeaderInfo: FC<Props> = ({ post, className }) => {
   const resolutionData = extractPostResolution(post);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const { ref, width } = useContainerSize<HTMLDivElement>();
   const [shouldUseCompact, setShouldUseCompact] = useState(false);
 
   useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const resizeObserver = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const width = entry.contentRect.width;
-        // Once it hits >500px, always keep it compact
-        if (width > 500) {
-          setShouldUseCompact(true);
-        }
-      }
-    });
-
-    resizeObserver.observe(container);
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, []);
+    // Once it hits >500px, always keep it compact
+    if (width > 500) {
+      setShouldUseCompact(true);
+    }
+  }, [width]);
 
   return (
     <div
@@ -51,7 +38,7 @@ const QuestionHeaderInfo: FC<Props> = ({ post, className }) => {
         className
       )}
     >
-      <div className="flex items-center gap-1.5 lg:gap-2" ref={containerRef}>
+      <div className="flex items-center gap-1.5 lg:gap-2" ref={ref}>
         <PostVoter post={post} />
 
         {/* CommentStatus - compact on small screens, full on large screens */}

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_info.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_info.tsx
@@ -1,7 +1,8 @@
 import { faEllipsis } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import React, { FC } from "react";
+import React, { FC, useEffect, useRef, useState } from "react";
 
+import ForecastersCounter from "@/app/(main)/questions/components/forecaster_counter";
 import { PostDropdownMenu } from "@/components/post_actions";
 import CommentStatus from "@/components/post_card/basic_post_card/comment_status";
 import PostVoter from "@/components/post_card/basic_post_card/post_voter";
@@ -12,8 +13,6 @@ import cn from "@/utils/core/cn";
 import { getPostLink } from "@/utils/navigation";
 import { extractPostResolution } from "@/utils/questions/resolution";
 
-import ForecastersCounter from "../../../../../components/forecaster_counter";
-
 type Props = {
   post: PostWithForecasts;
   className?: string;
@@ -21,6 +20,29 @@ type Props = {
 
 const QuestionHeaderInfo: FC<Props> = ({ post, className }) => {
   const resolutionData = extractPostResolution(post);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [shouldUseCompact, setShouldUseCompact] = useState(false);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const width = entry.contentRect.width;
+        // Once it hits >500px, always keep it compact
+        if (width > 500) {
+          setShouldUseCompact(true);
+        }
+      }
+    });
+
+    resizeObserver.observe(container);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
 
   return (
     <div
@@ -29,7 +51,7 @@ const QuestionHeaderInfo: FC<Props> = ({ post, className }) => {
         className
       )}
     >
-      <div className="flex items-center gap-1.5 lg:gap-2">
+      <div className="flex items-center gap-1.5 lg:gap-2" ref={containerRef}>
         <PostVoter post={post} />
 
         {/* CommentStatus - compact on small screens, full on large screens */}
@@ -59,6 +81,7 @@ const QuestionHeaderInfo: FC<Props> = ({ post, className }) => {
           post={post}
           resolution={resolutionData}
           className="hidden md:flex"
+          compact={shouldUseCompact}
         />
 
         {/* ForecastersCounter - compact on small screens, full on large screens */}


### PR DESCRIPTION
Added auto-compact mode for Question Header Info controls

Enough space:
<img width="769" height="196" alt="image" src="https://github.com/user-attachments/assets/d86759dd-8094-4eea-a060-a56d84d1bee7" />
Compact:
<img width="770" height="201" alt="image" src="https://github.com/user-attachments/assets/dcb326c2-bdce-4294-b4bf-5048613f46ab" />
