### PR TITLE
Weekly top comments compute data

### DIFF
--- a/comments/jobs.py
+++ b/comments/jobs.py
@@ -1,0 +1,28 @@
+from datetime import timedelta
+
+import dramatiq
+from django.utils import timezone
+
+from comments.services.common import update_top_comments_of_week
+
+
+@dramatiq.actor
+def update_current_top_comments_of_week():
+    # Update the weekly top comments list for the current week and the one before.
+    # We update the week before because the top comments scores are based on
+    # commment votes, key factor votes, and change my mind data collected a week
+    # after the comment was created (which is still ongoing)
+    today = timezone.now().date()
+    weekday = today.weekday()
+    if weekday == 6:  # today is Sunday, use this Sunday
+        week_start_date = today
+    else:
+        week_start_date = today - timedelta(
+            days=weekday + 1  # use +1 to get the previous Sunday
+        )
+
+    update_top_comments_of_week(week_start_date)
+
+    # Update the week before
+    week_start_date = week_start_date - timedelta(days=7)
+    update_top_comments_of_week(week_start_date)

--- a/comments/management/commands/update_top_comments_of_week_batch.py
+++ b/comments/management/commands/update_top_comments_of_week_batch.py
@@ -1,0 +1,79 @@
+import datetime
+from django.core.management.base import BaseCommand
+
+from comments.services.common import update_top_comments_of_week
+
+
+class Command(BaseCommand):
+    help = "Update top comments of the week for multiple weeks going backwards from a start date"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "week_start_date",
+            type=str,
+            help="Start date for the week in YYYY-MM-DD format (e.g., 2024-01-01)",
+        )
+        parser.add_argument(
+            "weeks_count",
+            type=int,
+            help="Number of weeks to process going backwards from the start date",
+        )
+
+    def handle(self, *args, **options):
+        try:
+            # Parse the week start date
+            week_start_date = datetime.datetime.strptime(
+                options["week_start_date"], "%Y-%m-%d"
+            ).date()
+        except ValueError:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Invalid date format: {options['week_start_date']}. "
+                    "Please use YYYY-MM-DD format (e.g., 2024-01-01)"
+                )
+            )
+            return
+
+        weeks_count = options["weeks_count"]
+
+        if weeks_count <= 0:
+            self.stdout.write(
+                self.style.ERROR("weeks_count must be a positive integer")
+            )
+            return
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Starting to update top comments for {weeks_count} weeks "
+                f"starting from {week_start_date}"
+            )
+        )
+
+        # Process each week going backwards from the start date
+        for i in range(weeks_count):
+            current_week_start = week_start_date - datetime.timedelta(weeks=i)
+
+            self.stdout.write(
+                f"Processing week starting {current_week_start} "
+                f"({i + 1}/{weeks_count})"
+            )
+
+            try:
+                update_top_comments_of_week(current_week_start)
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"✓ Successfully updated top comments for week starting {current_week_start}"
+                    )
+                )
+            except Exception as e:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"✗ Failed to update top comments for week starting {current_week_start}: {str(e)}"
+                    )
+                )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Completed processing {weeks_count} weeks of top comments"
+            )
+        )

--- a/comments/views.py
+++ b/comments/views.py
@@ -26,7 +26,6 @@ from comments.serializers import (
 )
 from comments.services.common import (
     set_comment_excluded_from_week_top,
-    update_top_comments_of_week,
     create_comment,
     pin_comment,
     unpin_comment,
@@ -389,9 +388,6 @@ def comments_of_week_view(request: Request):
     week_start_date = serializers.DateField(input_formats=["%Y-%m-%d"]).run_validation(
         request.query_params.get("start_date")
     )
-
-    # TODO: Recompute the weekly top comments for the current and previous week since
-    update_top_comments_of_week(week_start_date)
 
     # Admins can see all top (max 18) candidates for the weekly top comments
     top_comments_of_week_entries = CommentsOfTheWeekEntry.objects.filter(

--- a/misc/management/commands/cron.py
+++ b/misc/management/commands/cron.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django_dramatiq.tasks import delete_old_tasks
 
+from comments.jobs import update_current_top_comments_of_week
 from misc.jobs import sync_itn_articles
 from notifications.jobs import job_send_notification_groups
 from posts.jobs import (
@@ -194,3 +195,14 @@ class Command(BaseCommand):
             logger.info("Stopping scheduler...")
             scheduler.shutdown()
             logger.info("Scheduler shut down successfully!")
+
+        #
+        # Comment Jobs
+        #
+        scheduler.add_job(
+            close_old_connections(update_current_top_comments_of_week.send),
+            trigger=CronTrigger.from_crontab("0 * * * *"),  # Every hour
+            id="update_current_top_comments_of_week",
+            max_instances=1,
+            replace_existing=True,
+        )


### PR DESCRIPTION
Adds a new command to compute past week top comments and a cron job to do it hourly for the last 2 weeks (which need constant updates)