### PR TITLE
Consumer views qa feedback

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_layout/question_info.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_layout/question_info.tsx
@@ -58,9 +58,12 @@ const QuestionInfo: React.FC<Props> = ({
                   GroupOfQuestionsGraphType.MultipleChoiceGraph
                 }
                 prioritizeOpenSubquestions
-                className="dark:bg-dark-gray-0 mt-2 overflow-hidden bg-gray-0 p-2"
+                className="mt-2 overflow-hidden bg-gray-0 p-2 dark:bg-gray-0-dark"
               />
-              <QuestionTimeline className="bg-gray-0" postData={postData} />
+              <QuestionTimeline
+                className="bg-gray-0 dark:bg-gray-0-dark"
+                postData={postData}
+              />
             </SectionToggle>
           ) : null
         }

--- a/front_end/src/components/charts/fan_chart.tsx
+++ b/front_end/src/components/charts/fan_chart.tsx
@@ -580,11 +580,27 @@ function buildChartData({
       continue;
     }
 
+    if (option.resolved) {
+      const yVal =
+        Number.isFinite(option.resolvedValue) && option.resolvedValue != null
+          ? (option.resolvedValue as number)
+          : option.question
+            ? getResolutionPosition({ question: option.question, scaling })
+            : NaN;
+
+      resolutionPoints.push({
+        x: option.name,
+        y: yVal,
+        unsuccessfullyResolved: false,
+        resolved: true,
+      });
+    }
+
     if (
       questionForecastAvailability.isEmpty ||
       questionForecastAvailability.cpRevealsOn
     ) {
-      emptyPoints.push({ x: option.name, y: 0, unsuccessfullyResolved });
+      emptyPoints.push({ x: option.name, y: 0, unsuccessfullyResolved: false });
       continue;
     }
 
@@ -632,22 +648,6 @@ function buildChartData({
         communityLines.push(null);
         communityAreas.push(null);
       }
-    }
-
-    if (option.resolved) {
-      const yVal =
-        Number.isFinite(option.resolvedValue) && option.resolvedValue != null
-          ? (option.resolvedValue as number)
-          : option.question
-            ? getResolutionPosition({ question: option.question, scaling })
-            : NaN;
-
-      resolutionPoints.push({
-        x: option.name,
-        y: yVal,
-        unsuccessfullyResolved,
-        resolved: true,
-      });
     }
 
     if (option.userQuartiles) {

--- a/front_end/src/components/consumer_post_card/time_series_chart/time_series_label.tsx
+++ b/front_end/src/components/consumer_post_card/time_series_chart/time_series_label.tsx
@@ -95,7 +95,7 @@ const TimeSeriesLabel: FC<Props & any> = ({
           datum.isEmpty
             ? allQuestionsEmpty
               ? 0
-              : 60
+              : -5
             : ["no", "yes"].includes(datum.resolution as string)
               ? -8
               : -5


### PR DESCRIPTION
This PR addresses new consumer views qa feedback

Before:

<img width="1280" height="1154" alt="image" src="https://github.com/user-attachments/assets/6d6dbcbe-7347-4a3d-82ce-c787d912d816" />

After:

<img width="1280" height="1164" alt="image" src="https://github.com/user-attachments/assets/5d9e0a1c-4ac5-4b8c-a5b3-04b820694289" />

Before:

<img width="1280" height="757" alt="image" src="https://github.com/user-attachments/assets/ddd908d2-ff4e-4ddd-82a7-1e3459077ae6" />

After:

<img width="1280" height="775" alt="image" src="https://github.com/user-attachments/assets/59b170fc-ecef-4810-9c74-92446d3206cf" />

Before:

<img width="1280" height="988" alt="image" src="https://github.com/user-attachments/assets/cad652ea-3c4b-43f2-9ae8-af4a4b9e3038" />

After:

<img width="1280" height="1027" alt="image" src="https://github.com/user-attachments/assets/d6c1dca4-1010-436e-90d5-62cdb8c01551" />
