### PR TITLE
Social Auth Redirect to the previous page

### DIFF
--- a/front_end/src/components/auth/social_buttons.tsx
+++ b/front_end/src/components/auth/social_buttons.tsx
@@ -2,6 +2,7 @@
 
 import { faFacebook } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import React, { FC, useEffect, useState } from "react";
 
@@ -10,6 +11,7 @@ import { Google } from "@/components/icons/google";
 import Button from "@/components/ui/button";
 import LoadingSpinner from "@/components/ui/loading_spiner";
 import { SocialProvider } from "@/types/auth";
+import { addUrlParams } from "@/utils/navigation";
 
 type SocialButtonsType = {
   type: "signin" | "signup";
@@ -18,12 +20,21 @@ type SocialButtonsType = {
 const SocialButtons: FC<SocialButtonsType> = ({ type }) => {
   const t = useTranslations();
   const [socialProviders, setSocialProviders] = useState<SocialProvider[]>();
+  const pathname = usePathname();
 
   useEffect(() => {
     getSocialProviders()
       .then(setSocialProviders)
       .catch(() => setSocialProviders([]));
   }, []);
+
+  const constructSocialUrl = (originalUrl: string) =>
+    addUrlParams(originalUrl, [
+      {
+        paramName: "state",
+        paramValue: JSON.stringify({ redirect: pathname }),
+      },
+    ]);
 
   return (
     <>
@@ -35,7 +46,7 @@ const SocialButtons: FC<SocialButtonsType> = ({ type }) => {
               return (
                 <Button
                   key={provider.name}
-                  href={provider.auth_url}
+                  href={constructSocialUrl(provider.auth_url)}
                   variant="tertiary"
                   size="sm"
                   className="w-full"
@@ -52,7 +63,7 @@ const SocialButtons: FC<SocialButtonsType> = ({ type }) => {
               return (
                 <Button
                   key={provider.name}
-                  href={provider.auth_url}
+                  href={constructSocialUrl(provider.auth_url)}
                   variant="tertiary"
                   size="sm"
                   className="w-full"

--- a/front_end/src/utils/navigation.ts
+++ b/front_end/src/utils/navigation.ts
@@ -180,3 +180,29 @@ export const getPostEditLink = (post: Post) => {
 
   return `/questions/create/${edit_type}?post_id=${post.id}`;
 };
+
+/**
+ * Ensures a safe, normalized relative redirect path.
+ */
+export function ensureRelativeRedirect(input: string): string {
+  if (!input) return "/";
+
+  let url = input.trim();
+
+  if (url.startsWith("//")) {
+    throw new Error(
+      "Unsafe redirect URL: protocol-relative URLs are not allowed"
+    );
+  }
+
+  url = url.replace(/^\/+/, "");
+
+  if (/^[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(url)) {
+    throw new Error(
+      "Unsafe redirect URL: absolute or protocol URLs are not allowed"
+    );
+  }
+
+  // Normalize slashes
+  return "/" + url;
+}


### PR DESCRIPTION
- Users logging in via Google/Facebook will now be redirected back to the page they were on instead of always landing on the homepage. We encode the current path in the OAuth `state` param as JSON, then parse it on callback and redirect there. 
- Added validation to ensure the redirect path starts with / to prevent open redirect attacks

closes #3890 