### PR TITLE
Consumer Views QA feedback 4

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/index.tsx
@@ -84,6 +84,8 @@ const ConsumerQuestionView: React.FC<Props> = ({ postData }) => {
             </p>
           )}
 
+          {isFanGraph && <QuestionTimeline postData={postData} />}
+
           <QuestionActionButton postData={postData} />
         </div>
 
@@ -102,7 +104,7 @@ const ConsumerQuestionView: React.FC<Props> = ({ postData }) => {
             </div>
           )}
 
-        <QuestionTimeline postData={postData} />
+        {!isFanGraph && <QuestionTimeline postData={postData} />}
       </div>
     </div>
   );

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/binary_question_prediction.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/binary_question_prediction.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { faArrowRightLong } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { capitalize } from "lodash";

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/timeline/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/timeline/index.tsx
@@ -1,7 +1,11 @@
 import NumericForecastCard from "@/components/consumer_post_card/group_forecast_card/numeric_forecast_card";
 import DetailedGroupCard from "@/components/detailed_question_card/detailed_group_card";
 import DetailedQuestionCard from "@/components/detailed_question_card/detailed_question_card";
-import { PostWithForecasts, QuestionStatus } from "@/types/post";
+import {
+  GroupOfQuestionsGraphType,
+  PostWithForecasts,
+  QuestionStatus,
+} from "@/types/post";
 import { QuestionType } from "@/types/question";
 import cn from "@/utils/core/cn";
 import {
@@ -21,7 +25,14 @@ const QuestionTimeline: React.FC<Props> = ({
   className,
   hideTitle,
 }) => {
-  const wrapperClass = cn("mt-8 hidden sm:block", className);
+  const isFanGraph =
+    postData.group_of_questions?.graph_type ===
+    GroupOfQuestionsGraphType.FanGraph;
+  const wrapperClass = cn(
+    " hidden sm:block",
+    isFanGraph ? "mb-8" : "mt-8",
+    className
+  );
 
   if (isQuestionPost(postData)) {
     if (postData.question.status !== QuestionStatus.UPCOMING) {

--- a/front_end/src/components/charts/minified_continuous_area_chart.tsx
+++ b/front_end/src/components/charts/minified_continuous_area_chart.tsx
@@ -134,7 +134,7 @@ const MinifiedContinuousAreaChart: FC<Props> = ({
       );
       return {
         xDomain: [0, 1],
-        yDomain: [0.001, 1.2 * (maxValue <= 0 ? 1 : maxValue)],
+        yDomain: [0, 1.2 * (maxValue <= 0 ? 1 : maxValue)],
       };
     }
     const xDomain: Tuple<number> = [
@@ -264,6 +264,7 @@ const MinifiedContinuousAreaChart: FC<Props> = ({
                   <VictoryArea
                     key={`area-${index}`}
                     data={chart.graphLine}
+                    y0={yDomain[0]}
                     style={{
                       data: {
                         fill: (() => {
@@ -295,6 +296,7 @@ const MinifiedContinuousAreaChart: FC<Props> = ({
                 <VictoryBar
                   key={`bar-${index}`}
                   data={chart.graphLine}
+                  y0={yDomain[0]}
                   style={{
                     data: {
                       fill: (() => {

--- a/front_end/src/components/consumer_post_card/basic_consumer_post_card.tsx
+++ b/front_end/src/components/consumer_post_card/basic_consumer_post_card.tsx
@@ -36,18 +36,19 @@ const BasicConsumerPostCard: FC<PropsWithChildren<Props>> = ({
         )}
       <div
         className={cn(
-          "relative flex flex-col items-center overflow-hidden rounded border no-underline @container",
+          "relative z-0 flex flex-col items-center overflow-hidden rounded border no-underline @container",
           isNotebook
             ? "gap-1 border-purple-400/50 bg-purple-50/75 p-4 pt-3 dark:border-purple-400-dark/50  dark:bg-purple-100-dark/40"
             : "gap-2.5 border-blue-400 bg-gray-0 p-6 pt-5 dark:border-blue-400-dark dark:bg-gray-0-dark"
         )}
       >
-        <div className="z-10 flex items-center justify-between rounded-ee rounded-es dark:border-blue-400-dark max-lg:flex-1">
+        <div className="flex items-center justify-between rounded-ee rounded-es dark:border-blue-400-dark max-lg:flex-1">
           <CommentStatus
             totalCount={post.comment_count ?? 0}
             unreadCount={post.unread_comment_count ?? 0}
             url={getPostLink(post)}
             variant="gray"
+            className="z-[101]"
           />
           <ForecastersCounter forecasters={post.nr_forecasters} />
         </div>
@@ -70,7 +71,7 @@ const BasicConsumerPostCard: FC<PropsWithChildren<Props>> = ({
         </div>
         <Link
           href={getPostLink(post)}
-          className="absolute top-0 z-0 h-full w-full @container"
+          className="absolute top-0 z-100 h-full w-full @container"
         ></Link>
       </div>
     </div>

--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
@@ -48,7 +48,14 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
               "group-hover:text-gray-800 dark:group-hover:text-gray-800-dark"
             )}
             style={{
-              width: `calc(${otherItemsCount}% + 2px)`,
+              width: (() => {
+                const hasPct =
+                  typeof othersTotal === "number" && !Number.isNaN(othersTotal);
+                const pct = hasPct
+                  ? Math.min(100, Math.max(0, othersTotal))
+                  : Math.min(100, Math.max(0, otherItemsCount));
+                return `calc(${pct}% + 2px)`;
+              })(),
             }}
           >
             {t("otherWithCount", { count: otherItemsCount })}

--- a/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
@@ -9,7 +9,10 @@ import { QuestionType, Scaling } from "@/types/question";
 import { getPredictionDisplayValue } from "@/utils/formatters/prediction";
 import { scaleInternalLocation } from "@/utils/math";
 import { generateChoiceItemsFromGroupQuestions } from "@/utils/questions/choices";
-import { isGroupOfQuestionsPost } from "@/utils/questions/helpers";
+import {
+  checkGroupOfQuestionsPostType,
+  isGroupOfQuestionsPost,
+} from "@/utils/questions/helpers";
 
 import ForecastCardWrapper from "./forecast_card_wrapper";
 import ForecastChoiceBar from "./forecast_choice_bar";
@@ -28,6 +31,8 @@ const NumericForecastCard: FC<Props> = ({ post, forceColorful }) => {
   if (!isGroupOfQuestionsPost(post)) {
     return null;
   }
+
+  const isDateGroup = checkGroupOfQuestionsPostType(post, QuestionType.Date);
 
   const choices = generateChoiceItemsFromGroupQuestions(
     post.group_of_questions,
@@ -102,7 +107,9 @@ const NumericForecastCard: FC<Props> = ({ post, forceColorful }) => {
           const formattedChoiceValue = getPredictionDisplayValue(
             rawChoiceValue,
             {
-              questionType: QuestionType.Numeric,
+              questionType: isDateGroup
+                ? QuestionType.Date
+                : QuestionType.Numeric,
               scaling: normalizedScaling,
               actual_resolve_time: actual_resolve_time ?? null,
               emptyLabel: t("Upcoming"),


### PR DESCRIPTION
This PR addresses qa feedback

Showed dates instead of numbers

<img width="1090" height="1280" alt="image" src="https://github.com/user-attachments/assets/7afd2ca1-2bd5-4a7b-b3ef-f27808e8d3ba" />

Swapped locations of the fan graph and the colored timeline below

<img width="1280" height="1172" alt="image" src="https://github.com/user-attachments/assets/6805d833-37b7-4570-8e28-0f90189c5851" />

Aligned checkboxes

<img width="1230" height="898" alt="image" src="https://github.com/user-attachments/assets/80d21d98-4865-45d7-aa9d-71ff18ce4094" />

Returned others behaviour for group questions

<img width="1280" height="738" alt="image" src="https://github.com/user-attachments/assets/aede6fdd-04cb-4945-8024-09aa3220cf03" />

<img width="1280" height="647" alt="image" src="https://github.com/user-attachments/assets/18c3f93e-8fc9-4780-a03a-433136251a89" />

Removed others toggle when we have less than 4 options

<img width="1280" height="714" alt="image" src="https://github.com/user-attachments/assets/f91df881-6d6e-4207-aad7-31cf43281c1b" />

Fixed the length of the others bar

<img width="1280" height="386" alt="image" src="https://github.com/user-attachments/assets/0e75cba3-7ed7-494a-b5f5-8cba6f2af5ea" />

Fixed a few pixels mismatch

<img width="1207" height="1280" alt="image" src="https://github.com/user-attachments/assets/432b0ebf-e744-4dda-846c-771746f86178" />
