### PR TITLE
Revert "Configured gunicorn workers to auto-restart"

### DIFF
--- a/scripts/prod/startapp.sh
+++ b/scripts/prod/startapp.sh
@@ -25,8 +25,6 @@ source venv/bin/activate
     --threads 2 \
     --timeout 25 \
     --keep-alive 5 \
-    --max-requests 1500 \
-    --max-requests-jitter 150 \
     --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(M)s' \
     --access-logfile - \
     --error-logfile - \


### PR DESCRIPTION
All these 502 errors are related to my latest PR, which introduced auto-restarting of Gunicorn workers every 1.5k requests. I had expected this to be good practice — to periodically free up allocated resources and guard against potential memory leaks — but it’s not working as I hoped.
I assumed Gunicorn would re-route traffic to other active workers during a restart so users wouldn’t notice, but it seems like it’s actually throwing 502s during the restart window instead.
Rolling back the PR for now and will investigate further

Reverts Metaculus/metaculus#2823