### PR TITLE
Prediction text should wrap

### DIFF
--- a/front_end/src/components/forecast_maker/forecast_maker_question/prediction_success_box.tsx
+++ b/front_end/src/components/forecast_maker/forecast_maker_question/prediction_success_box.tsx
@@ -32,12 +32,10 @@ const PredictionSuccessBox: FC<PredictionSuccessBoxProps> = ({
         className
       )}
     >
-      <h4 className="m-0">
+      <h4 className="m-0 text-balance">
         {t("youPredicted")}{" "}
-        <span className="text-orange-800 dark:text-orange-800-dark">
-          <span className="whitespace-nowrap font-bold text-orange-800 dark:text-orange-800-dark">
-            {forecastValue}
-          </span>
+        <span className="whitespace-normal break-words font-bold text-orange-800 dark:text-orange-800-dark">
+          {forecastValue}
         </span>
       </h4>
       <div className="mx-1 flex flex-wrap items-center justify-center gap-2">


### PR DESCRIPTION
Fixes #3253

<img width="594" height="446" alt="image" src="https://github.com/user-attachments/assets/ce1a8774-c826-4bd3-9e0f-4bb86e44f906" />
