### PR TITLE
Text change on question creation page

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -677,8 +677,6 @@
   "backgroundInformation": "Základní informace",
   "backgroundInfoExplanation": "Poskytněte základní informace k vaší otázce ve věcném a nestranném tónu. Odkazy by měly být přidány na relevantní a užitečné zdroje pomocí <link>markdown syntaxi</link>: <markdown>[Název odkazu](https://link-url.com)</markdown>.",
   "resolutionCriteriaExplanation": "Dobrá otázka se téměř vždy vyřeší jednoznačně. Pokud máte zdroj dat, podle kterého se otázka vyřeší, přidejte jej sem. Pokud bude třeba provést jednoduchou matematiku k vyřešení této otázky, definujte rovnici v markdown: <markdown>\\[ y = ax^2+b \\]</markdown>.",
-  "closingDate": "uzavírací datum",
-  "resolvingDate": "datum vyřešení",
   "choicesSeparatedBy": "Možnosti (oddělené čárkou)",
   "projects": "projekty",
   "FABPrizePool": "CENOVÝ FOND",
@@ -1522,5 +1520,7 @@
   "causally": "kauzálně",
   "hastens": "urychluje",
   "delays": "zpožďuje",
+  "closeTime": "čas uzavření",
+  "resolveTime": "doba řešení",
   "othersCount": "Ostatní ({count})"
 }

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -893,8 +893,6 @@
   "backgroundInformation": "Background Information",
   "backgroundInfoExplanation": "Provide background information for your question in a factual and unbiased tone. Links should be added to relevant and helpful resources using <link>markdown syntax</link>: <markdown>[Link title](https://link-url.com)</markdown>.",
   "resolutionCriteriaExplanation": "A good question will almost always resolve unambiguously. If you have a data source by which the question will resolve, link to it here. If there is some simple math that will need to be done to resolve this question, define the equation in markdown: <markdown>\\[ y = ax^2+b \\]</markdown>.",
-  "closingDate": "closing date",
-  "resolvingDate": "resolving date",
   "choices": "Choices",
   "choicesSeparatedBy": "Choices (separated by ,)",
   "projects": "projects",
@@ -1506,7 +1504,6 @@
   "inNews": "In the News",
   "info": "Question Info",
   "noParticipationProject": "You have not participated in this {projectType} yet.",
-  "hiddenUntil": "Hidden until",
   "low": "Low strength",
   "medium": "Medium strength",
   "high": "High strength",
@@ -1516,5 +1513,8 @@
   "otherQuestionCausesThisQuestionAdverbial": "<otherQuestion></otherQuestion> <type></type> <direction></direction> this question",
   "causally" : "causally",
   "hastens" : "hastens",
-  "delays" : "delays"
+  "delays" : "delays",
+  "closeTime": "close time",
+  "resolveTime": "resolving time",
+  "hiddenUntil": "Hidden until"
 }

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -679,8 +679,6 @@
   "backgroundInformation": "Información de Fondo",
   "backgroundInfoExplanation": "Proporciona información de fondo para tu pregunta en un tono objetivo y sin sesgos. Los enlaces deben agregarse a recursos relevantes y útiles utilizando la <link>sintaxis markdown</link>: <markdown>[Título del Enlace](https://link-url.com)</markdown>.",
   "resolutionCriteriaExplanation": "Una buena pregunta casi siempre se resolverá de manera inequívoca. Si tienes una fuente de datos con la que se resolverá la pregunta, enlázala aquí. Si es necesario realizar algunos cálculos simples para resolver esta pregunta, define la ecuación en markdown: <markdown>\\[ y = ax^2+b \\]</markdown>.",
-  "closingDate": "fecha de cierre",
-  "resolvingDate": "fecha de resolución",
   "choicesSeparatedBy": "Opciones (separadas por ,)",
   "projects": "proyectos",
   "FABPrizePool": "FONDO DE PREMIOS",
@@ -1522,5 +1520,7 @@
   "causally": "causalmente",
   "hastens": "acelera",
   "delays": "retrasa",
+  "closeTime": "hora de cierre",
+  "resolveTime": "tiempo de resolución",
   "othersCount": "Otros ({count})"
 }

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -756,8 +756,6 @@
   "backgroundInformation": "Informações de Fundo",
   "backgroundInfoExplanation": "Forneça informações de fundo para sua pergunta em um tom factual e imparcial. Links devem ser adicionados a recursos relevantes e úteis usando <link>markdown syntax</link>: <markdown>[Título do Link](https://link-url.com)</markdown>.",
   "resolutionCriteriaExplanation": "Uma boa pergunta quase sempre se resolve de forma inequívoca. Se você tem uma fonte de dados pela qual a pergunta será resolvida, link para ela aqui. Se houver alguma matemática simples que precisará ser feita para resolver esta pergunta, defina a equação em markdown: <markdown>\\[ y = ax^2+b \\]</markdown>.",
-  "closingDate": "data de encerramento",
-  "resolvingDate": "data de resolução",
   "choices": "Escolhas",
   "choicesSeparatedBy": "Escolhas (separadas por ,)",
   "projects": "projetos",
@@ -1520,5 +1518,7 @@
   "causally": "causalmente",
   "hastens": "acelera",
   "delays": "atrasos",
+  "closeTime": "hora de fechamento",
+  "resolveTime": "tempo de resolução",
   "othersCount": "Outros ({count})"
 }

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -820,8 +820,6 @@
   "backgroundInformation": "背景信息",
   "backgroundInfoExplanation": "以事實和不偏不倚的語氣提供問題的背景信息。鏈接應使用<link>Markdown語法</link>添加至相關和有用的資源：<markdown>[鏈接標題](https://link-url.com)</markdown>。",
   "resolutionCriteriaExplanation": "一個好的問題幾乎總是能夠毫不含糊地解決。如果您有解析問題的數據來源，請在此處鏈接。如果需要進行一些簡單的數學運算來解析這個問題，請使用markdown定義方程：<markdown>\\[ y = ax^2+b \\]</markdown>。",
-  "closingDate": "結束日期",
-  "resolvingDate": "解決日期",
   "choices": "選擇",
   "choicesSeparatedBy": "選擇（以,分隔）",
   "projects": "專案",
@@ -1519,5 +1517,7 @@
   "causally": "原因地",
   "hastens": "加速",
   "delays": "延遲",
+  "closeTime": "結束時間",
+  "resolveTime": "解決時間",
   "withdrawAfterPercentSetting2": "問題總生命周期後撤回"
 }

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -668,8 +668,6 @@
   "backgroundInformation": "背景資訊",
   "backgroundInfoExplanation": "以客觀和中立的語氣提供問題的背景資訊。應使用<link>markdown語法</link>添加相關和有用資源的連結：<markdown>[連結標題](https://link-url.com)</markdown>。",
   "resolutionCriteriaExplanation": "一個好的問題幾乎總是能夠明確解決。如果你有用於解決問題的數據源，請在此處連結。如果需要進行一些簡單的數學計算來解決這個問題，請用markdown定義方程式：<markdown>\\[ y = ax^2+b \\]</markdown>。",
-  "closingDate": "結束日期",
-  "resolvingDate": "解決日期",
   "choicesSeparatedBy": "選項（以逗號分隔）",
   "projects": "專案",
   "FABPrizePool": "獎金池",
@@ -1524,5 +1522,7 @@
   "causally": "因果地",
   "hastens": "加速",
   "delays": "延迟",
+  "closeTime": "关闭时间",
+  "resolveTime": "解决时间",
   "othersCount": "其他（{count}）"
 }

--- a/front_end/src/app/(main)/questions/components/group_form.tsx
+++ b/front_end/src/app/(main)/questions/components/group_form.tsx
@@ -811,7 +811,7 @@ const GroupForm: React.FC<Props> = ({
                     )}
                     <div className="flex flex-col gap-4 md:flex-row">
                       <InputContainer
-                        labelText={t("closingDate")}
+                        labelText={t("closeTime")}
                         className="w-full"
                       >
                         <DatetimeUtc
@@ -850,7 +850,7 @@ const GroupForm: React.FC<Props> = ({
                         />
                       </InputContainer>
                       <InputContainer
-                        labelText={t("resolvingDate")}
+                        labelText={t("resolveTime")}
                         className="w-full"
                       >
                         <DatetimeUtc

--- a/front_end/src/app/(main)/questions/components/group_form_bulk_modal.tsx
+++ b/front_end/src/app/(main)/questions/components/group_form_bulk_modal.tsx
@@ -47,11 +47,11 @@ const GroupFormBulkModal: FC<{
       },
       {
         field: "scheduled_close_time",
-        label: t("closingDate"),
+        label: t("closeTime"),
       },
       {
         field: "scheduled_resolve_time",
-        label: t("resolvingDate"),
+        label: t("resolveTime"),
       },
     ],
     [t]


### PR DESCRIPTION
Closes #3299

This PR changes text on question creation page. It updates text to "Close Time" and "Resolving Time" to be consistent with the other options and question types.

<img width="1240" height="1280" alt="image" src="https://github.com/user-attachments/assets/f5c40347-56fb-4839-a65c-4dd6b69de1b7" />
