### PR TITLE
Filter out annulled and ambiguous questions from resolved_questions count

### DIFF
--- a/misc/views.py
+++ b/misc/views.py
@@ -115,14 +115,9 @@ def get_site_stats(request):
     stats = {
         "predictions": Forecast.objects.filter(question__in=public_questions).count(),
         "questions": public_questions.count(),
-        "resolved_questions": public_questions.filter(
-            actual_resolve_time__isnull=False
-        ).exclude(
-            resolution__in=[
-                UnsuccessfulResolutionType.AMBIGUOUS,
-                UnsuccessfulResolutionType.ANNULLED,
-            ]
-        ).count(),
+        "resolved_questions": public_questions.filter(actual_resolve_time__isnull=False)
+        .exclude(resolution__in=UnsuccessfulResolutionType)
+        .count(),
         "years_of_predictions": now_year - 2015 + 1,
     }
     return JsonResponse(stats)


### PR DESCRIPTION
This update ensures that the resolved_questions counter in the get_site_stats view only counts questions that were successfully resolved, excluding those that were annulled or resolved as ambiguous.

Fixes #3629

Generated with [Claude Code](https://claude.ai/code)