### PR TITLE
Replace the big ol' M on project previews with nicer project imagery / details

### DIFF
--- a/front_end/src/app/og/tournament/[slug]/page.tsx
+++ b/front_end/src/app/og/tournament/[slug]/page.tsx
@@ -1,0 +1,100 @@
+import type { StaticImageData } from "next/image";
+
+import tournamentPlaceholder from "@/app/assets/images/tournament.png";
+import ServerProjectsApi from "@/services/api/projects/projects.server";
+import type { Tournament } from "@/types/projects";
+
+export const dynamic = "force-dynamic";
+
+export default async function OgTournamentPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  const t: Tournament | null = await ServerProjectsApi.getTournament(slug);
+
+  const headerFromApi = (t?.header_image || "").trim();
+  const headerSrc: string | StaticImageData =
+    headerFromApi.length > 0 ? headerFromApi : tournamentPlaceholder;
+  const headerSrcStr =
+    typeof headerSrc === "string"
+      ? headerSrc
+      : (headerSrc as StaticImageData).src;
+
+  const title = t?.name ?? "Metaculus";
+  const desc = stripFirstLine(t?.subtitle || t?.description).slice(0, 180);
+  const count = getQuestionCount(t);
+
+  return (
+    <div
+      id="id-used-by-screenshot-donot-change"
+      className="relative h-[630px] w-[1240px] bg-blue-900 font-sans dark:bg-blue-900-dark"
+    >
+      <div className="absolute inset-0 overflow-hidden">
+        <img
+          src={headerSrcStr}
+          alt=""
+          className="pointer-events-none absolute -left-[0.5%] -top-[0.5%] ml-1.5 block h-[101%] w-[101%] select-none object-cover"
+          loading="eager"
+        />
+
+        <div className="absolute inset-0 bg-gradient-to-b from-transparent via-blue-900/40 to-blue-900/80" />
+
+        <div className="absolute inset-0 p-12">
+          <div className="flex h-full items-end">
+            <div className="w-full">
+              <div
+                id="id-logo-used-by-screenshot-donot-change"
+                className="mb-3 flex items-center gap-3 text-gray-0 drop-shadow-[0_1px_4px_rgba(0,0,0,0.35)]"
+              >
+                <div className="flex h-8 w-8 items-center justify-center rounded-md bg-blue-800 text-gray-0">
+                  <span className="text-[20px] leading-none">M</span>
+                </div>
+                <span className="text-[28px] font-semibold leading-none">
+                  Metaculus
+                </span>
+              </div>
+
+              <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-6">
+                <h1
+                  className="col-span-2 m-0 line-clamp-2 text-[64px] font-extrabold leading-[1.05] text-gray-0 drop-shadow-[0_2px_8px_rgba(0,0,0,0.35)]"
+                  title={title}
+                >
+                  {title}
+                </h1>
+
+                {desc ? (
+                  <p
+                    className="m-0 min-w-0 truncate text-[28px] font-medium text-gray-0/90 drop-shadow-[0_1px_4px_rgba(0,0,0,0.35)]"
+                    title={desc}
+                  >
+                    {desc}
+                  </p>
+                ) : (
+                  <div className="m-0 min-w-0" />
+                )}
+
+                {count > 0 && (
+                  <div className="shrink-0 justify-self-end rounded-xl bg-blue-900/60 px-4 py-2 text-[26px] font-bold text-gray-0 shadow-md backdrop-blur-sm">
+                    {count} {count === 1 ? "Question" : "Questions"}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const stripFirstLine = (html?: string): string =>
+  (html ?? "")
+    .replace(/<[^>]*>/g, "")
+    .split("\n")[0]
+    ?.trim() ?? "";
+
+const getQuestionCount = (t: Tournament | null): number =>
+  t?.questions_count ?? 0;

--- a/front_end/src/app/og/tournament/[slug]/route/route.ts
+++ b/front_end/src/app/og/tournament/[slug]/route/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getPublicSettings } from "@/utils/public_settings.server";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const theme = req.nextUrl.searchParams.get("theme") ?? "light";
+
+  const { PUBLIC_APP_URL } = getPublicSettings();
+
+  const { slug } = await params;
+
+  const pageUrl = `${PUBLIC_APP_URL}/og/tournament/${encodeURIComponent(
+    slug
+  )}?theme=${theme}&non-interactive=true`;
+
+  const screenshotEndpoint = new URL(
+    "/api/screenshot/",
+    process.env.SCREENSHOT_SERVICE_API_URL
+  ).toString();
+
+  const payload = {
+    url: pageUrl,
+    selector: "#id-used-by-screenshot-donot-change",
+    selector_to_wait: "#id-logo-used-by-screenshot-donot-change",
+    width: 1200,
+    height: 630,
+  };
+
+  try {
+    const r = await fetch(screenshotEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        api_key: process.env.SCREENSHOT_SERVICE_API_KEY || "",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!r.ok) {
+      const text = await r.text();
+      return NextResponse.json({ error: text }, { status: r.status });
+    }
+
+    const buf = await r.arrayBuffer();
+    return new NextResponse(buf, {
+      status: 200,
+      headers: {
+        "Content-Type": "image/png",
+        "Cache-Control":
+          process.env.NODE_ENV === "production"
+            ? "public, max-age=0, s-maxage=86400, stale-while-revalidate=3600"
+            : "no-store",
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: "screenshot failed" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Closes #3334

This PR adds OG images for project previews

<img width="1364" height="630" alt="image" src="https://github.com/user-attachments/assets/8ddd209a-c2b3-4c3d-ab4c-697f2ed571f2" />

<img width="831" height="479" alt="image" src="https://github.com/user-attachments/assets/748df401-fc45-474c-adfa-61c14fc14a1e" />

<img width="833" height="442" alt="image" src="https://github.com/user-attachments/assets/c3743646-e136-4c5a-9dda-0fb2a827af51" />
