### PR TITLE
always show (spot_)peer and (spot_)baseline in score display area

### DIFF
--- a/front_end/src/components/forecast_maker/resolution/score_display.tsx
+++ b/front_end/src/components/forecast_maker/resolution/score_display.tsx
@@ -127,8 +127,12 @@ const ScoreDisplay: FC<Props> = ({ question, className, variant }) => {
   ];
   const primaryScoreBoxes = [];
   const secondaryScoreBoxes = [];
+  const spotScores = question.default_score_type.startsWith("spot");
   for (const { key, scoreBox } of keyedScoreBoxes) {
-    if (key === question.default_score_type) {
+    if (
+      (spotScores && (key === "spot_baseline" || key === "spot_peer")) ||
+      (!spotScores && (key === "baseline" || key === "peer"))
+    ) {
       primaryScoreBoxes.push(scoreBox);
     } else {
       secondaryScoreBoxes.push(scoreBox);


### PR DESCRIPTION
addresses https://metaculus.slack.com/archives/C01Q9AQBVHB/p1753110192268749?thread_ts=1752940247.221389&cid=C01Q9AQBVHB