### PR TITLE
tweaks to global leaderboard data serving

### DIFF
--- a/scoring/views.py
+++ b/scoring/views.py
@@ -61,11 +61,14 @@ def global_leaderboard_view(
 
     user = request.user
     entries = leaderboard.entries.select_related("user").order_by("rank", "-score")
-    entries = entries.filter(
-        Q(medal__isnull=False)
-        | Q(rank__lte=max(3, np.ceil(entries.exclude(excluded=True).count() * 0.05)))
-        | Q(user_id=user.id)
-    )
+    if leaderboard.score_type != LeaderboardScoreTypes.MANUAL:
+        entries = entries.filter(
+            Q(medal__isnull=False)
+            | Q(
+                rank__lte=max(3, np.ceil(entries.exclude(excluded=True).count() * 0.05))
+            )
+            | Q(user_id=user.id)
+        )
 
     if not user.is_staff:
         bot_status: Project.BotLeaderboardStatus = leaderboard.bot_status or (

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -27,7 +27,15 @@ class BaseUserSerializer(serializers.ModelSerializer):
             "username",
             "is_bot",
             "is_staff",
+            "metadata",
         )
+
+    def get_metadata(self, obj: User):
+        data = obj.metadata
+        if data is None or not isinstance(data, dict):
+            return data
+        # only bot_details is public, other public fields may be added
+        return {key: value for key, value in data.items() if key == "bot_details"}
 
 
 class UserPublicSerializer(serializers.ModelSerializer):
@@ -68,8 +76,8 @@ class UserPublicSerializer(serializers.ModelSerializer):
         data = obj.metadata
         if data is None or not isinstance(data, dict):
             return data
-        # pro_details is private
-        return {key: value for key, value in data.items() if key != "pro_details"}
+        # only bot_details is public, other public fields may be added
+        return {key: value for key, value in data.items() if key == "bot_details"}
 
 
 class UserPrivateSerializer(UserPublicSerializer):


### PR DESCRIPTION
dont trucate results if global leaderboard is manual
add metadata to base user serializer
make only bot_details public in metadata