### PR TITLE
CP movement text fixes

### DIFF
--- a/front_end/src/components/period_movement.tsx
+++ b/front_end/src/components/period_movement.tsx
@@ -61,13 +61,13 @@ const PeriodMovement: FC<Props> = ({
   message,
   className,
   iconClassName,
-  highIsGood,
+  highIsGood = true,
 }) => {
   const noChange = !direction || direction == MovementDirection.UNCHANGED;
   return (
-    <div className={cn("flex gap-1", className)}>
+    <div className={cn("flex min-w-0 items-center gap-1", className)}>
       <span
-        className={cn("text-nowrap font-medium leading-4", {
+        className={cn("truncate font-medium leading-4", {
           "text-salmon-600 dark:text-salmon-600-dark": highIsGood
             ? direction == MovementDirection.DOWN
             : direction === MovementDirection.UP,
@@ -81,11 +81,13 @@ const PeriodMovement: FC<Props> = ({
         })}
       >
         {!noChange && (
-          <MovementIcon
-            highIsGood={highIsGood}
-            iconClassName={iconClassName}
-            direction={direction}
-          />
+          <span className="shrink-0">
+            <MovementIcon
+              highIsGood={highIsGood}
+              iconClassName={iconClassName}
+              direction={direction}
+            />
+          </span>
         )}
         {message}
       </span>

--- a/front_end/src/components/prediction_chip.tsx
+++ b/front_end/src/components/prediction_chip.tsx
@@ -126,7 +126,7 @@ const PredictionChip: FC<Props> = ({
         {showWeeklyMovement && (
           <QuestionCPMovement
             question={question}
-            className="my-1 max-w-[110px]"
+            className="my-1 max-w-[140px] sm:max-w-[110px] md:max-w-[200px]"
           />
         )}
       </>


### PR DESCRIPTION
This PR fixes the issue with prediction text
Slack thread: https://metaculus.slack.com/archives/C01Q9AQBVHB/p1757073768335829

<img width="1964" height="958" alt="image" src="https://github.com/user-attachments/assets/d78111bb-6748-4293-8c34-5adfdd74b244" />
