### PR TITLE
TypeError r.at is not a function

### DIFF
--- a/front_end/src/polyfills.ts
+++ b/front_end/src/polyfills.ts
@@ -1,3 +1,12 @@
 // provide any required polyfills here that will be used client-side
 import "core-js/features/array/find-last";
 import "core-js/stable/structured-clone";
+
+if (!Array.prototype.at) {
+  Array.prototype.at = function (n: number) {
+    const len = this.length >>> 0;
+    let i = Math.trunc(n) || 0;
+    if (i < 0) i += len;
+    return i < 0 || i >= len ? undefined : this[i];
+  };
+}


### PR DESCRIPTION
This PR solves the issue with at is not a function.

The problem seems to rise in the mobile safari browser 15.2

<img width="2030" height="876" alt="image" src="https://github.com/user-attachments/assets/682c1f72-b608-456f-9a1b-9394891b067d" />

Which according to this [website](https://caniuse.com/mdn-javascript_builtins_array_at) does not support that array method, so I've created a polyfill for it

<img width="2974" height="966" alt="image" src="https://github.com/user-attachments/assets/ed5faaf7-6086-40e4-9d47-9e2cd627ea3e" />
