### PR TITLE
Mc/3801/backend/scoring

### DIFF
--- a/tests/unit/test_scoring/test_score_math.py
+++ b/tests/unit/test_scoring/test_score_math.py
@@ -47,7 +47,7 @@ def F(q=None, v=None, s=None, e=None):
     return forecast
 
 
-def A(p: list[float] | None = None, n: int = 0, t: int | None = None):
+def A(p: list[float | None] | None = None, n: int = 0, t: int | None = None):
     # Create an AggregationEntry object with basic values
     # p: pmf
     # n: number of forecasters
@@ -75,6 +75,11 @@ class TestScoreMath:
             ([F()] * 100, [A(n=100)]),
             # maths
             ([F(v=0.7), F(v=0.8), F(v=0.9)], [A(p=[0.18171206, 0.79581144], n=3)]),
+            # multiple choice forecasts with placeholder 0s
+            (
+                [F(q=QT.MULTIPLE_CHOICE, v=[0.6, 0.15, None, 0.25])] * 2,
+                [A(n=2, p=[0.6, 0.15, 0.0, 0.25])],
+            ),
             # start times
             ([F(), F(s=1)], [A(), A(t=1, n=2)]),
             ([F(), F(s=1), F(s=2)], [A(), A(t=1, n=2), A(t=2, n=3)]),
@@ -85,7 +90,7 @@ class TestScoreMath:
             # numeric
             (
                 [F(q=QT.NUMERIC), F(q=QT.NUMERIC)],
-                [A(p=[0] + [1 / 200] * 200 + [0], n=2)],
+                [A(p=[0.0] + [1 / 200] * 200 + [0.0], n=2)],
             ),
             (
                 [
@@ -103,7 +108,10 @@ class TestScoreMath:
         result = get_geometric_means(forecasts)
         assert len(result) == len(expected)
         for ra, ea in zip(result, expected):
-            assert all(round(r, 8) == round(e, 8) for r, e in zip(ra.pmf, ea.pmf))
+            assert all(
+                ((r == e) or (round(r, 8) == round(e, 8)))
+                for r, e in zip(ra.pmf, ea.pmf)
+            )
             assert ra.num_forecasters == ea.num_forecasters
             assert ra.timestamp == ea.timestamp
 
@@ -131,6 +139,37 @@ class TestScoreMath:
             ([F(v=0.9, s=5)], {}, [S(v=84.79969066 / 2, c=0.5)]),  # half coverage
             ([F(v=2 ** (-1 / 2))], {}, [S(v=50)]),
             ([F(v=2 ** (-3 / 2))], {}, [S(v=-50)]),
+            # multiple choice w/ placeholder at index 2
+            (
+                [
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[1 / 3, 1 - 3 ** (-0.5) - 1 / 3, None, 3 ** (-0.5)],
+                    )
+                ],
+                {"resolution_bucket": 0, "question_type": QT.MULTIPLE_CHOICE},
+                [S(v=0.0)],
+            ),  # chosen to have a score of 0 for simplicity
+            (
+                [
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[1 / 3, 1 - 3 ** (-0.5) - 1 / 3, None, 3 ** (-0.5)],
+                    )
+                ],
+                {"resolution_bucket": 2, "question_type": QT.MULTIPLE_CHOICE},
+                [S(v=50)],
+            ),  # same score as index == 3 since None should read from "Other"
+            (
+                [
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[1 / 3, 1 - 3 ** (-0.5) - 1 / 3, None, 3 ** (-0.5)],
+                    )
+                ],
+                {"resolution_bucket": 3, "question_type": QT.MULTIPLE_CHOICE},
+                [S(v=50)],
+            ),  # chosen to have a score of 50 for simplicity
             # numeric
             (
                 [F(q=QT.NUMERIC)],
@@ -199,6 +238,37 @@ class TestScoreMath:
             ([F(v=0.9, s=5)], {}, [S(v=84.79969066, c=1)]),
             ([F(v=2 ** (-1 / 2))], {}, [S(v=50)]),
             ([F(v=2 ** (-3 / 2))], {}, [S(v=-50)]),
+            # multiple choice w/ placeholder at index 2
+            (
+                [
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[1 / 3, 1 - 3 ** (-0.5) - 1 / 3, None, 3 ** (-0.5)],
+                    )
+                ],
+                {"resolution_bucket": 0, "question_type": QT.MULTIPLE_CHOICE},
+                [S(v=0.0)],
+            ),  # chosen to have a score of 0 for simplicity
+            (
+                [
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[1 / 3, 1 - 3 ** (-0.5) - 1 / 3, None, 3 ** (-0.5)],
+                    )
+                ],
+                {"resolution_bucket": 2, "question_type": QT.MULTIPLE_CHOICE},
+                [S(v=50)],
+            ),  # same score as index == 3 since None should read from "Other"
+            (
+                [
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[1 / 3, 1 - 3 ** (-0.5) - 1 / 3, None, 3 ** (-0.5)],
+                    )
+                ],
+                {"resolution_bucket": 3, "question_type": QT.MULTIPLE_CHOICE},
+                [S(v=50)],
+            ),  # chosen to have a score of 50 for simplicity
             # numeric
             (
                 [F(q=QT.NUMERIC)],
@@ -319,6 +389,64 @@ class TestScoreMath:
                     S(v=100 * (0.5 * 0 + 0.5 * np.log(0.9 / gmean([0.1, 0.5]))), c=0.5),
                 ],
             ),
+            # multiple choice w/ placeholder at index 2
+            (
+                [
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[
+                            1 / 3,
+                            1 - (np.e ** (0.25) / 3) - 1 / 3,
+                            None,
+                            np.e ** (0.25) / 3,
+                        ],
+                    ),
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[1 / 3, 1 / 3, None, 1 / 3],
+                    ),
+                ],
+                {"resolution_bucket": 0, "question_type": QT.MULTIPLE_CHOICE},
+                [S(v=0), S(v=0)],
+            ),  # chosen to have a score of 0 for simplicity
+            (
+                [
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[
+                            1 / 3,
+                            1 - (np.e ** (0.25) / 3) - 1 / 3,
+                            None,
+                            np.e ** (0.25) / 3,
+                        ],
+                    ),
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[1 / 3, 1 / 3, None, 1 / 3],
+                    ),
+                ],
+                {"resolution_bucket": 2, "question_type": QT.MULTIPLE_CHOICE},
+                [S(v=25), S(v=-25)],
+            ),  # same score as index == 3 since 0.0 should read from "Other"
+            (
+                [
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[
+                            1 / 3,
+                            1 - (np.e ** (0.25) / 3) - 1 / 3,
+                            None,
+                            np.e ** (0.25) / 3,
+                        ],
+                    ),
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[1 / 3, 1 / 3, None, 1 / 3],
+                    ),
+                ],
+                {"resolution_bucket": 3, "question_type": QT.MULTIPLE_CHOICE},
+                [S(v=25), S(v=-25)],
+            ),  # chosen to have a score of 25 for simplicity
             # TODO: add tests with base forecasts different from forecasts
         ],
     )
@@ -403,6 +531,64 @@ class TestScoreMath:
                 {},
                 [S(v=100 * np.log(0.1 / 0.5)), S(v=100 * np.log(0.5 / 0.1)), S(c=0)],
             ),
+            # multiple choice w/ placeholder at index 2
+            (
+                [
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[
+                            1 / 3,
+                            1 - (np.e ** (0.25) / 3) - 1 / 3,
+                            None,
+                            np.e ** (0.25) / 3,
+                        ],
+                    ),
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[1 / 3, 1 / 3, None, 1 / 3],
+                    ),
+                ],
+                {"resolution_bucket": 0, "question_type": QT.MULTIPLE_CHOICE},
+                [S(v=0), S(v=0)],
+            ),  # chosen to have a score of 0 for simplicity
+            (
+                [
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[
+                            1 / 3,
+                            1 - (np.e ** (0.25) / 3) - 1 / 3,
+                            None,
+                            np.e ** (0.25) / 3,
+                        ],
+                    ),
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[1 / 3, 1 / 3, None, 1 / 3],
+                    ),
+                ],
+                {"resolution_bucket": 2, "question_type": QT.MULTIPLE_CHOICE},
+                [S(v=25), S(v=-25)],
+            ),  # same score as index == 3 since None should read from "Other"
+            (
+                [
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[
+                            1 / 3,
+                            1 - (np.e ** (0.25) / 3) - 1 / 3,
+                            None,
+                            np.e ** (0.25) / 3,
+                        ],
+                    ),
+                    F(
+                        q=QT.MULTIPLE_CHOICE,
+                        v=[1 / 3, 1 / 3, None, 1 / 3],
+                    ),
+                ],
+                {"resolution_bucket": 3, "question_type": QT.MULTIPLE_CHOICE},
+                [S(v=25), S(v=-25)],
+            ),  # chosen to have a score of 25 for simplicity
             # TODO: add tests with base forecasts different from forecasts
         ],
     )

--- a/tests/unit/test_utils/test_the_math/test_formulas.py
+++ b/tests/unit/test_utils/test_the_math/test_formulas.py
@@ -15,7 +15,12 @@ class TestFormulas:
     binary_details = {"type": Question.QuestionType.BINARY}
     multiple_choice_details = {
         "type": Question.QuestionType.MULTIPLE_CHOICE,
-        "options": ["A", "B", "C"],
+        "options": ["a", "c", "Other"],
+        "options_history": [
+            (0, ["a", "b", "Other"]),
+            (100, ["a", "Other"]),
+            (200, ["a", "c", "Other"]),
+        ],
     }
     numeric_details = {
         "type": Question.QuestionType.NUMERIC,
@@ -57,8 +62,10 @@ class TestFormulas:
             ("", binary_details, None),
             (None, binary_details, None),
             # Multiple choice questions
-            ("A", multiple_choice_details, 0),
-            ("C", multiple_choice_details, 2),
+            ("a", multiple_choice_details, 0),
+            ("b", multiple_choice_details, 1),
+            ("c", multiple_choice_details, 2),
+            ("Other", multiple_choice_details, 3),
             # Numeric questions
             ("below_lower_bound", numeric_details, 0),
             ("-2", numeric_details, 0),

--- a/utils/the_math/formulas.py
+++ b/utils/the_math/formulas.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from questions.constants import UnsuccessfulResolutionType
 from questions.models import Question
+from questions.services.multiple_choice_handlers import get_all_options_from_history
 from utils.typing import ForecastValues
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,8 @@ def string_location_to_scaled_location(
     if question.type == Question.QuestionType.BINARY:
         return 1.0 if string_location == "yes" else 0.0
     if question.type == Question.QuestionType.MULTIPLE_CHOICE:
-        return float(question.options.index(string_location))
+        list_of_all_options = get_all_options_from_history(question.options_history)
+        return float(list_of_all_options.index(string_location))
     # continuous
     if string_location == "below_lower_bound":
         return question.range_min - 1.0


### PR DESCRIPTION
closes #3801 

creates support for scoring questions with changing options_history
adds `multiple_choice_interpret_forecasts` for interpreting forecasts into a full-optioned version for scoring
adds support for choosing the resolution bucket index from full optioned list
adds tests for relevant parts

see issue for TODOs