### PR TITLE
Resolution of date question isn't consistent between chip and forecasting area

### DIFF
--- a/front_end/src/utils/formatters/resolution.ts
+++ b/front_end/src/utils/formatters/resolution.ts
@@ -1,4 +1,5 @@
-import { format, isValid } from "date-fns";
+import { isValid } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { capitalize } from "lodash";
 
 import { QuestionType, Scaling } from "@/types/question";
@@ -10,7 +11,6 @@ import {
 } from "@/utils/formatters/prediction";
 import { isUnsuccessfullyResolved } from "@/utils/questions/resolution";
 import { formatValueUnit } from "@/utils/questions/units";
-import { formatInTimeZone } from "date-fns-tz";
 
 export function formatResolution({
   resolution,


### PR DESCRIPTION
Fixes #3257

This PR fixes timestamp inconsistencies caused between different locales of the server and client

<img width="1326" height="1844" alt="image" src="https://github.com/user-attachments/assets/1ebaca76-d99d-4c38-8851-a9566eaceb26" />
