### PR TITLE
Fixed error during saving changes of post subscriptions

### DIFF
--- a/posts/serializers.py
+++ b/posts/serializers.py
@@ -599,12 +599,6 @@ class SubscriptionSpecificTimeSerializer(serializers.ModelSerializer):
             "created_at",
         )
 
-    def validate_next_trigger_datetime(self, value):
-        if value <= timezone.now():
-            raise ValidationError("Can not be in the past")
-
-        return value
-
     def validate_recurrence_interval(self, value):
         if not value:
             return


### PR DESCRIPTION
The issue was that we didn’t allow saving post subscriptions with reminders set in the past. This PR removes that validation.

Fixes #3455
