### PR TITLE
Add Leaderboard Chip to "..." menu for subquestions

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/sidebar_question_projects.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/sidebar_question_projects.tsx
@@ -37,6 +37,9 @@ const SidebarQuestionProjects: FC<Props> = ({ projects: projectsData }) => {
     ...leaderboard_tag,
   ];
 
+  const getChipText = (name: string, type?: string) =>
+    type === "leaderboard_tag" ? `🏆 ${name}` : name;
+
   if (allProjects.length > 0) {
     return (
       <SidebarContainer>
@@ -59,7 +62,7 @@ const SidebarQuestionProjects: FC<Props> = ({ projects: projectsData }) => {
                   })
                 }
               >
-                {element.name}
+                {getChipText(element.name, element.type)}
               </Chip>
             ))}
           </div>


### PR DESCRIPTION
Closes #1901

This PR adds a leaderboard chip

<img width="668" height="304" alt="image" src="https://github.com/user-attachments/assets/ef1e4b9e-4a5c-43c3-9f10-1c2384152620" />
