### PR TITLE
remove logic breaking when zero_point is above range

### DIFF
--- a/utils/the_math/formulas.py
+++ b/utils/the_math/formulas.py
@@ -85,9 +85,7 @@ def unscaled_location_to_scaled_location(
         return unscaled_location
 
     if zero_point is not None:
-        deriv_ratio = (range_max - zero_point) / max(
-            (range_min - zero_point), 0.0000001
-        )
+        deriv_ratio = (range_max - zero_point) / (range_min - zero_point)
         return range_min + (range_max - range_min) * (
             deriv_ratio**unscaled_location - 1
         ) / (deriv_ratio - 1)
@@ -107,9 +105,7 @@ def scaled_location_to_unscaled_location(
         question.range_min,
     )
     if zero_point is not None:
-        deriv_ratio = (range_max - zero_point) / max(
-            (range_min - zero_point), 0.0000001
-        )
+        deriv_ratio = (range_max - zero_point) / (range_min - zero_point)
         return (
             np.log(
                 (scaled_location - range_min) * (deriv_ratio - 1)


### PR DESCRIPTION
The logic was initially put in there during the rewrite to secure against a divide by zero error, but that error shouldn't occur and if it does it should fail loudly. Said fix didn't account for when the zero point is above the range.