### PR TITLE
open discrete bounds should show >= next value

### DIFF
--- a/front_end/src/components/forecast_maker/continuous_table/index.tsx
+++ b/front_end/src/components/forecast_maker/continuous_table/index.tsx
@@ -189,7 +189,7 @@ const ContinuousTable: FC<Props> = ({
                 <Td></Td>
                 {question.open_lower_bound && (
                   <Td className="rounded bg-blue-400/60 p-1 dark:bg-blue-600/20 ">
-                    {getDisplayValue(0)}
+                    {getDisplayValue(-0.1)}
                   </Td>
                 )}
                 <Td className="rounded bg-blue-400/60 p-1 dark:bg-blue-600/20">
@@ -203,7 +203,7 @@ const ContinuousTable: FC<Props> = ({
                 </Td>
                 {question.open_upper_bound && (
                   <Td className="rounded bg-blue-400/60 p-1 dark:bg-blue-600/20">
-                    {getDisplayValue(1)}
+                    {getDisplayValue(1.1)}
                   </Td>
                 )}
               </>

--- a/front_end/src/utils/charts/axis.ts
+++ b/front_end/src/utils/charts/axis.ts
@@ -505,7 +505,7 @@ export function generateScale({
     !isNil(rangeMax)
   ) {
     discreteValueOptions = [];
-    for (let i = 0; i < inbound_outcome_count; i++) {
+    for (let i = -1; i < inbound_outcome_count + 1; i++) {
       discreteValueOptions.push(
         rangeMin + ((rangeMax - rangeMin) * (i + 0.5)) / inbound_outcome_count
       );
@@ -522,7 +522,7 @@ export function generateScale({
   ) {
     // get last label width to determine the number of labels
     const lastLabel = getPredictionDisplayValue(
-      1 - 0.5 / inbound_outcome_count,
+      1 + 0.5 / inbound_outcome_count,
       {
         questionType: displayType as QuestionType,
         scaling: rangeScaling,

--- a/front_end/src/utils/formatters/prediction.ts
+++ b/front_end/src/utils/formatters/prediction.ts
@@ -24,7 +24,7 @@ export function getDiscreteValueOptions(
     return undefined;
   }
   const discreteValueOptions: number[] = [];
-  for (let i = 0; i < question.inbound_outcome_count; i++) {
+  for (let i = -1; i < question.inbound_outcome_count + 1; i++) {
     discreteValueOptions.push(
       question.scaling.range_min +
         ((question.scaling.range_max - question.scaling.range_min) *


### PR DESCRIPTION
closes #3723 

include out of range values in discrete value options and display these extremes in table

Not ready to merge. `checkQuartilesOutOfBorders` needs to know if this is discrete so it should display >= for example