### PR TITLE
Improve comment error feedback

### DIFF
--- a/front_end/src/components/comment_feed/validate_comment.tsx
+++ b/front_end/src/components/comment_feed/validate_comment.tsx
@@ -21,7 +21,7 @@ export function validateComment(
         {(tags) =>
           t.rich("commentTooShort", {
             ...tags,
-            info: (chunks) => <p className="mt-2 text-sm">{chunks}</p>,
+            info: (chunks) => <p className="my-0 mt-2 text-sm">{chunks}</p>,
             link: (chunks) => <Link href="/help/guidelines/">{chunks}</Link>,
           })
         }


### PR DESCRIPTION
This PR adds client-side validation feedback to the CommentEditor so new accounts see a clear error when trying to post comments under 30 characters.
Slack thread: https://metaculus.slack.com/archives/C02JGTBC7DJ/p1754839367744259

<img width="1378" height="470" alt="image" src="https://github.com/user-attachments/assets/b8af9d9b-3bd2-450f-a230-a89fde60cb60" />
