### PR TITLE
fix/3815/reaffirm-single-question-in-group

### DIFF
--- a/front_end/src/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
+++ b/front_end/src/components/forecast_maker/forecast_maker_group/forecast_maker_group_continuous.tsx
@@ -351,8 +351,8 @@ const ForecastMakerGroupContinuous: FC<Props> = ({
 
   const handleSingleQuestionSubmit = useCallback(
     async (questionId: number, forecastExpiration: ForecastExpirationValue) => {
-      const optionToSubmit = questionsToSubmit.find(
-        (opt) => opt.id === questionId
+      const optionToSubmit = groupOptions.find(
+        (opt) => opt.question.id === questionId
       );
 
       if (!optionToSubmit) return;


### PR DESCRIPTION
closes #3815

looks like `questionsToSubmit` only includes `isDirty` options, so reaffirming a single option resulted in no `optionToSubmit` so that `handleSingleQuestionSubmit` defaulted to return nothing.
Changing to using all `groupOptions` works properly, but I'm not certain this is the intended list to use at this point, so it would be good to get a review on this.