### PR TITLE
Updated comment text limit to 150k chars

### DIFF
--- a/comments/migrations/0001_initial.py
+++ b/comments/migrations/0001_initial.py
@@ -60,7 +60,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("is_soft_deleted", models.BooleanField(null=True)),
-                ("text", models.TextField()),
+                ("text", models.TextField(max_length=150000)),
                 ("is_private", models.BooleanField(default=False)),
                 ("edit_history", models.JSONField(blank=True, default=list)),
             ],

--- a/comments/migrations/0005_comment_content_last_md5_and_more.py
+++ b/comments/migrations/0005_comment_content_last_md5_and_more.py
@@ -23,26 +23,26 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="comment",
             name="text_cs",
-            field=models.TextField(null=True),
+            field=models.TextField(null=True, max_length=150000),
         ),
         migrations.AddField(
             model_name="comment",
             name="text_en",
-            field=models.TextField(null=True),
+            field=models.TextField(null=True, max_length=150000),
         ),
         migrations.AddField(
             model_name="comment",
             name="text_es",
-            field=models.TextField(null=True),
+            field=models.TextField(null=True, max_length=150000),
         ),
         migrations.AddField(
             model_name="comment",
             name="text_original",
-            field=models.TextField(null=True),
+            field=models.TextField(null=True, max_length=150000),
         ),
         migrations.AddField(
             model_name="comment",
             name="text_zh",
-            field=models.TextField(null=True),
+            field=models.TextField(null=True, max_length=150000),
         ),
     ]

--- a/comments/migrations/0007_comment_text_pt.py
+++ b/comments/migrations/0007_comment_text_pt.py
@@ -13,6 +13,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="comment",
             name="text_pt",
-            field=models.TextField(null=True),
+            field=models.TextField(null=True, max_length=150000),
         ),
     ]

--- a/comments/migrations/0014_comment_text_zh_tw_keyfactor_text_zh_tw.py
+++ b/comments/migrations/0014_comment_text_zh_tw_keyfactor_text_zh_tw.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="comment",
             name="text_zh_TW",
-            field=models.TextField(null=True),
+            field=models.TextField(null=True, max_length=150000),
         ),
         migrations.AddField(
             model_name="keyfactor",

--- a/comments/models.py
+++ b/comments/models.py
@@ -101,7 +101,7 @@ class Comment(TimeStampedModel, TranslatedModel):
     )
     # auto_now_add=True must be disabled when the migration is run
     is_soft_deleted = models.BooleanField(default=False, db_index=True)
-    text = models.TextField()
+    text = models.TextField(max_length=150_000)
     on_post = models.ForeignKey(
         Post, models.CASCADE, null=True, related_name="comments"
     )


### PR DESCRIPTION
Updated comment text limit to 150k chars. 

Note: `TextField(max_length=150000)` does not enforce length at the DB level (Postgres text has no limit). Backfilled the old migration to avoid generating an extra one