### PR TITLE
Debug Sentry error on "Cannot read properties of null (reading 'data')"

### DIFF
--- a/front_end/src/hooks/use_server_action.ts
+++ b/front_end/src/hooks/use_server_action.ts
@@ -19,10 +19,16 @@ export const useServerAction = <P extends unknown[], R>(
 
   const runAction = async (...args: P): Promise<R | undefined> => {
     startTransition(() => {
-      action(...args).then((data) => {
-        setResult(data);
-        setFinished(true);
-      });
+      action(...args)
+        .then((data) => {
+          setResult(data);
+        })
+        .catch((err) => {
+          console.error(err);
+        })
+        .finally(() => {
+          setFinished(true);
+        });
     });
 
     return new Promise((resolve) => {


### PR DESCRIPTION
Related to https://metaculus.sentry.io/issues/6845249662/?alert_rule_id=15493011&alert_type=issue&notification_uuid=aaffe723-f0ac-4ce1-bbc6-fa5f48d7ea11&project=4507883273125888

This PR should solve the issue with unhandled errors

I've looked into all the places that can have "addWeeks" fn from date-fns on this page, but it does not seem to be the case. Also, I checked all the places where we can potentially access data on an object that can be null or sth and it seems that the error can happen when we access .data in the error handler after calling our server side action for unresolving and currently our server action hook does not handle that at all, so I've added a catch clause there to prevent app from potential crashes in the future