### PR TITLE
Some top comments are not collapsed by default

### DIFF
--- a/front_end/src/components/comment_feed/comment_card.tsx
+++ b/front_end/src/components/comment_feed/comment_card.tsx
@@ -159,7 +159,7 @@ const CommentCard: FC<Props> = ({
   const effectiveExpanded = localExpanded ?? controlledExpanded ?? isExpanded;
 
   // Fixed height threshold - adjust this value as needed
-  const HEIGHT_THRESHOLD = 200; // pixels
+  const HEIGHT_THRESHOLD = 10; // pixels
 
   useEffect(() => {
     const measureHeight = () => {


### PR DESCRIPTION
Fixes #3416

This PR fixes the issue with not collapsed top comments.

Before:

https://github.com/user-attachments/assets/feac0221-3bf2-4ea6-a11b-00be5655fc24

After:

https://github.com/user-attachments/assets/f416a5c6-5fbf-4540-a367-adc4aca5f17a
