### PR TITLE
for resolution chip, read from post.actual_resolve_time

### DIFF
--- a/front_end/src/components/post_status/index.tsx
+++ b/front_end/src/components/post_status/index.tsx
@@ -63,7 +63,7 @@ const PostStatus: FC<Props> = ({
         </>
       );
     }
-    if (status === PostStatusEnum.RESOLVED) {
+    if (status === PostStatusEnum.RESOLVED && actual_resolve_time) {
       return (
         <>
           {t("resolved")}{" "}


### PR DESCRIPTION
closes #1298 