### PR TITLE
Fixed Maximum call stack size exceeded error in middleware

### DIFF
--- a/front_end/src/middleware.ts
+++ b/front_end/src/middleware.ts
@@ -10,8 +10,8 @@ import {
   getAlphaTokenSession,
   getServerSession,
 } from "@/services/session";
-import { ErrorResponse } from "@/types/fetch";
 import { getAlphaAccessToken } from "@/utils/alpha_access";
+import { ApiError } from "@/utils/core/errors";
 import { getPublicSettings } from "@/utils/public_settings.server";
 
 export async function middleware(request: NextRequest) {
@@ -39,7 +39,7 @@ export async function middleware(request: NextRequest) {
     try {
       await ServerAuthApi.verifyToken();
     } catch (error) {
-      const errorResponse = error as ErrorResponse;
+      const errorResponse = error as ApiError;
 
       if (errorResponse?.response?.status === 403) {
         request.cookies.delete(COOKIE_NAME_TOKEN);


### PR DESCRIPTION
Initially, we designed the auth flow so that if the frontend sends an invalid auth token, the backend would catch the 403 in middleware and automatically remove the cookie to prevent the user from getting stuck in an infinite loop.

It turned out this didn’t work in production because of Sentry logging. After a long investigation, I found that the middleware wasn’t catching the expected `ApiError` because Next.js was throwing `RangeError: Maximum call stack size exceeded`, which caused both performance issues and broken behavior.

I’m still not completely sure why this happened, but it seems Next.js has some ad-hoc logic that traces errors and logs console output, which triggered recursion inside `ApiError.response`.

The fix was to create a truncated version of the `ApiError.response` object, which resolves the recursion problem.
