### PR TITLE
fix: show comments on medium screens in consumer views

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_layout/consumer_question_layout/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_layout/consumer_question_layout/index.tsx
@@ -108,7 +108,7 @@ const ConsumerQuestionLayout: React.FC<PropsWithChildren<Props>> = ({
           />
         </div>
       </QuestionSection>
-      <div className="hidden lg:block">
+      <div className="hidden sm:block">
         <ResponsiveCommentFeed postData={postData} />
       </div>
     </div>


### PR DESCRIPTION
Fixes #3846

### Changes
Changed ResponsiveCommentFeed display breakpoint from `lg:block` to `sm:block` to ensure comments are visible for screen widths between 640px and 1024px.

Previously, comments were hidden in this range because the tabbed version was hidden at sm (≥640px) and the feed version only appeared at lg (≥1024px).

### Testing
To verify the fix:
1. Open any question page in consumer view
2. Resize browser window to 640px-1024px range
3. Confirm comments are now visible

---
Generated with [Claude Code](https://claude.ai/code)