### PR TITLE
allow tranlsated fields to be edited

### DIFF
--- a/utils/models.py
+++ b/utils/models.py
@@ -59,27 +59,6 @@ class CustomTranslationAdmin(admin.ModelAdmin):
             extra_fields += localized_field_names
         return uniques_ordered_list(fields + extra_fields)
 
-    def get_readonly_fields(self, request, obj=None):
-        model_class = self.model
-        translation_fields = get_translation_fields_for_model(model_class)
-        ro_fields = list(super().get_readonly_fields(request, obj))
-
-        if obj and not obj.is_automatically_translated:
-            return uniques_ordered_list(ro_fields + translation_fields)
-
-        # We are showing the language specific fields as read only
-        extra_ro_fields = []
-        for field_name in translation_fields:
-            localized_field_names = [
-                build_supported_localized_fieldname(field_name, lang[0])
-                for lang in settings.LANGUAGES
-            ]
-            extra_ro_fields += localized_field_names
-
-        extra_ro_fields.append("content_last_md5")
-
-        return uniques_ordered_list(ro_fields + extra_ro_fields)
-
     @admin.action(description="Update translations")
     def update_translations(self, request, queryset):
         for obj in queryset:


### PR DESCRIPTION
Allow translated fields to be edited in the admin panel.

Maybe a disclaimer should be added somewhere so that admins know that their changes will be overwritten if the text is ever updated from the front end. But in the situation where a translation to a particular language is poor, it seems worth it to have a normal path to overwriting the bad translation.

brought up here: https://metaculus.slack.com/archives/C02J55VPUCX/p1756417671729499?thread_ts=1755626429.335829&cid=C02J55VPUCX

Note to self: in the case where this is not approved, there is a bug that currently allows Project translations to be manually updated, which seems like is not the current intent.