### PR TITLE
Deprecate images remote patterns

### DIFF
--- a/front_end/next.config.mjs
+++ b/front_end/next.config.mjs
@@ -27,11 +27,6 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "raw.githubusercontent.com",
-        pathname: "/**",
-      },
-      {
-        protocol: "https",
         hostname: "cdn.metaculus.com",
         pathname: "/**",
       },

--- a/front_end/src/app/(main)/faq/page_es.tsx
+++ b/front_end/src/app/(main)/faq/page_es.tsx
@@ -2790,7 +2790,7 @@ export default function FAQ() {
           </p>
           {/* <img alt="Interfaz de predicción" loading="lazy" width="769" height="773" decoding="async" data-nimg="1" className="my-4" style="color:transparent" srcset="/_next/image/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryooan%2Ffaq%2Fmain%2Fstatic%2Fimg%2Finterface.png&amp;w=828&amp;q=75 1x, /_next/image/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryooan%2Ffaq%2Fmain%2Fstatic%2Fimg%2Finterface.png&amp;w=1920&amp;q=75 2x" src="/_next/image/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryooan%2Ffaq%2Fmain%2Fstatic%2Fimg%2Finterface.png&amp;w=1920&amp;q=75"> */}
           <Image
-            src="https://raw.githubusercontent.com/ryooan/faq/main/static/img/interface.png"
+            src="https://cdn.metaculus.com/static/faq/interface.png"
             alt="Prediction Interface"
             className="my-4"
             width={769}
@@ -2815,7 +2815,7 @@ export default function FAQ() {
           </p>
           {/* <img alt="Interfaz acumulada" loading="lazy" width="771" height="776" decoding="async" data-nimg="1" className="my-4" style="color:transparent" srcset="/_next/image/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryooan%2Ffaq%2Fmain%2Fstatic%2Fimg%2Fcumulative.png&amp;w=828&amp;q=75 1x, /_next/image/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryooan%2Ffaq%2Fmain%2Fstatic%2Fimg%2Fcumulative.png&amp;w=1920&amp;q=75 2x" src="/_next/image/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryooan%2Ffaq%2Fmain%2Fstatic%2Fimg%2Fcumulative.png&amp;w=1920&amp;q=75"> */}
           <Image
-            src="https://raw.githubusercontent.com/ryooan/faq/main/static/img/cumulative.png"
+            src="https://cdn.metaculus.com/static/faq/cumulative.png"
             alt="Cumulative Interface"
             className="my-4"
             width={771}

--- a/front_end/src/app/(main)/faq/page_pt.tsx
+++ b/front_end/src/app/(main)/faq/page_pt.tsx
@@ -2817,7 +2817,7 @@ export default function FAQ() {
           </p>
           {/* <img alt="Prediction Interface"loading="lazy"width="769"height="773"decoding="async"data-nimg="1"className="my-4"style="color: transparent;"srcset="/_next/image/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryooan%2Ffaq%2Fmain%2Fstatic%2Fimg%2Finterface.png&amp;w=828&amp;q=75 1x, /_next/image/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryooan%2Ffaq%2Fmain%2Fstatic%2Fimg%2Finterface.png&amp;w=1920&amp;q=75 2x"src="/_next/image/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryooan%2Ffaq%2Fmain%2Fstatic%2Fimg%2Finterface.png&amp;w=1920&amp;q=75"> */}
           <Image
-            src="https://raw.githubusercontent.com/ryooan/faq/main/static/img/interface.png"
+            src="https://cdn.metaculus.com/static/faq/interface.png"
             alt="Prediction Interface"
             className="my-4"
             width={769}
@@ -2841,7 +2841,7 @@ export default function FAQ() {
           </p>
           {/* <img alt="Cumulative Interface"loading="lazy"width="771"height="776"decoding="async"data-nimg="1"className="my-4"style="color: transparent;"srcset="/_next/image/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryooan%2Ffaq%2Fmain%2Fstatic%2Fimg%2Fcumulative.png&amp;w=828&amp;q=75 1x, /_next/image/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryooan%2Ffaq%2Fmain%2Fstatic%2Fimg%2Fcumulative.png&amp;w=1920&amp;q=75 2x"src="/_next/image/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fryooan%2Ffaq%2Fmain%2Fstatic%2Fimg%2Fcumulative.png&amp;w=1920&amp;q=75"> */}
           <Image
-            src="https://raw.githubusercontent.com/ryooan/faq/main/static/img/cumulative.png"
+            src="https://cdn.metaculus.com/static/faq/cumulative.png"
             alt="Cumulative Interface"
             className="my-4"
             width={771}


### PR DESCRIPTION
Comment images have been already migrated to cdn so we can finally deprecate hardcoded buckets