### PR TITLE
Revert "Moved Dramatiq rate limit redis db to the same db as queues (…

### DIFF
--- a/metaculus_web/settings.py
+++ b/metaculus_web/settings.py
@@ -302,7 +302,10 @@ DRAMATIQ_BROKER = {
         "django_dramatiq.middleware.DbConnectionsMiddleware",
     ],
 }
-
+DRAMATIQ_RATE_LIMITER_BACKEND_OPTIONS = {
+    # Setting redis db to 1 for the MQ storage
+    "url": f"{REDIS_URL}/2?{REDIS_URL_CONFIG}",
+}
 
 # Setting StubBroker broker for unit tests environment
 # Integration tests should run as the real env

--- a/utils/dramatiq.py
+++ b/utils/dramatiq.py
@@ -8,11 +8,7 @@ from dramatiq.rate_limits.backends import RedisBackend
 
 
 def get_redis_backend():
-    """
-    ConcurrentRateLimiter uses the same Redis db index as redis queue
-    """
-
-    return RedisBackend(**settings.DRAMATIQ_BROKER["OPTIONS"])
+    return RedisBackend(**settings.DRAMATIQ_RATE_LIMITER_BACKEND_OPTIONS)
 
 
 def concurrency_retries(max_retries=20):


### PR DESCRIPTION
…#2872)"

This reverts commit 4c08f3178e62a584d8f3199e488419fce4e51187.