### PR TITLE
XSS injection problem

### DIFF
--- a/front_end/src/components/theme_provider.tsx
+++ b/front_end/src/components/theme_provider.tsx
@@ -29,16 +29,22 @@ const BlockCrossTabThemeSync: FC = () => {
   return null;
 };
 
+const ALLOWED: AppTheme[] = Object.values(AppTheme);
+
 const AppThemeProvided: FC<PropsWithChildren> = ({ children }) => {
   const params = useSearchParams();
-  const themeParam = params.get(ENFORCED_THEME_PARAM) as AppTheme | null;
+  const raw = params.get(ENFORCED_THEME_PARAM);
+
+  const themeParam = (ALLOWED as readonly string[]).includes(raw ?? "")
+    ? (raw as AppTheme)
+    : undefined;
 
   return (
     <ThemeProvider
       attribute="class"
       defaultTheme="system"
       enableSystem
-      forcedTheme={themeParam ?? undefined}
+      forcedTheme={themeParam}
     >
       <BlockCrossTabThemeSync />
       <InnerTheme>{children}</InnerTheme>


### PR DESCRIPTION
This PR fixes XSS injection problem.

Root cause: `next-themes` injected a tiny inline `<script>` to set the theme before paint. When `forcedTheme` was provided, that value was interpolated into that inline script (so the page doesn’t flash).

Before:

https://github.com/user-attachments/assets/c4f9e97e-3bec-4a8a-b092-372555f552cc

After:

https://github.com/user-attachments/assets/fc455c16-51ce-4e31-b71b-85a5f4a0b4e4

Verified that there's no problem for other params:

https://github.com/user-attachments/assets/1f1de2c3-59fa-4afc-b686-6c6e7bb933e6
