### PR TITLE
Create collapse all button in group question editor

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -1421,5 +1421,7 @@
   "registrationInfoAbility4": "Připojte se k diskuzi s nejlepšími prognostiky na světě",
   "registrationInfoAbility5": "Předkládejte vlastní otázky komunitě",
   "registrationInfoAbility6": "Prořízněte si přes šum, abyste sledovali důležité příběhy",
+  "expandAll": "Rozbalit vše",
+  "collapseAll": "Sbalit vše",
   "withdrawAfterPercentSetting2": "z celkové životnosti otázky"
 }

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1417,5 +1417,7 @@
   "pageNotFound": "Page not found",
   "thinkSupposedPageNote": "If you think there's supposed to be a page here, <link>send a note to us</link> and we'll try to get it fixed.",
   "entryExcluded": "This entry is not eligible to earn rank or prize. This is where they would have placed if they were eligible.",
+  "expandAll": "Expand All",
+  "collapseAll": "Collapse All",
   "returnToHomePage": "Return to Home page"
 }

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -1421,5 +1421,7 @@
   "registrationInfoAbility4": "Únete a la conversación con los mejores pronosticadores del mundo",
   "registrationInfoAbility5": "Envía tus propias preguntas a la comunidad",
   "registrationInfoAbility6": "Despeja el ruido para seguir las historias que importan",
+  "expandAll": "Expandir todo",
+  "collapseAll": "Colapsar todo",
   "withdrawAfterPercentSetting2": "del tiempo de vida total de la pregunta"
 }

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -1419,5 +1419,7 @@
   "registrationInfoAbility4": "Junte-se à conversa com os melhores previsores do mundo",
   "registrationInfoAbility5": "Envie suas próprias perguntas para a comunidade",
   "registrationInfoAbility6": "Corte o ruído para acompanhar as histórias que importam",
+  "expandAll": "Expandir Tudo",
+  "collapseAll": "Recolher Tudo",
   "withdrawAfterPercentSetting2": "da duração total da pergunta"
 }

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -1418,5 +1418,7 @@
   "registrationInfoAbility4": "與世界上最優秀的預測者一起參與討論",
   "registrationInfoAbility5": "向社群提交自己的問題",
   "registrationInfoAbility6": "從嘈雜中篩選出重要的故事",
+  "expandAll": "全部展開",
+  "collapseAll": "全部摺疊",
   "withdrawAfterPercentSetting2": "問題總生命周期後撤回"
 }

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -1423,5 +1423,7 @@
   "registrationInfoAbility4": "与世界顶级预测者一起参与讨论",
   "registrationInfoAbility5": "向社区提交你自己的问题",
   "registrationInfoAbility6": "剖析噪音以追踪重要的故事",
+  "expandAll": "全部展开",
+  "collapseAll": "全部折叠",
   "withdrawAfterPercentSetting2": "的问题总生命周期"
 }

--- a/front_end/src/components/forecast_maker/container.tsx
+++ b/front_end/src/components/forecast_maker/container.tsx
@@ -16,7 +16,7 @@ const ForecastMakerContainer: FC<PropsWithChildren<Props>> = ({
     <section
       id="prediction-section"
       className={cn(
-        "my-4 rounded bg-blue-200 p-3 dark:bg-blue-200-dark",
+        "relative my-4 rounded bg-blue-200 p-3 dark:bg-blue-200-dark",
         className
       )}
     >

--- a/front_end/src/components/forecast_maker/continuous_group_accordion/group_forecast_accordion.tsx
+++ b/front_end/src/components/forecast_maker/continuous_group_accordion/group_forecast_accordion.tsx
@@ -2,6 +2,7 @@ import { useTranslations } from "next-intl";
 import { FC, ReactNode, useMemo, useState } from "react";
 
 import ForecastMakerGroupCopyMenu from "@/components/forecast_maker/forecast_maker_group/forecast_maker_group_copy_menu";
+import Button from "@/components/ui/button";
 import { useAuth } from "@/contexts/auth_context";
 import { useHideCP } from "@/contexts/cp_context";
 import { ContinuousForecastInputType } from "@/types/charts";
@@ -125,6 +126,9 @@ const GroupForecastAccordion: FC<Props> = ({
       [options]
     );
 
+  const [expandAll, setExpandAll] = useState(false);
+  const toggleExpandAll = () => setExpandAll((prev) => !prev);
+
   const homogeneousUnit = useMemo(() => {
     const units = Array.from(new Set(options.map((obj) => obj.question.unit)));
 
@@ -135,6 +139,16 @@ const GroupForecastAccordion: FC<Props> = ({
 
   return (
     <div className="w-full">
+      <div className="absolute right-4 top-4 mb-2 hidden justify-end sm:flex">
+        <Button
+          onClick={toggleExpandAll}
+          size="xs"
+          variant="tertiary"
+          className="ml-auto"
+        >
+          {expandAll ? t("collapseAll") : t("expandAll")}
+        </Button>
+      </div>
       {!!activeOptions.length && (
         <div className="mb-0.5 mt-2 flex w-full gap-0.5 text-left text-xs font-bold text-blue-700 dark:text-blue-700-dark">
           <div className="flex shrink grow items-center overflow-hidden bg-blue-600/15 py-1 dark:bg-blue-400/15">
@@ -159,8 +173,9 @@ const GroupForecastAccordion: FC<Props> = ({
           <AccordionItem
             option={option}
             showCP={showCP}
-            key={option.id}
+            key={`${option.id}-expand-${expandAll}`}
             forcedOpenId={forcedOpenId}
+            forcedExpandAll={expandAll}
             subQuestionId={subQuestionId}
             type={QuestionStatus.OPEN}
             unit={
@@ -209,8 +224,9 @@ const GroupForecastAccordion: FC<Props> = ({
             option={option}
             showCP={true}
             subQuestionId={subQuestionId}
+            forcedExpandAll={expandAll}
             type={QuestionStatus.CLOSED}
-            key={option.id}
+            key={`${option.id}-expand-${expandAll}`}
           >
             <ContinuousInputWrapper
               option={option}
@@ -251,8 +267,9 @@ const GroupForecastAccordion: FC<Props> = ({
             option={option}
             showCP={true}
             subQuestionId={subQuestionId}
+            forcedExpandAll={expandAll}
             type={QuestionStatus.RESOLVED}
-            key={option.id}
+            key={`${option.id}-expand-${expandAll}`}
           >
             <ContinuousInputWrapper
               option={option}

--- a/front_end/src/components/forecast_maker/continuous_group_accordion/group_forecast_accordion_item.tsx
+++ b/front_end/src/components/forecast_maker/continuous_group_accordion/group_forecast_accordion_item.tsx
@@ -33,10 +33,20 @@ type AccordionItemProps = {
   type: QuestionStatus.OPEN | QuestionStatus.CLOSED | QuestionStatus.RESOLVED;
   unit?: string;
   forcedOpenId?: number;
+  forcedExpandAll?: boolean;
 };
 
 const AccordionItem: FC<PropsWithChildren<AccordionItemProps>> = memo(
-  ({ option, showCP, children, subQuestionId, type, unit, forcedOpenId }) => {
+  ({
+    option,
+    showCP,
+    children,
+    subQuestionId,
+    type,
+    unit,
+    forcedOpenId,
+    forcedExpandAll,
+  }) => {
     const locale = useLocale();
     const [isModalOpen, setIsModalOpen] = useState(false);
     const {
@@ -125,7 +135,9 @@ const AccordionItem: FC<PropsWithChildren<AccordionItemProps>> = memo(
         <Disclosure
           as="div"
           defaultOpen={
-            subQuestionId === option.id || forcedOpenId === option.id
+            forcedExpandAll ||
+            subQuestionId === option.id ||
+            forcedOpenId === option.id
           }
           id={`group-option-${option.id}`}
           // Change the key so that when forceOpen toggles, Disclosure re-mounts


### PR DESCRIPTION
Closes #2619

Implementation uses a key-based rerender strategy to force  to re-evaluate `defaultOpen`, since Headless UI does not support controlled open/onChange props