### PR TITLE
feat: Add UTC suffix to resolved date times

### DIFF
--- a/front_end/src/utils/formatters/resolution.ts
+++ b/front_end/src/utils/formatters/resolution.ts
@@ -78,7 +78,7 @@ export function formatResolution({
     if (!isNaN(Number(resolution)) && resolution.trim() !== "") {
       const date = new Date(Number(resolution));
       if (isValid(date)) {
-        return scaling
+        const formattedDate = scaling
           ? formatInTimeZone(
               date,
               "UTC",
@@ -89,13 +89,14 @@ export function formatResolution({
               })
             )
           : formatDate(locale, date);
+        return `${formattedDate} UTC`;
       }
       return resolution;
     }
 
     const date = new Date(resolution);
     if (isValid(date)) {
-      return scaling
+      const formattedDate = scaling
         ? formatInTimeZone(
             date,
             "UTC",
@@ -106,6 +107,7 @@ export function formatResolution({
             })
           )
         : formatDate(locale, date);
+      return `${formattedDate} UTC`;
     }
     return resolution;
   }


### PR DESCRIPTION
## Summary

Adds "UTC" suffix to date type question resolutions to clarify the timezone for users.

## Changes

- Modified `front_end/src/utils/formatters/resolution.ts` to append " UTC" to formatted date resolutions
- Applies to all Date type questions when displaying resolution results

## Example

- Before: "What was the final result? 13 Nov 2025 03:15"
- After: "What was the final result? 13 Nov 2025 03:15 UTC"

Fixes #3786

----

🤖 Generated with [Claude Code](https://claude.ai/code)