### PR TITLE
fix: overflow

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
@@ -127,10 +127,13 @@ const QuestionHeaderCPStatus: FC<Props> = ({
           </div>
           <QuestionCPMovement
             question={question}
-            className={cn("mx-auto min-w-[100px]", {
-              "-mt-2 text-center": size === "md" && hideLabel, // Center + negative margin for mobile continuous
-              "text-center": size === "md" && !hideLabel, // Just center for mobile binary
-            })}
+            className={cn(
+              "mx-auto min-w-[100px] max-w-full text-center md:[&>span]:whitespace-normal",
+              {
+                "-mt-2 text-center": size === "md" && hideLabel, // Center + negative margin for mobile continuous
+                "text-center": size === "md" && !hideLabel, // Just center for mobile binary
+              }
+            )}
             size={"sm"}
             // Hide unit on small sizes
             unit={size === "md" ? "" : undefined}


### PR DESCRIPTION
This PR fixes the issue with text overflow

Before:

<img width="1536" height="884" alt="image" src="https://github.com/user-attachments/assets/73f93384-8b91-4abe-a007-de166917f557" />

After:

<img width="1560" height="908" alt="image" src="https://github.com/user-attachments/assets/405fa8e0-0ee6-4234-a3a7-f3a98d47f884" />
