### PR TITLE
Fixed Screenshots Service heroku github action

### DIFF
--- a/.github/workflows/deploy_screenshot.yml
+++ b/.github/workflows/deploy_screenshot.yml
@@ -15,5 +15,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Build and deploy to Heroku
         run: |
+          curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
           heroku container:login # uses the HEROKU_API_KEY
           cd screenshot && ./deploy_to_heroku.sh


### PR DESCRIPTION
Apparently, native Heroku CLI is deprecated in newer Ubuntu versions, so this PR installs it manually.
