### PR TITLE
Added LRU Cache for ConcurrentRateLimiter Redis Backend

### DIFF
--- a/utils/dramatiq.py
+++ b/utils/dramatiq.py
@@ -7,6 +7,7 @@ from dramatiq.rate_limits import ConcurrentRateLimiter
 from dramatiq.rate_limits.backends import RedisBackend
 
 
+@functools.lru_cache(maxsize=None)
 def get_redis_backend():
     """
     ConcurrentRateLimiter uses the same Redis db index as redis queue


### PR DESCRIPTION
Currently, each task execution utilizing ConcurrentRateLimiter re-initializes the RedisBackend. This triggers a full Redis connection setup for every single job, causing unnecessary overhead.

This PR adds @functools.lru_cache to the backend getter. The backend instance (and its internal connection pool) is now lazy-loaded once per worker process and reused for all subsequent tasks