### PR TITLE
Unified sentry config and made transactions less noisy

### DIFF
--- a/front_end/sentry.edge.config.ts
+++ b/front_end/sentry.edge.config.ts
@@ -1,16 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
-import {
-  beforeSentryAlertSend,
-  SENTRY_IGNORE_ERRORS,
-} from "@/utils/core/errors";
+import { buildSentryOptions } from "@/sentry/options";
 
 if (!!process.env.PUBLIC_FRONTEND_SENTRY_DSN) {
-  Sentry.init({
-    environment: process.env.METACULUS_ENV,
-    dsn: process.env.PUBLIC_FRONTEND_SENTRY_DSN,
-    tracesSampleRate: 0.1,
-    ignoreErrors: SENTRY_IGNORE_ERRORS,
-    beforeSend: beforeSentryAlertSend,
-  });
+  Sentry.init(buildSentryOptions(process.env.PUBLIC_FRONTEND_SENTRY_DSN));
 }

--- a/front_end/sentry.server.config.ts
+++ b/front_end/sentry.server.config.ts
@@ -1,16 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
-import {
-  beforeSentryAlertSend,
-  SENTRY_IGNORE_ERRORS,
-} from "@/utils/core/errors";
+import { buildSentryOptions } from "@/sentry/options";
 
 if (!!process.env.PUBLIC_FRONTEND_SENTRY_DSN) {
-  Sentry.init({
-    environment: process.env.METACULUS_ENV,
-    dsn: process.env.PUBLIC_FRONTEND_SENTRY_DSN,
-    tracesSampleRate: 0.1,
-    ignoreErrors: SENTRY_IGNORE_ERRORS,
-    beforeSend: beforeSentryAlertSend,
-  });
+  Sentry.init(buildSentryOptions(process.env.PUBLIC_FRONTEND_SENTRY_DSN));
 }

--- a/front_end/src/instrumentation-client.ts
+++ b/front_end/src/instrumentation-client.ts
@@ -1,23 +1,11 @@
 import * as Sentry from "@sentry/nextjs";
 
 import { getPublicSetting } from "@/components/public_settings_script";
-import {
-  beforeSentryAlertSend,
-  SENTRY_IGNORE_ERRORS,
-} from "@/utils/core/errors";
+import { buildSentryOptions } from "@/sentry/options";
 
 const sentryDsn = getPublicSetting("PUBLIC_FRONTEND_SENTRY_DSN");
 if (!!sentryDsn) {
-  Sentry.init({
-    environment: process.env.METACULUS_ENV,
-    dsn: sentryDsn,
-    tracesSampleRate: 0.1,
-    integrations: [Sentry.replayIntegration()],
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
-    ignoreErrors: SENTRY_IGNORE_ERRORS,
-    beforeSend: beforeSentryAlertSend,
-  });
+  Sentry.init(buildSentryOptions(sentryDsn));
 }
 
 // This export will instrument router navigations, and is only relevant if you enable tracing.

--- a/front_end/src/sentry/options.ts
+++ b/front_end/src/sentry/options.ts
@@ -1,0 +1,37 @@
+import type {
+  BrowserOptions,
+  NodeOptions,
+  VercelEdgeOptions,
+} from "@sentry/nextjs";
+
+import {
+  beforeSentryAlertSend,
+  SENTRY_IGNORE_ERRORS,
+} from "@/utils/core/errors";
+
+export function buildSentryOptions<
+  T extends BrowserOptions | NodeOptions | VercelEdgeOptions,
+>(dsn?: string): T {
+  return {
+    environment: process.env.METACULUS_ENV,
+    dsn,
+    tracesSampler: (ctx) => {
+      const name = ctx?.transactionContext?.name;
+      const op = ctx?.transactionContext?.op;
+
+      // We want to limit app-version and middleware traces
+      // since they’re not informative, don’t involve complex logic,
+      // and currently account for up to 50% of all frontend transactions
+      if (
+        name === "GET /front_end/src/app/(api)/app-version" ||
+        op === "http.server.middleware"
+      ) {
+        return 0.01;
+      }
+
+      return 0.1;
+    },
+    ignoreErrors: SENTRY_IGNORE_ERRORS as (string | RegExp)[],
+    beforeSend: beforeSentryAlertSend,
+  } as T;
+}


### PR DESCRIPTION
- Moved sentry config to `src/sentry/options.ts`, so now we configure it in one place only
- Made transactions less noisy by lowering tracesSampleRate for middleware + app version transactions to 1%
- Disabled replays!