### PR TITLE
Fixed Social Signup Last Login Date

### DIFF
--- a/authentication/social_pipeline.py
+++ b/authentication/social_pipeline.py
@@ -1,9 +1,20 @@
 from django.conf import settings
+from django.contrib.auth import user_logged_in
 from rest_framework.exceptions import ValidationError
 
 
 def check_signup_allowed(strategy, details, backend, user=None, *args, **kwargs):
     if not settings.PUBLIC_ALLOW_SIGNUP and not user:
         raise ValidationError("Signup is disabled")
+
+    return {"user": user, **kwargs}
+
+
+def send_user_logged_in(strategy, user=None, *args, **kwargs):
+    """
+    Sends the user_logged_in signal when a user logs in via social auth.
+    """
+    if user:
+        user_logged_in.send(sender=user.__class__, request=strategy.request, user=user)
 
     return {"user": user, **kwargs}

--- a/metaculus_web/settings.py
+++ b/metaculus_web/settings.py
@@ -208,6 +208,7 @@ SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.social_auth.associate_user",
     "social_core.pipeline.social_auth.load_extra_data",
     "social_core.pipeline.user.user_details",
+    "authentication.social_pipeline.send_user_logged_in",
 )
 
 SOCIAL_AUTH_FACEBOOK_KEY = os.environ.get("SOCIAL_AUTH_FACEBOOK_KEY")


### PR DESCRIPTION
Fixed the issue where signing in or signing up via social auth didn’t update the `User.last_login` field