### PR TITLE
Aggregation explorer fixes

### DIFF
--- a/front_end/src/app/(main)/aggregation-explorer/components/aggregation_tab.tsx
+++ b/front_end/src/app/(main)/aggregation-explorer/components/aggregation_tab.tsx
@@ -27,6 +27,7 @@ type Props = {
   selectedSubQuestionOption: number | string | null;
   postId: number;
   questionTitle: string;
+  userIds?: number[];
 };
 
 const AggregationsTab: FC<Props> = ({
@@ -35,6 +36,7 @@ const AggregationsTab: FC<Props> = ({
   selectedSubQuestionOption,
   postId,
   questionTitle,
+  userIds,
 }) => {
   const t = useTranslations();
 
@@ -176,7 +178,8 @@ const AggregationsTab: FC<Props> = ({
           ? selectedSubQuestionOption
           : undefined,
         aggregationMethod,
-        tabData.includeBots
+        tabData.includeBots,
+        userIds
       );
       const filename = `${questionTitle.replaceAll(" ", "_")}-${aggregationMethod}${tabData.includeBots ? "-bots" : ""}.zip`;
       saveAs(blob, filename);

--- a/front_end/src/app/(main)/aggregation-explorer/components/aggregation_wrapper.tsx
+++ b/front_end/src/app/(main)/aggregation-explorer/components/aggregation_wrapper.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useMemo, useState } from "react";
+import { FC, useCallback, useState } from "react";
 
 import ClientAggregationExplorerApi from "@/services/api/aggregation_explorer/aggregation_explorer.client";
 import { PostWithForecasts } from "@/types/post";

--- a/front_end/src/app/(main)/aggregation-explorer/components/aggregation_wrapper.tsx
+++ b/front_end/src/app/(main)/aggregation-explorer/components/aggregation_wrapper.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useState } from "react";
+import { FC, useCallback, useMemo, useState } from "react";
 
 import ClientAggregationExplorerApi from "@/services/api/aggregation_explorer/aggregation_explorer.client";
 import { PostWithForecasts } from "@/types/post";
@@ -19,7 +19,7 @@ type Props = {
   data: QuestionWithForecasts | PostWithForecasts;
   selectedSubQuestionOption: number | string | null;
   additionalParams?: {
-    userIdsText?: string; // Array of user IDs as a comma-separated string
+    userIds?: number[]; // Array of user IDs as a comma-separated string
   };
 };
 
@@ -106,7 +106,12 @@ export const AggregationWrapper: FC<Props> = ({
         logError(err);
       }
     },
-    [postId, selectedSubQuestionOption, selectedAggregationMethods]
+    [
+      selectedAggregationMethods,
+      selectedSubQuestionOption,
+      postId,
+      additionalParams,
+    ]
   );
 
   return activeTab ? (
@@ -116,6 +121,7 @@ export const AggregationWrapper: FC<Props> = ({
       selectedSubQuestionOption={selectedSubQuestionOption}
       postId={postId}
       questionTitle={data.title}
+      userIds={additionalParams.userIds}
     />
   ) : (
     <AggregationsDrawer

--- a/front_end/src/app/(main)/aggregation-explorer/components/explorer.tsx
+++ b/front_end/src/app/(main)/aggregation-explorer/components/explorer.tsx
@@ -146,7 +146,7 @@ const Explorer: FC<Props> = ({ searchParams }) => {
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [post_id, question_id, option]);
+  }, [searchParams]);
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();

--- a/front_end/src/app/(main)/aggregation-explorer/components/explorer.tsx
+++ b/front_end/src/app/(main)/aggregation-explorer/components/explorer.tsx
@@ -213,7 +213,7 @@ const Explorer: FC<Props> = ({ searchParams }) => {
             onTabChange={setActiveTab}
             data={data}
             selectedSubQuestionOption={selectedSubQuestionOption}
-            additionalParams={{ userIdsText }}
+            additionalParams={{ userIds: sanitizeUserIds(userIdsText) }}
           />
         </>
       );

--- a/front_end/src/services/api/aggregation_explorer/aggregation_explorer.shared.ts
+++ b/front_end/src/services/api/aggregation_explorer/aggregation_explorer.shared.ts
@@ -1,28 +1,27 @@
 import { ApiService } from "@/services/api/api_service";
 import { AggregationQuestion } from "@/types/question";
+import { encodeQueryParams } from "@/utils/navigation";
 
 type AggregationExplorerParams = {
   postId?: number | string | null;
   questionId?: number | string | null;
   includeBots?: boolean;
   aggregationMethods?: string;
-  userIdsText?: string;
+  userIds?: number[];
 };
 
 class AggregationExplorerApi extends ApiService {
   async getAggregations(params: AggregationExplorerParams) {
-    const queryParams: Record<string, string> = {
+    const queryParams = encodeQueryParams({
       post_id: params.postId?.toString() || "",
       question_id: params.questionId?.toString() || "",
       include_bots: params.includeBots?.toString() || "false",
       aggregation_methods: params.aggregationMethods || "",
-      user_ids: params.userIdsText || "",
-    };
-
-    const queryString = new URLSearchParams(queryParams).toString();
+      ...(params.userIds !== undefined ? { user_ids: params.userIds } : {}),
+    });
 
     return await this.get<AggregationQuestion>(
-      `/aggregation_explorer/?${queryString}`
+      `/aggregation_explorer/${queryParams}`
     );
   }
 }

--- a/front_end/src/services/api/posts/posts.shared.ts
+++ b/front_end/src/services/api/posts/posts.shared.ts
@@ -195,7 +195,8 @@ class PostsApi extends ApiService {
     postId: number,
     subQuestionId?: number,
     aggregationMethods?: string,
-    includeBots?: boolean
+    includeBots?: boolean,
+    userIds?: number[]
   ): Promise<Blob> {
     const queryParams = encodeQueryParams({
       ...(subQuestionId ? { sub_question: subQuestionId } : {}),
@@ -203,6 +204,7 @@ class PostsApi extends ApiService {
         ? { aggregation_methods: aggregationMethods }
         : { aggregation_methods: "all" }),
       ...(includeBots !== undefined ? { include_bots: includeBots } : {}),
+      ...(userIds !== undefined ? { user_ids: userIds } : {}),
     });
 
     return await this.get<Blob>(

--- a/utils/serializers.py
+++ b/utils/serializers.py
@@ -76,7 +76,9 @@ class DataGetRequestSerializer(serializers.Serializer):
     include_comments = serializers.BooleanField(required=False, default=False)
     include_scores = serializers.BooleanField(required=False, default=True)
     include_user_data = serializers.BooleanField(required=False, allow_null=True)
-    user_ids = serializers.CharField(required=False, allow_null=True)
+    user_ids = serializers.ListField(
+        child=serializers.IntegerField(), required=False, allow_null=True
+    )
     include_bots = serializers.BooleanField(required=False, allow_null=True)
     anonymized = serializers.BooleanField(required=False)
 
@@ -109,14 +111,9 @@ class DataGetRequestSerializer(serializers.Serializer):
             ]
         return methods
 
-    def validate_user_ids(self, value):
-        if not value:
-            return value
-        user_ids = value.split(",")
-        if not all(user_id.isdigit() for user_id in user_ids):
-            raise serializers.ValidationError(
-                "Invalid user_ids. Must be a comma-separated list of integers."
-            )
+    def validate_user_ids(self, user_ids: list[int]):
+        if not user_ids:
+            return user_ids
         if not (self.context.get("is_staff") or self.context.get("is_whitelisted")):
             raise serializers.ValidationError(
                 "Current user cannot view user-specific data. "

--- a/utils/views.py
+++ b/utils/views.py
@@ -1,12 +1,11 @@
-from rest_framework.decorators import api_view, permission_classes
-from rest_framework.exceptions import ValidationError, NotFound
-from rest_framework.permissions import AllowAny, IsAuthenticated
-from rest_framework.response import Response
-from rest_framework.request import Request
-
 from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.exceptions import ValidationError, NotFound
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from misc.models import WhitelistUser
 from posts.models import Post
@@ -18,9 +17,9 @@ from questions.models import Question
 from questions.serializers.common import serialize_question
 from users.models import User
 from utils.csv_utils import export_data_for_questions
-from utils.the_math.aggregations import get_aggregation_history
 from utils.serializers import DataGetRequestSerializer, DataPostRequestSerializer
 from utils.tasks import email_data_task
+from utils.the_math.aggregations import get_aggregation_history
 
 
 @api_view(["GET"])
@@ -101,7 +100,11 @@ def aggregation_explorer_api_view(request):
     )
 
     # Add forecasters count
-    data["forecasters_count"] = question.get_forecasters().count()
+    forecasters_qs = question.get_forecasters()
+    if user_ids:
+        forecasters_qs = forecasters_qs.filter(id__in=user_ids)
+
+    data["forecasters_count"] = forecasters_qs.count()
 
     return Response(data)
 


### PR DESCRIPTION
- Fixed "Total Forecasters" counter to reflect selected user IDs correctly  
- Refactored `userIds` state to use `number[]` instead of text  
- Fixed a bug where changing user IDs didn’t trigger data refresh  
- Updated download zip logic to respect selected user IDs  
- Minor backend refactoring
