### PR TITLE
If you typo a username in "Invite Users to Project," have to refresh to try again

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/components/members/members_invite.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/components/members/members_invite.tsx
@@ -39,6 +39,7 @@ const MembersInvite: FC<Props> = ({ projectId, members }) => {
 
       setIsSubmitting(true);
       const responses = await inviteProjectUsers(projectId, usernames);
+      setIsSubmitting(false);
 
       if (responses && "errors" in responses && !!responses.errors) {
         setSubmitErrors(responses.errors);


### PR DESCRIPTION
Fixes #1989