### PR TITLE
Bring back the leaderboard score explanation

### DIFF
--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/project_leaderboard.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/project_leaderboard.tsx
@@ -1,7 +1,9 @@
+import Link from "next/link";
 import { getTranslations } from "next-intl/server";
-import { FC } from "react";
+import { FC, Fragment } from "react";
 
 import WithServerComponentErrorBoundary from "@/components/server_component_error_boundary";
+import InfoToggle from "@/components/ui/info_toggle";
 import ServerLeaderboardApi from "@/services/api/leaderboard/leaderboard.server";
 import { LeaderboardType } from "@/types/scoring";
 
@@ -35,13 +37,51 @@ const ProjectLeaderboard: FC<Props> = async ({
     ? t("openLeaderboard")
     : t("leaderboard");
 
+  const scoreType = leaderboardDetails.score_type;
+  const isPeer = scoreType === "peer_tournament";
+  const isSpotPeer = scoreType === "spot_peer_tournament";
+  const showExplainer = isPeer || isSpotPeer;
+
   return (
-    <ProjectLeaderboardClient
-      leaderboardDetails={leaderboardDetails}
-      leaderboardTitle={leaderboardTitle}
-      isQuestionSeries={isQuestionSeries}
-      userId={userId}
-    />
+    <Fragment>
+      <ProjectLeaderboardClient
+        leaderboardDetails={leaderboardDetails}
+        leaderboardTitle={leaderboardTitle}
+        isQuestionSeries={isQuestionSeries}
+        userId={userId}
+      />
+
+      {showExplainer && (
+        <div className="rounded border border-gray-300 bg-blue-100 dark:border-gray-300-dark dark:bg-blue-100-dark">
+          <InfoToggle title={t("scoringTerminology")}>
+            <div className="mt-2">
+              <dl className="m-0">
+                <div className="m-2 flex text-sm">
+                  <dt className="mr-2 w-28 flex-none font-bold">
+                    {t("score")}
+                  </dt>
+                  <dd>
+                    {t.rich(isPeer ? "peerScoreInfo" : "spotPeerScoreInfo", {
+                      link: (chunks) => (
+                        <Link
+                          href={
+                            isPeer
+                              ? "/help/scores-faq/#peer-score"
+                              : "/help/scores-faq/#spot-score"
+                          }
+                        >
+                          {chunks}
+                        </Link>
+                      ),
+                    })}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </InfoToggle>
+        </div>
+      )}
+    </Fragment>
   );
 };
 


### PR DESCRIPTION
Closes #3358

This PR adds an expandable score explanation section

<img width="1280" height="443" alt="image" src="https://github.com/user-attachments/assets/1d26fb6c-4e7e-493b-be63-6e3e395375b9" />

<img width="1280" height="385" alt="image" src="https://github.com/user-attachments/assets/76ec1e05-c4ce-41c9-b8de-4a0bab691e9f" />

<img width="1280" height="408" alt="image" src="https://github.com/user-attachments/assets/9633d4bc-c7a6-42c3-8a77-55ca822aa454" />
