### PR TITLE
fix: move Scoring Terminology inside leaderboard section

### DIFF
--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/project_leaderboard.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/project_leaderboard.tsx
@@ -1,9 +1,7 @@
-import Link from "next/link";
 import { getTranslations } from "next-intl/server";
-import { FC, Fragment } from "react";
+import { FC } from "react";
 
 import WithServerComponentErrorBoundary from "@/components/server_component_error_boundary";
-import InfoToggle from "@/components/ui/info_toggle";
 import ServerLeaderboardApi from "@/services/api/leaderboard/leaderboard.server";
 import { LeaderboardType } from "@/types/scoring";
 
@@ -37,51 +35,13 @@ const ProjectLeaderboard: FC<Props> = async ({
     ? t("openLeaderboard")
     : t("leaderboard");
 
-  const scoreType = leaderboardDetails.score_type;
-  const isPeer = scoreType === "peer_tournament";
-  const isSpotPeer = scoreType === "spot_peer_tournament";
-  const showExplainer = isPeer || isSpotPeer;
-
   return (
-    <Fragment>
-      <ProjectLeaderboardClient
-        leaderboardDetails={leaderboardDetails}
-        leaderboardTitle={leaderboardTitle}
-        isQuestionSeries={isQuestionSeries}
-        userId={userId}
-      />
-
-      {showExplainer && (
-        <div className="rounded border border-gray-300 bg-blue-100 dark:border-gray-300-dark dark:bg-blue-100-dark">
-          <InfoToggle title={t("scoringTerminology")}>
-            <div className="mt-2">
-              <dl className="m-0">
-                <div className="m-2 flex text-sm">
-                  <dt className="mr-2 w-28 flex-none font-bold">
-                    {t("score")}
-                  </dt>
-                  <dd>
-                    {t.rich(isPeer ? "peerScoreInfo" : "spotPeerScoreInfo", {
-                      link: (chunks) => (
-                        <Link
-                          href={
-                            isPeer
-                              ? "/help/scores-faq/#peer-score"
-                              : "/help/scores-faq/#spot-score"
-                          }
-                        >
-                          {chunks}
-                        </Link>
-                      ),
-                    })}
-                  </dd>
-                </div>
-              </dl>
-            </div>
-          </InfoToggle>
-        </div>
-      )}
-    </Fragment>
+    <ProjectLeaderboardClient
+      leaderboardDetails={leaderboardDetails}
+      leaderboardTitle={leaderboardTitle}
+      isQuestionSeries={isQuestionSeries}
+      userId={userId}
+    />
   );
 };
 

--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/project_leaderboard_client.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/project_leaderboard_client.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 
+import InfoToggle from "@/components/ui/info_toggle";
 import SectionToggle from "@/components/ui/section_toggle";
 import Switch from "@/components/ui/switch";
 import { LeaderboardDetails } from "@/types/scoring";
@@ -39,6 +41,11 @@ const ProjectLeaderboardClient = ({
     </div>
   );
 
+  const scoreType = leaderboardDetails.score_type;
+  const isPeer = scoreType === "peer_tournament";
+  const isSpotPeer = scoreType === "spot_peer_tournament";
+  const showExplainer = isPeer || isSpotPeer;
+
   return (
     <SectionToggle
       title={leaderboardTitle}
@@ -61,6 +68,36 @@ const ProjectLeaderboardClient = ({
         userId={userId}
         isAdvanced={isAdvanced}
       />
+      {showExplainer && (
+        <div className="rounded border border-gray-300 bg-blue-100 dark:border-gray-300-dark dark:bg-blue-100-dark">
+          <InfoToggle title={t("scoringTerminology")}>
+            <div className="mt-2">
+              <dl className="m-0">
+                <div className="m-2 flex text-sm">
+                  <dt className="mr-2 w-28 flex-none font-bold">
+                    {t("score")}
+                  </dt>
+                  <dd>
+                    {t.rich(isPeer ? "peerScoreInfo" : "spotPeerScoreInfo", {
+                      link: (chunks) => (
+                        <Link
+                          href={
+                            isPeer
+                              ? "/help/scores-faq/#peer-score"
+                              : "/help/scores-faq/#spot-score"
+                          }
+                        >
+                          {chunks}
+                        </Link>
+                      ),
+                    })}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </InfoToggle>
+        </div>
+      )}
     </SectionToggle>
   );
 };


### PR DESCRIPTION
Moved the "Scoring Terminology" InfoToggle component from outside the leaderboard to inside the SectionToggle component, matching the pattern used in the "My Score" section.

Fixes #3686

Generated with [Claude Code](https://claude.ai/code)