### PR TITLE
Sentry frontend: ignore middleware & app-version transactions

### DIFF
--- a/front_end/src/sentry/options.ts
+++ b/front_end/src/sentry/options.ts
@@ -16,16 +16,12 @@ export function buildSentryOptions<
     environment: process.env.METACULUS_ENV,
     dsn,
     tracesSampler: (ctx) => {
-      const name = ctx?.transactionContext?.name;
-      const op = ctx?.transactionContext?.op;
+      const name = ctx.name;
 
       // We want to limit app-version and middleware traces
       // since they’re not informative, don’t involve complex logic,
       // and currently account for up to 50% of all frontend transactions
-      if (
-        name === "GET /front_end/src/app/(api)/app-version" ||
-        op === "http.server.middleware"
-      ) {
+      if (name.startsWith("middleware ") || name.includes("/app-version")) {
         return 0.01;
       }
 


### PR DESCRIPTION
Sentry frontend: ignore middleware & app-version transactions

Currently, 50–70% of Sentry traces are flooded with low-value middleware spans and app-version requests. This PR reduces the trace sampling rate for these transactions from 10% to 1% using `tracesSampler`, helping clean up noise and improve signal-to-noise ratio in Sentry performance monitoring