### PR TITLE
fix uncommon floating point error in cdf length determination

### DIFF
--- a/front_end/src/utils/math.ts
+++ b/front_end/src/utils/math.ts
@@ -90,7 +90,7 @@ export function cdfFromSliders(
   const params = logisticDistributionParamsFromSliders(left, center, right);
   const step = 1 / inboundOutcomeCount;
   const xArr = Array.from(
-    { length: Math.floor(1 / step) + 1 },
+    { length: inboundOutcomeCount + 1 },
     (_, i) => i * step
   );
   let cdf = [


### PR DESCRIPTION
closes #3348

No reason to first calculate step by:
`step = 1 / inboundOutcomeCount`
followed by using: `Math.floor(1 / step)`
That's just begging for a floating point error.
Using `Math.round` would work just fine, but even better is to just use the constant directly.