### PR TITLE
scale index values by set index range

### DIFF
--- a/front_end/src/components/markdown_editor/editor.css
+++ b/front_end/src/components/markdown_editor/editor.css
@@ -58,6 +58,13 @@
   @apply sticky top-0 z-10;
 }
 
+.mdxeditor-toolbar {
+  @apply sticky top-12 flex-wrap @container;
+  & [class*="toolbarTitleMode"] {
+    display: none; /* We render our custom source mode title instead */
+  }
+}
+
 .markdown-editor.dark-theme {
   --baseBg: theme("colors.blue.100.dark");
   --basePageBg: theme("colors.gray.0.dark");

--- a/tests/unit/test_projects/test_services/test_indexes.py
+++ b/tests/unit/test_projects/test_services/test_indexes.py
@@ -333,7 +333,6 @@ def test_calculate_questions_index_bounds():
     # Active forecasts
     #
 
-    # This will result as (0.5, 0.95)
     add_agg(
         question_binary,
         start=datetime_aware(2025, 1, 4),
@@ -341,7 +340,6 @@ def test_calculate_questions_index_bounds():
         interval_lower_bounds=[0.15, 0.5],
         interval_upper_bounds=[0.30, 0.95],
     )
-    # This will result as (0.1, 0.45)
     add_agg(
         question_numeric,
         start=datetime_aware(2025, 1, 4),


### PR DESCRIPTION
solves an issue where the index bounds are nominally set on the ProjectIndex object, but the code assumed that the value will be between -1 and 1 and then scale it up to -100 to 100
Instead, this just treats all forecasts / resolutions as being in the range [0, 1] and then scales the result up to the range [index min, index max].