### PR TITLE
show user predictions after resolution

### DIFF
--- a/posts/models.py
+++ b/posts/models.py
@@ -55,14 +55,9 @@ class PostQuerySet(models.QuerySet):
             prefetches += [
                 Prefetch(
                     f"{rel}__user_forecasts",
-                    # only retrieve forecasts that were made before question close
-                    queryset=Forecast.objects.filter(author_id=user_id)
-                    .annotate(actual_close_time=F("question__actual_close_time"))
-                    .filter(
-                        Q(actual_close_time__isnull=True)
-                        | Q(start_time__lte=F("actual_close_time"))
-                    )
-                    .order_by("start_time"),
+                    queryset=Forecast.objects.filter(author_id=user_id).order_by(
+                        "start_time"
+                    ),
                     to_attr="request_user_forecasts",
                 ),
                 Prefetch(

--- a/questions/serializers/aggregate_forecasts.py
+++ b/questions/serializers/aggregate_forecasts.py
@@ -92,21 +92,6 @@ def serialize_question_aggregations(
                     "movement": None,
                 }
 
-        # Debug method for building aggregation history from scratch
-        # Will be replaced in favour of aggregation explorer
-        if not minimize:
-            aggregate_forecasts_by_method = get_aggregation_history(
-                question,
-                aggregation_methods=[
-                    AggregationMethod.RECENCY_WEIGHTED,
-                    AggregationMethod.UNWEIGHTED,
-                ],
-                minimize=False,
-                include_stats=True,
-                include_bots=question.include_bots_in_aggregates,
-                histogram=True,
-            )
-
         if question.is_cp_hidden:
             # don't show any forecasts
             aggregate_forecasts_by_method = {}


### PR DESCRIPTION
addresses #3058 
incomplete!

always give all user predictions to front end
remove some unused code
set last point of numeric timeline to actual close time if applicable

having trouble with getting resolution diamond to be visible instead of % chip on timeline
Presumably, the same changes will have to be applied to group timeline charts as well