### PR TITLE
Don't show aggregations in the future in the aggregation explorer

### DIFF
--- a/utils/views.py
+++ b/utils/views.py
@@ -87,6 +87,7 @@ def aggregation_explorer_api_view(request):
             else question.include_bots_in_aggregates
         ),
         histogram=True,
+        include_future=False,
     )
     aggregate_forecasts = []
     for aggregation in aggregations.values():


### PR DESCRIPTION
Fixed the issue when Aggregation Explorer was rendering incorrect Aggregate Forecasts in the future