### PR TITLE
Missing format code blocks

### DIFF
--- a/front_end/src/app/(main)/questions/components/group_form.tsx
+++ b/front_end/src/app/(main)/questions/components/group_form.tsx
@@ -669,6 +669,7 @@ const GroupForm: React.FC<Props> = ({
             name={"resolution_criteria"}
             defaultValue={post?.group_of_questions?.resolution_criteria}
             errors={form.formState.errors.resolution_criteria}
+            withCodeBlocks
           />
         </InputContainer>
         <InputContainer
@@ -681,6 +682,7 @@ const GroupForm: React.FC<Props> = ({
             name={"fine_print"}
             defaultValue={post?.group_of_questions?.fine_print}
             errors={form.formState.errors.fine_print}
+            withCodeBlocks
           />
         </InputContainer>
         <InputContainer

--- a/front_end/src/app/(main)/questions/components/question_form.tsx
+++ b/front_end/src/app/(main)/questions/components/question_form.tsx
@@ -716,6 +716,7 @@ const QuestionForm: FC<Props> = ({
             name={"resolution_criteria"}
             defaultValue={post?.question?.resolution_criteria}
             errors={form.formState.errors.resolution_criteria}
+            withCodeBlocks
           />
         </InputContainer>
         <InputContainer
@@ -728,6 +729,7 @@ const QuestionForm: FC<Props> = ({
             name={"fine_print"}
             defaultValue={post?.question?.fine_print}
             errors={form.formState.errors.fine_print}
+            withCodeBlocks
           />
         </InputContainer>
 

--- a/front_end/src/components/question/resolution_criteria.tsx
+++ b/front_end/src/components/question/resolution_criteria.tsx
@@ -107,13 +107,13 @@ const ResolutionCriteria: FC<Props> = ({
         collapseLabel={collapseLabel}
         className="-mt-4"
       >
-        <MarkdownEditor markdown={description} />
+        <MarkdownEditor withCodeBlocks markdown={description} />
         {!!finePrint && (
           <>
             <h3 className="text-base font-normal leading-5 opacity-70">
               {t("finePrint")}
             </h3>
-            <MarkdownEditor markdown={finePrint} />
+            <MarkdownEditor withCodeBlocks markdown={finePrint} />
           </>
         )}
       </ExpandableContent>

--- a/front_end/src/components/ui/form_field.tsx
+++ b/front_end/src/components/ui/form_field.tsx
@@ -184,6 +184,7 @@ type MarkdownEditorFieldProps<T extends FieldValues = FieldValues> = {
   defaultValue?: PathValue<T, Path<T>>;
   errors?: ErrorResponse;
   className?: string;
+  withCodeBlocks?: boolean;
 };
 
 export const MarkdownEditorField = <T extends FieldValues = FieldValues>({
@@ -192,6 +193,7 @@ export const MarkdownEditorField = <T extends FieldValues = FieldValues>({
   errors,
   defaultValue,
   className,
+  withCodeBlocks,
 }: MarkdownEditorFieldProps<T>) => {
   const { field } = useController({ control, name, defaultValue });
   const editorRef = useRef<MDXEditorMethods>(null);
@@ -236,6 +238,7 @@ export const MarkdownEditorField = <T extends FieldValues = FieldValues>({
           }}
           onBlur={field.onBlur}
           className="markdown-editor-form w-full"
+          withCodeBlocks={withCodeBlocks}
         />
       </div>
       {errors && (


### PR DESCRIPTION
This PR adds support for missing code formatting blocks for fine prints and resolution criteria.

<img width="1684" height="1850" alt="image" src="https://github.com/user-attachments/assets/fcb2276a-d837-46bf-93c1-f6ee574ead87" />

<img width="1542" height="1180" alt="image" src="https://github.com/user-attachments/assets/d8f725aa-3cd8-4e12-ad4e-0e02c85da13c" />


