### PR TITLE
make sure most recent historical entry has a histogram

### DIFF
--- a/utils/the_math/aggregations.py
+++ b/utils/the_math/aggregations.py
@@ -971,7 +971,7 @@ def get_aggregation_history(
                 )
             else:
                 include_histogram = question.type == Question.QuestionType.BINARY and (
-                    i == last_historical_entry_index or i == (len(forecast_history) - 1)
+                    i >= last_historical_entry_index
                 )
 
             if forecast_set.forecasts_values:


### PR DESCRIPTION
closes #3658

since we started allowing for future dated withdrawal, the forecast history for a question includes future dated timesteps, we can no longer only have last aggregation have a histogram. Now the current and all future ones require a histogram.

All future require a histogram because the aggregation doesn't get recalculated, so if we pass the current aggregate's end time, the next one is used and wouldn't have a histogram.
