### PR TITLE
Binary questions week delta

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -1568,5 +1568,6 @@
   "posting": "Zveřejňování…",
   "postComment": "Zveřejnit komentář",
   "sendReport": "Odeslat hlášení",
+  "points": "body",
   "othersCount": "Ostatní ({count})"
 }

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1562,5 +1562,6 @@
   "posting": "Posting…",
   "postComment": "Post Comment",
   "sendReport": "Send Report",
+  "points": "points",
   "none": "none"
 }

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -1568,5 +1568,6 @@
   "posting": "Publicando…",
   "postComment": "Publicar comentario",
   "sendReport": "Enviar reporte",
+  "points": "puntos",
   "othersCount": "Otros ({count})"
 }

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -1566,5 +1566,6 @@
   "posting": "Publicando…",
   "postComment": "Publicar Comentário",
   "sendReport": "Enviar Relatório",
+  "points": "pontos",
   "othersCount": "Outros ({count})"
 }

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -1565,5 +1565,6 @@
   "posting": "正在發佈……",
   "postComment": "發佈評論",
   "sendReport": "發送報告",
+  "points": "點數",
   "withdrawAfterPercentSetting2": "問題總生命周期後撤回"
 }

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -1570,5 +1570,6 @@
   "posting": "正在发布…",
   "postComment": "发表评论",
   "sendReport": "发送报告",
+  "points": "积分",
   "othersCount": "其他（{count}）"
 }

--- a/front_end/src/components/cp_movement.tsx
+++ b/front_end/src/components/cp_movement.tsx
@@ -24,6 +24,7 @@ type Props = {
   size?: "xs" | "sm";
   variant?: "message" | "chip";
   boldValueUnit?: boolean;
+  suffixHidden?: boolean;
 };
 
 export const QuestionCPMovement: FC<Props> = ({
@@ -33,6 +34,7 @@ export const QuestionCPMovement: FC<Props> = ({
   size = "sm",
   variant = "message",
   boldValueUnit = false,
+  suffixHidden = false,
   unit: unitOverride,
 }) => {
   const t = useTranslations();
@@ -44,7 +46,6 @@ export const QuestionCPMovement: FC<Props> = ({
   }
 
   const mc = getMovementComponents(question, movement, t);
-
   if (!mc) return null;
 
   const unit = unitOverride ?? mc.unit;
@@ -59,19 +60,20 @@ export const QuestionCPMovement: FC<Props> = ({
       n
     );
 
+  const formattedValue = formatValueUnit(amount, unit);
   const valueNode =
-    variant === "message" ? maybeBold(formatValueUnit(amount, unit)) : <></>;
-
-  const chip =
-    variant === "chip" ? maybeBold(formatValueUnit(amount, unit)) : undefined;
+    variant === "message" ? maybeBold(formattedValue) : undefined;
+  const chip = variant === "chip" ? maybeBold(formattedValue) : undefined;
+  const periodKey = getMovementPeriodMessage(Number(movement.period));
+  const messageOriginal = t.rich(periodKey, {
+    value: () => valueNode ?? "",
+  });
 
   return (
     <PeriodMovement
       direction={movement.direction}
       chip={chip}
-      message={t.rich(getMovementPeriodMessage(Number(movement.period)), {
-        value: () => valueNode,
-      })}
+      message={suffixHidden ? valueNode : messageOriginal}
       className={cn("", className)}
       iconClassName=""
       size={size}

--- a/front_end/src/components/period_movement.tsx
+++ b/front_end/src/components/period_movement.tsx
@@ -7,7 +7,7 @@ import cn from "@/utils/core/cn";
 
 type Props = {
   direction: MovementDirection;
-  message: string | ReactNode;
+  message?: string | ReactNode;
   className?: string;
   iconClassName?: string;
   highIsGood?: boolean;
@@ -148,5 +148,4 @@ const PeriodMovement: FC<Props> = ({
     </div>
   );
 };
-
 export default PeriodMovement;

--- a/front_end/src/components/post_card/question_tile/prediction_binary_info.tsx
+++ b/front_end/src/components/post_card/question_tile/prediction_binary_info.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import { FC } from "react";
 
 import ForecastersCounter from "@/app/(main)/questions/components/forecaster_counter";
@@ -33,6 +34,7 @@ const PredictionBinaryInfo: FC<Props> = ({
   size = "sm",
   cpMovementClassName,
 }) => {
+  const t = useTranslations();
   const { hideCP } = useHideCP();
 
   if (question.status === QuestionStatus.RESOLVED && question.resolution) {
@@ -58,6 +60,8 @@ const PredictionBinaryInfo: FC<Props> = ({
             size={size === "sm" ? "xs" : "sm"}
             boldValueUnit
             variant={cpMovementVariant}
+            suffixHidden
+            unit={t("points")}
           />
         )}
       </div>


### PR DESCRIPTION
This PR simplifies CP movement updates display, when it gets truncated, preserving original behaviour in other places.

Before:

<img width="1304" height="382" alt="image" src="https://github.com/user-attachments/assets/aeb1e5ff-6f38-4304-9dbc-19124b1cbfa5" />

After:

<img width="1304" height="376" alt="image" src="https://github.com/user-attachments/assets/24344c2a-e1a4-4e2c-8032-195adb7e30d0" />

In other places stays intact:

<img width="1404" height="442" alt="image" src="https://github.com/user-attachments/assets/a5dc38d6-7045-482f-b94a-7960d614d909" />


