### PR TITLE
KeyFactors consumer views scroll comment

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_consumer_section.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_consumer_section.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { FC } from "react";
 
 import { useBreakpoint } from "@/hooks/tailwind";
+import useScrollTo from "@/hooks/use_scroll_to";
 import { KeyFactor } from "@/types/comment";
+import { sendAnalyticsEvent } from "@/utils/analytics";
 
 import { KeyFactorItem } from "./key_factor_item";
 import KeyFactorsCarousel from "./key_factors_carousel";
@@ -16,6 +19,7 @@ type Props = {
 const KeyFactorsConsumerSection: FC<Props> = ({ keyFactors }) => {
   const t = useTranslations();
   const isDesktop = useBreakpoint("sm");
+  const scrollTo = useScrollTo();
 
   return (
     <div
@@ -30,12 +34,29 @@ const KeyFactorsConsumerSection: FC<Props> = ({ keyFactors }) => {
         listClassName="pb-0 [&>:first-child]:pl-4 [&>:last-child]:pr-4 sm:[&>:first-child]:pl-0 sm:[&>:last-child]:pr-0"
         items={keyFactors}
         renderItem={(kf) => (
-          <KeyFactorItem
-            keyFactor={kf}
-            mode={"consumer"}
-            isCompact={!isDesktop}
-            className="sm:max-w-[200px]"
-          />
+          <Link
+            href={`#comment-${kf.comment_id}`}
+            className="no-underline"
+            onClick={(e) => {
+              const target = document.getElementById(
+                `comment-${kf.comment_id}`
+              );
+              if (target) {
+                e.preventDefault();
+                scrollTo(target.getBoundingClientRect().top);
+              }
+              sendAnalyticsEvent("KeyFactorClick", {
+                event_label: "fromList",
+              });
+            }}
+          >
+            <KeyFactorItem
+              keyFactor={kf}
+              mode={"consumer"}
+              isCompact={!isDesktop}
+              className="sm:max-w-[200px]"
+            />
+          </Link>
         )}
       />
     </div>

--- a/front_end/src/app/(main)/questions/[id]/components/question_layout/consumer_question_layout/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_layout/consumer_question_layout/index.tsx
@@ -1,7 +1,6 @@
 import { useTranslations } from "next-intl";
 import { PropsWithChildren, Suspense } from "react";
 
-import CommentFeed from "@/components/comment_feed";
 import DetailedGroupCard from "@/components/detailed_question_card/detailed_group_card";
 import {
   Tabs,
@@ -19,6 +18,7 @@ import NewsMatch from "../../sidebar/news_match";
 import NewsPresence from "../../sidebar/news_match/news_presence";
 import QuestionInfo from "../question_info";
 import QuestionSection from "../question_section";
+import ResponsiveCommentFeed from "./responsive_comment_feed";
 
 type Props = {
   postData: PostWithForecasts;
@@ -54,7 +54,7 @@ const ConsumerQuestionLayout: React.FC<PropsWithChildren<Props>> = ({
             </TabsList>
 
             <TabsSection value="comments">
-              <CommentFeed compactVersion postData={postData} />
+              <ResponsiveCommentFeed compactVersion postData={postData} />
             </TabsSection>
             {hasTimeline && (
               <TabsSection className="space-y-4" value="timeline">
@@ -103,7 +103,7 @@ const ConsumerQuestionLayout: React.FC<PropsWithChildren<Props>> = ({
         </div>
       </QuestionSection>
       <div className="hidden lg:block">
-        <CommentFeed postData={postData} />
+        <ResponsiveCommentFeed postData={postData} />
       </div>
     </div>
   );

--- a/front_end/src/app/(main)/questions/[id]/components/question_layout/consumer_question_layout/responsive_comment_feed.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_layout/consumer_question_layout/responsive_comment_feed.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { FC } from "react";
+
+import CommentFeed from "@/components/comment_feed";
+import { useBreakpoint } from "@/hooks/tailwind";
+import { PostWithForecasts } from "@/types/post";
+
+type Props = {
+  postData: PostWithForecasts;
+  compactVersion?: boolean;
+};
+
+/**
+ * Responsive wrapper around CommentFeed that conditionally renders based on screen size.
+ * Used in consumer question layout where both mobile (compact) and desktop versions
+ * are declared but only one should exist in DOM at a time to avoid duplicate IDs.
+ *
+ * - compactVersion: renders only on screens < lg (< 1024px)
+ * - non-compact: renders only on screens >= lg (>= 1024px)
+ */
+const ResponsiveCommentFeed: FC<Props> = ({
+  postData,
+  compactVersion = false,
+}) => {
+  const isLargeScreen = useBreakpoint("lg");
+
+  // Only render compact version on small screens, desktop version on large screens
+  if (compactVersion && isLargeScreen) {
+    return null;
+  }
+  if (!compactVersion && !isLargeScreen) {
+    return null;
+  }
+
+  return <CommentFeed postData={postData} compactVersion={compactVersion} />;
+};
+
+export default ResponsiveCommentFeed;


### PR DESCRIPTION
- Fixed consumer view comment feed: now we conditionally render feed based on viewport to prevent `id=comment-{id}` duplicates
- Now ConsumerView carousel scrolls to the relevant comment on click