### PR TITLE
Remove "title" from hyperlink dialogue

### DIFF
--- a/front_end/src/components/markdown_editor/editor.css
+++ b/front_end/src/components/markdown_editor/editor.css
@@ -121,3 +121,7 @@
 .mdx-content-editable a {
   @apply text-blue-800 decoration-blue-500 underline-offset-2 dark:text-blue-800-dark dark:decoration-blue-500-dark;
 }
+
+.mdxeditor-popup-container [role="dialog"] form > *:has(#link-title) {
+  display: none;
+}


### PR DESCRIPTION
Closes #755

This PR removes title field from the dialog

<img width="988" height="602" alt="image" src="https://github.com/user-attachments/assets/d54ce426-5793-4934-aa72-1fefe4c6783b" />

<img width="1652" height="512" alt="image" src="https://github.com/user-attachments/assets/71ade98c-b335-46b6-9524-e6a8862889e2" />

<img width="1716" height="418" alt="image" src="https://github.com/user-attachments/assets/fc802e5d-6dbb-4dde-9282-719b00a51fbc" />