### PR TITLE
add user ids to aggregation explorer

### DIFF
--- a/front_end/src/app/(main)/aggregation-explorer/components/aggregation_wrapper.tsx
+++ b/front_end/src/app/(main)/aggregation-explorer/components/aggregation_wrapper.tsx
@@ -31,7 +31,6 @@ export const AggregationWrapper: FC<Props> = ({
   additionalParams = {},
 }) => {
   const postId = "post_id" in data ? data.post_id : data.id;
-  const userIdsText = additionalParams.userIdsText;
   const [selectedAggregationMethods, setSelectedAggregationMethods] = useState<
     AggregationMethodWithBots[]
   >([]);
@@ -62,7 +61,7 @@ export const AggregationWrapper: FC<Props> = ({
           questionId: adjustedQuestionId,
           includeBots,
           aggregationMethods: aggregationMethod,
-          userIdsText,
+          ...additionalParams,
         });
 
         const fetchedAggregationData = response.aggregations[aggregationMethod];

--- a/front_end/src/app/(main)/aggregation-explorer/components/aggregation_wrapper.tsx
+++ b/front_end/src/app/(main)/aggregation-explorer/components/aggregation_wrapper.tsx
@@ -18,6 +18,9 @@ type Props = {
   onTabChange: (activeTab: AggregationMethodWithBots) => void;
   data: QuestionWithForecasts | PostWithForecasts;
   selectedSubQuestionOption: number | string | null;
+  additionalParams?: {
+    userIdsText?: string; // Array of user IDs as a comma-separated string
+  };
 };
 
 export const AggregationWrapper: FC<Props> = ({
@@ -25,8 +28,10 @@ export const AggregationWrapper: FC<Props> = ({
   onTabChange,
   selectedSubQuestionOption,
   data,
+  additionalParams = {},
 }) => {
   const postId = "post_id" in data ? data.post_id : data.id;
+  const userIdsText = additionalParams.userIdsText;
   const [selectedAggregationMethods, setSelectedAggregationMethods] = useState<
     AggregationMethodWithBots[]
   >([]);
@@ -57,6 +62,7 @@ export const AggregationWrapper: FC<Props> = ({
           questionId: adjustedQuestionId,
           includeBots,
           aggregationMethods: aggregationMethod,
+          userIdsText,
         });
 
         const fetchedAggregationData = response.aggregations[aggregationMethod];

--- a/front_end/src/app/(main)/aggregation-explorer/components/explorer.tsx
+++ b/front_end/src/app/(main)/aggregation-explorer/components/explorer.tsx
@@ -14,7 +14,9 @@ import { FC, FormEvent, useCallback, useEffect, useState } from "react";
 
 import Button from "@/components/ui/button";
 import LoadingIndicator from "@/components/ui/loading_indicator";
+import SectionToggle from "@/components/ui/section_toggle";
 import Select from "@/components/ui/select";
+import { useAuth } from "@/contexts/auth_context";
 import useSearchParams from "@/hooks/use_search_params";
 import ClientPostsApi from "@/services/api/posts/posts.client";
 import { SearchParams } from "@/types/navigation";
@@ -56,6 +58,15 @@ const Explorer: FC<Props> = ({ searchParams }) => {
 
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const { user } = useAuth();
+
+  // Additional fields (only available to staff users)
+  const [userIdsText, setUserIdsText] = useState<string>(
+    (Array.isArray(searchParams.user_ids)
+      ? searchParams.user_ids[0]
+      : searchParams.user_ids
+    )?.toString() || ""
+  );
 
   // clear subquestion options when post id input changes
   useEffect(() => {
@@ -146,6 +157,14 @@ const Explorer: FC<Props> = ({ searchParams }) => {
         : {}),
     });
 
+    // Append additional fields for staff users
+    if (user?.is_staff) {
+      const cleanedIds = sanitizeUserIds(userIdsText);
+      if (cleanedIds.length) {
+        params.set("user_ids", cleanedIds.join(","));
+      }
+    }
+
     router.push(`/aggregation-explorer?${params.toString()}`);
   };
 
@@ -189,6 +208,7 @@ const Explorer: FC<Props> = ({ searchParams }) => {
             onTabChange={setActiveTab}
             data={data}
             selectedSubQuestionOption={selectedSubQuestionOption}
+            additionalParams={{ userIdsText }}
           />
         </>
       );
@@ -266,6 +286,31 @@ const Explorer: FC<Props> = ({ searchParams }) => {
             value={selectedSubQuestionOption}
             onChange={handleSubQuestionSelectChange}
           />
+          {user?.is_staff && (
+            <div className="mt-3">
+              <SectionToggle
+                title="Advanced options"
+                variant="light"
+                defaultOpen={!!userIdsText}
+              >
+                <div className="space-y-3">
+                  <div>
+                    <label className="mb-1 block text-sm">
+                      User Ids (comma-separated integers). Will act as if these
+                      are the only participants.
+                    </label>
+                    <Input
+                      name="user_ids"
+                      type="text"
+                      value={userIdsText}
+                      onChange={(e) => setUserIdsText(e.target.value)}
+                      className="w-full cursor-default overflow-hidden rounded border border-gray-500 bg-white p-2 text-left text-sm leading-5 text-gray-900 focus:outline-none focus:ring-0 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 dark:bg-blue-950 dark:text-gray-200 sm:text-sm"
+                    />
+                  </div>
+                </div>
+              </SectionToggle>
+            </div>
+          )}
           <Button
             variant="primary"
             type="submit"
@@ -388,3 +433,13 @@ function shouldRenderAggregation(
 }
 
 export default Explorer;
+
+function sanitizeUserIds(input: string): number[] {
+  if (!input) return [];
+  return input
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((s) => Number(s))
+    .filter((n) => Number.isInteger(n) && isFinite(n));
+}

--- a/front_end/src/services/api/aggregation_explorer/aggregation_explorer.shared.ts
+++ b/front_end/src/services/api/aggregation_explorer/aggregation_explorer.shared.ts
@@ -6,6 +6,7 @@ type AggregationExplorerParams = {
   questionId?: number | string | null;
   includeBots?: boolean;
   aggregationMethods?: string;
+  userIdsText?: string;
 };
 
 class AggregationExplorerApi extends ApiService {
@@ -15,6 +16,7 @@ class AggregationExplorerApi extends ApiService {
       question_id: params.questionId?.toString() || "",
       include_bots: params.includeBots?.toString() || "false",
       aggregation_methods: params.aggregationMethods || "",
+      user_ids: params.userIdsText || "",
     };
 
     const queryString = new URLSearchParams(queryParams).toString();


### PR DESCRIPTION
request from Ryan: https://metaculus.slack.com/archives/C02J55VPUCX/p1756994110912979

Ability to get aggregations for a selected group of users.
The back end data return was already set up for it, but the aggregation explorer hasn't been updated in a while. This is a quick and dirty implementation of that particular feature.