### PR TITLE
Bullet lists add empty line below

### DIFF
--- a/front_end/src/components/markdown_editor/initialized_editor.tsx
+++ b/front_end/src/components/markdown_editor/initialized_editor.tsx
@@ -21,7 +21,7 @@ import {
 } from "@mdxeditor/editor";
 import { BeautifulMentionsTheme } from "lexical-beautiful-mentions";
 import { useTranslations } from "next-intl";
-import React, {
+import {
   FC,
   ForwardedRef,
   useCallback,
@@ -47,6 +47,7 @@ import { processMarkdown } from "./helpers";
 import { equationPlugin } from "./plugins/equation";
 import { linkPlugin } from "./plugins/link";
 import { mentionsPlugin } from "./plugins/mentions";
+import { trimTrailingParagraphPlugin } from "./plugins/trim_trailing_plugin";
 
 type EditorMode = "write" | "read";
 
@@ -253,6 +254,7 @@ const InitializedMarkdownEditor: FC<
         jsxPlugin({ jsxComponentDescriptors }),
         ...(editorDiffSourcePlugin ? [editorDiffSourcePlugin] : []),
         ...(editorToolbarPlugin ? [editorToolbarPlugin] : []),
+        ...(mode === "read" ? [trimTrailingParagraphPlugin()] : []),
       ]}
       lexicalTheme={{
         beautifulMentions: beautifulMentionsTheme,

--- a/front_end/src/components/markdown_editor/plugins/trim_trailing_plugin.tsx
+++ b/front_end/src/components/markdown_editor/plugins/trim_trailing_plugin.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { realmPlugin, createRootEditorSubscription$ } from "@mdxeditor/editor";
+import { $getRoot, $isParagraphNode } from "lexical";
+
+export const trimTrailingParagraphPlugin = realmPlugin({
+  init(realm) {
+    realm.pub(createRootEditorSubscription$, (editor) => {
+      const trim = () => {
+        editor.update(() => {
+          const root = $getRoot();
+          const children = root.getChildren();
+          if (children.length <= 1) return;
+
+          const last = children[children.length - 1];
+          if ($isParagraphNode(last)) {
+            const text = last
+              .getTextContent()
+              .replace(/\u200B/g, "")
+              .trim();
+            if (text === "" && last.getChildrenSize() <= 1) {
+              last.remove();
+            }
+          }
+        });
+      };
+
+      trim();
+      return editor.registerUpdateListener(() => {
+        trim();
+      });
+    });
+  },
+});


### PR DESCRIPTION
Fixes #1979

Introduce a custom plugin to trim unexpected trailing empty lines

<img width="1412" height="406" alt="image" src="https://github.com/user-attachments/assets/2e2023d7-584d-4358-89f9-391634dbcfd2" />
