### PR TITLE
fix retroactive resolver causing false withdrawal indication

### DIFF
--- a/questions/serializers/common.py
+++ b/questions/serializers/common.py
@@ -622,6 +622,14 @@ def serialize_question(
         scores = question.user_scores
         archived_scores = question.user_archived_scores
         user_forecasts = question.request_user_forecasts
+        last_forecast = user_forecasts[-1] if user_forecasts else None
+        if (
+            last_forecast
+            and last_forecast.end_time
+            and question.actual_close_time
+            and (last_forecast.end_time > question.actual_close_time)
+        ):
+            last_forecast.end_time = None
         serialized_data["my_forecasts"] = {
             "history": MyForecastSerializer(
                 user_forecasts,


### PR DESCRIPTION
closes #1644

discovered the underlying issue.

When a question retroactively resolves, and there is a user forecast made after it's retroactive resolve date, we just served all the forecasts made before the question closed. The last forecast in the series would thus have an `end_time`.
Usually this isn't a problem because the timeline gets truncated at the close time, so that end_time doesn't appear.
In the mentioned group question, the timelines of each subquestion are different, so the end time actually can appear on the graph, making it seem like it was withdrawn.

This just artificially removes the end time from the last forecast if it has an end time after the question's actual_close_time.