### PR TITLE
Resolution marker wrong direction

### DIFF
--- a/front_end/src/components/charts/continuous_area_chart.tsx
+++ b/front_end/src/components/charts/continuous_area_chart.tsx
@@ -876,7 +876,7 @@ const ContinuousAreaChart: FC<Props> = ({
                   <ResolutionDiamond
                     hoverable={false}
                     axisPadPx={3}
-                    rotateDeg={resPlacement === "left" ? -90 : 90}
+                    rotateDeg={resPlacement === "left" ? 90 : -90}
                     refProps={{}}
                   />
                 }


### PR DESCRIPTION
This PR fixes the issue with resolution diamond pointing in the wrong direction

Before:

<img width="1478" height="1130" alt="image" src="https://github.com/user-attachments/assets/44e2e79b-8351-42d0-985f-8d8a4adb45c0" />

After:

<img width="1446" height="1038" alt="image" src="https://github.com/user-attachments/assets/f17fe9f8-df09-45d3-a0c7-899105e328a5" />
