### PR TITLE
Allow Empty Comment text for BaseRate & News

### DIFF
--- a/comments/migrations/0021_keyfactorbaserate_alter_keyfactor_driver_and_more.py
+++ b/comments/migrations/0021_keyfactorbaserate_alter_keyfactor_driver_and_more.py
@@ -113,4 +113,45 @@ class Migration(migrations.Migration):
                 name="num_nonnulls_check",
             ),
         ),
+        # Not affected real db
+        migrations.AlterField(
+            model_name="comment",
+            name="text",
+            field=models.TextField(blank=True, max_length=150000),
+        ),
+        migrations.AlterField(
+            model_name="comment",
+            name="text_cs",
+            field=models.TextField(blank=True, max_length=150000, null=True),
+        ),
+        migrations.AlterField(
+            model_name="comment",
+            name="text_en",
+            field=models.TextField(blank=True, max_length=150000, null=True),
+        ),
+        migrations.AlterField(
+            model_name="comment",
+            name="text_es",
+            field=models.TextField(blank=True, max_length=150000, null=True),
+        ),
+        migrations.AlterField(
+            model_name="comment",
+            name="text_original",
+            field=models.TextField(blank=True, max_length=150000, null=True),
+        ),
+        migrations.AlterField(
+            model_name="comment",
+            name="text_pt",
+            field=models.TextField(blank=True, max_length=150000, null=True),
+        ),
+        migrations.AlterField(
+            model_name="comment",
+            name="text_zh",
+            field=models.TextField(blank=True, max_length=150000, null=True),
+        ),
+        migrations.AlterField(
+            model_name="comment",
+            name="text_zh_TW",
+            field=models.TextField(blank=True, max_length=150000, null=True),
+        ),
     ]

--- a/comments/models.py
+++ b/comments/models.py
@@ -103,7 +103,8 @@ class Comment(TimeStampedModel, TranslatedModel):
     )
     # auto_now_add=True must be disabled when the migration is run
     is_soft_deleted = models.BooleanField(default=False, db_index=True)
-    text = models.TextField(max_length=150_000)
+    # Some comments with KeyFactors can have empty text
+    text = models.TextField(max_length=150_000, blank=True)
     on_post = models.ForeignKey(
         Post, models.CASCADE, null=True, related_name="comments"
     )

--- a/comments/services/key_factors/common.py
+++ b/comments/services/key_factors/common.py
@@ -199,10 +199,18 @@ def calculate_votes_strength(scores: list[int]):
     return (sum(scores) + 2 * max(0, 3 - len(scores))) / max(3, len(scores))
 
 
+@transaction.atomic
 def delete_key_factor(key_factor: KeyFactor):
-    # TODO: should it delete a comment if that comment was automatically created?
-
+    comment = key_factor.comment
     key_factor.delete()
+
+    # Delete comment without text if it was the last key factor
+    if (
+        not comment.text
+        and not comment.text_original
+        and not comment.key_factors.exists()
+    ):
+        comment.delete()
 
 
 def get_key_factor_question_lifetime(key_factor: KeyFactor) -> float:

--- a/comments/views/common.py
+++ b/comments/views/common.py
@@ -23,7 +23,6 @@ from comments.serializers.common import (
     CommentFilterSerializer,
     serialize_comments_of_the_week_many,
 )
-from comments.serializers.key_factors import KeyFactorWriteSerializer
 from comments.services.common import (
     set_comment_excluded_from_week_top,
     create_comment,
@@ -130,10 +129,7 @@ def comment_create_api_view(request: Request):
     on_post = serializer.validated_data["on_post"]
     parent = serializer.validated_data.get("parent")
     included_forecast = serializer.validated_data.pop("included_forecast", False)
-
-    key_factors = KeyFactorWriteSerializer(allow_null=True, many=True).run_validation(
-        request.data.get("key_factors")
-    )
+    key_factors = serializer.validated_data.pop("key_factors", None)
 
     # Small validation
     permission = get_post_permission_for_user(

--- a/tests/unit/test_comments/test_views.py
+++ b/tests/unit/test_comments/test_views.py
@@ -1,7 +1,8 @@
 import pytest  # noqa
 from django.urls import reverse
+from django_dynamic_fixture import G
 
-from comments.models import Comment, KeyFactorBaseRate, KeyFactorDriver
+from comments.models import Comment, KeyFactorBaseRate, KeyFactorDriver, KeyFactor
 from comments.services.feed import get_comments_feed
 from questions.services import create_forecast
 from tests.unit.test_comments.factories import factory_comment, factory_key_factor
@@ -225,6 +226,11 @@ class TestCommentCreation:
     def post(self, user1, question_binary):
         return factory_post(author=user1, question=question_binary)
 
+    def test_no_text_failure(self, post, user1_client, user1, user2):
+        response = user1_client.post(self.url, {"on_post": post.pk})
+
+        assert response.status_code == 400
+
     def test_private(self, post, user1_client, user1, user2):
         response = user1_client.post(
             self.url,
@@ -393,6 +399,59 @@ class TestCommentCreation:
         assert kf["base_rate"]["source"] == "Semiconductor Industry Association"
         assert kf["driver"] is None
 
+    def test_create_with_base_rate_trend__no_comment_text(self, user1_client, post):
+        """
+        We should allow comment without text if it contains a BaseRate/News key factor
+        """
+
+        response = user1_client.post(
+            self.url,
+            {
+                "on_post": post.pk,
+                "key_factors": [
+                    {
+                        "base_rate": {
+                            "type": "trend",
+                            "reference_class": "Global AI chip demand",
+                            "projected_value": 250.5,
+                            "projected_by_year": 2025,
+                            "unit": "billion USD",
+                            "extrapolation": "other",
+                            "based_on": "Moore's Law extrapolation",
+                            "source": "Semiconductor Industry Association",
+                        }
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        assert response.status_code == 201
+        assert response.data["on_post"] == post.pk
+        assert not response.data["text"]
+
+        kf = response.data["key_factors"][0]
+        assert kf["base_rate"]["type"] == "trend"
+        assert kf["base_rate"]["reference_class"] == "Global AI chip demand"
+
+    def test_create_with_driver__no_comment_text__failure(self, user1_client, post):
+        """
+        Other Key Factor types should not allow empty text
+        """
+
+        response = user1_client.post(
+            self.url,
+            {
+                "on_post": post.pk,
+                "key_factors": [
+                    {"driver": {"text": "Key Factor Driver", "impact_direction": -1}}
+                ],
+            },
+            format="json",
+        )
+
+        assert response.status_code == 400
+
     def test_create_with_mixed_key_factors(self, user1_client, post, question_binary):
         """Test creating a comment with both Driver and BaseRate key factors"""
         response = user1_client.post(
@@ -486,3 +545,46 @@ class TestKeyFactorVoting:
         response = user1_client.post(url, data={"vote": 5}, format="json")
         assert response.status_code == 200
         assert response.data["count"] == 2
+
+
+class TestKeyFactorDeletion:
+    @pytest.fixture()
+    def post(self, user1):
+        return factory_post(author=user1)
+
+    def test_regular_comment(self, user1, post, user1_client):
+        comment = factory_comment(
+            author=user1, on_post=post, text_original="Regular Comment"
+        )
+        kf = factory_key_factor(comment=comment, driver=G(KeyFactorDriver))
+
+        response = user1_client.delete(
+            reverse("key-factor-delete", kwargs={"pk": kf.pk})
+        )
+        assert response.status_code == 204
+
+        assert not KeyFactor.objects.filter(pk=kf.pk).exists()
+        assert Comment.objects.filter(pk=comment.pk).exists()
+
+    def test_empty_comment(self, user1, post, user1_client):
+        comment = factory_comment(author=user1, on_post=post)
+        kf1 = factory_key_factor(comment=comment, driver=G(KeyFactorDriver))
+        kf2 = factory_key_factor(comment=comment, driver=G(KeyFactorDriver))
+
+        response = user1_client.delete(
+            reverse("key-factor-delete", kwargs={"pk": kf1.pk})
+        )
+        assert response.status_code == 204
+
+        assert not KeyFactor.objects.filter(pk=kf1.pk).exists()
+        # Comment exists
+        assert Comment.objects.filter(pk=comment.pk).exists()
+
+        response = user1_client.delete(
+            reverse("key-factor-delete", kwargs={"pk": kf2.pk})
+        )
+        assert response.status_code == 204
+
+        assert not KeyFactor.objects.filter(pk=kf2.pk).exists()
+        # Last KF deleted - drop comment
+        assert not Comment.objects.filter(pk=comment.pk).exists()


### PR DESCRIPTION
- Small refactoring of `CommentWriteSerializer`
- Allow comment to have an empty text if it contains BaseRate or News Key Factor
- Automatically hard-delete comment if it's empty and has no key factors
- Added extra unit tests
- Small fixes