### PR TITLE
Fix discrete question bounds to use ≥/≤ and adjust bounds by full step

### DIFF
--- a/front_end/src/utils/charts/axis.ts
+++ b/front_end/src/utils/charts/axis.ts
@@ -565,8 +565,9 @@ export function generateScale({
       : inbound_outcome_count + openBoundCount;
 
     const halfBucket = 0.5 / inbound_outcome_count;
-    const tickStart = question?.open_lower_bound ? -halfBucket : halfBucket;
-    const tickEnd = 1 + (question?.open_upper_bound ? halfBucket : -halfBucket);
+    const fullBucket = 1 / inbound_outcome_count;
+    const tickStart = question?.open_lower_bound ? -fullBucket : halfBucket;
+    const tickEnd = 1 + (question?.open_upper_bound ? fullBucket : -halfBucket);
 
     minorTicks = range(
       tickStart,

--- a/front_end/src/utils/formatters/prediction.ts
+++ b/front_end/src/utils/formatters/prediction.ts
@@ -160,7 +160,7 @@ function checkQuartilesOutOfBorders(
     return quartile <= 0 ? "Less than " : quartile >= 1 ? "More than " : "";
   }
 
-  return quartile <= 0 ? "<" : quartile >= 1 ? ">" : "";
+  return quartile <= 0 ? "≤" : quartile >= 1 ? "≥" : "";
 }
 
 type PredictionDisplayValueParams = {


### PR DESCRIPTION
- Change inequality symbols from < and > to ≤ and ≥ for discrete question bounds
- Adjust open bounds to use full bucket step (lower_bound - step, upper_bound + step) instead of half bucket step
- Applies to both PDF/CDF graph x-axis labels and displayed resolution values

Fixes #3723

🤖 Generated with [Claude Code](https://claude.com/claude-code)