### PR TITLE
Tournaments order regression

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_list.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_list.tsx
@@ -39,9 +39,10 @@ const TournamentsList: FC<Props> = ({
   const { params } = useSearchParams();
 
   const searchString = params.get(TOURNAMENTS_SEARCH) ?? "";
-  const sortBy = disableClientSort
+  const sortBy: TournamentsSortBy | null = disableClientSort
     ? null
-    : (params.get(TOURNAMENTS_SORT) as TournamentsSortBy | null);
+    : (params.get(TOURNAMENTS_SORT) as TournamentsSortBy | null) ??
+      TournamentsSortBy.StartDateDesc;
 
   const filteredItems = useMemo(
     () => filterItems(items, decodeURIComponent(searchString), sortBy),


### PR DESCRIPTION
Fix a regression introduced in #3295 when missing `sort_by` param in the URL resulted in wrong order
Slack thread: https://metaculus.slack.com/archives/C01Q9AQBVHB/p1755092359423909