### PR TITLE
Annulled subquestions in a fan graph should look different

### DIFF
--- a/front_end/src/components/charts/fan_chart.tsx
+++ b/front_end/src/components/charts/fan_chart.tsx
@@ -573,7 +573,12 @@ function buildChartData({
       ? getQuestionForecastAvailability(option.question)
       : { isEmpty: false, cpRevealsOn: null as number | null };
 
-    const isResolved = option.resolved && !unsuccessfullyResolved;
+    const isResolved = !!option.resolved && !unsuccessfullyResolved;
+
+    if (unsuccessfullyResolved) {
+      emptyPoints.push({ x: option.name, y: 0, unsuccessfullyResolved: true });
+      continue;
+    }
 
     if (
       questionForecastAvailability.isEmpty ||

--- a/front_end/src/components/charts/primitives/chart_fan_tooltip.tsx
+++ b/front_end/src/components/charts/primitives/chart_fan_tooltip.tsx
@@ -144,7 +144,13 @@ const ChartFanTooltip: FC<Props> = ({
         height={height}
         x={x}
         y={y}
-        className="border-purple-600 p-2 dark:border-purple-600-dark"
+        className={[
+          "border-purple-600 dark:border-purple-600-dark",
+          "p-2",
+          "text-[10px] leading-[14px]",
+          "text-gray-900 dark:text-gray-900-dark",
+          "bg-gray-0 dark:bg-gray-0-dark",
+        ].join(" ")}
       >
         <div>
           {formatResolution({

--- a/front_end/src/components/charts/primitives/fan_point.tsx
+++ b/front_end/src/components/charts/primitives/fan_point.tsx
@@ -48,6 +48,42 @@ const FanPoint: FC<Props> = ({
   if (isNil(x) || isNil(y)) {
     return null;
   }
+  const datumUnsuccess = datum?.unsuccessfullyResolved;
+  const isAnnulled =
+    typeof unsuccessfullyResolved === "boolean"
+      ? unsuccessfullyResolved
+      : !!datumUnsuccess;
+
+  if (isAnnulled) {
+    const circleSize = 8;
+    const xSize = 3;
+
+    return (
+      <g>
+        <line
+          x1={x}
+          y1={"5%"}
+          x2={x}
+          y2={`calc(100% - ${bottomPadding}px)`}
+          stroke={getThemeColor(METAC_COLORS.purple[active ? "600" : "300"])}
+          strokeWidth={1}
+        />
+        <circle
+          cx={x}
+          cy={y}
+          r={circleSize}
+          fill={bgColor ?? getThemeColor(METAC_COLORS.gray["200"])}
+          stroke={getThemeColor(METAC_COLORS.purple["700"])}
+          strokeWidth={active ? 2 : 1}
+        />
+        <g stroke={getThemeColor(METAC_COLORS.purple["700"])} strokeWidth={1.5}>
+          <line x1={x - xSize} y1={y - xSize} x2={x + xSize} y2={y + xSize} />
+          <line x1={x + xSize} y1={y - xSize} x2={x - xSize} y2={y + xSize} />
+        </g>
+      </g>
+    );
+  }
+
   if (isClosed) {
     return (
       <g>
@@ -72,35 +108,6 @@ const FanPoint: FC<Props> = ({
             <stop offset="1" stopColor="white" stopOpacity="0" />
           </linearGradient>
         </defs>
-      </g>
-    );
-  }
-  if (unsuccessfullyResolved) {
-    const circleSize = 8;
-    const xSize = 3;
-
-    return (
-      <g>
-        <line
-          x1={x}
-          y1={"5%"}
-          x2={x}
-          y2={`calc(100% - ${bottomPadding}px)`}
-          stroke={getThemeColor(METAC_COLORS.purple["300"])}
-          strokeWidth={1}
-        />
-        <circle
-          cx={x}
-          cy={y}
-          r={circleSize}
-          fill={bgColor ?? getThemeColor(METAC_COLORS.gray["200"])}
-          stroke={getThemeColor(METAC_COLORS.purple["700"])}
-          strokeWidth={active ? 2 : 1}
-        />
-        <g stroke={getThemeColor(METAC_COLORS.purple["700"])} strokeWidth={1.5}>
-          <line x1={x - xSize} y1={y - xSize} x2={x + xSize} y2={y + xSize} />
-          <line x1={x + xSize} y1={y - xSize} x2={x - xSize} y2={y + xSize} />
-        </g>
       </g>
     );
   }


### PR DESCRIPTION
Closes #3496

This PR updates annulled subquestions on fan graphs

Before:

<img width="1550" height="748" alt="image" src="https://github.com/user-attachments/assets/87162b66-7414-414d-afc5-3a266fbdbaaf" />

After:

<img width="1548" height="792" alt="image" src="https://github.com/user-attachments/assets/c479dc63-a275-4aae-8e2b-6985a75c9e39" />
