### PR TITLE
fix: Display option names instead of "Yes" in feed tile resolution chips

### DIFF
--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -859,7 +859,9 @@ const ResolutionChip: FC<{
   const { getThemeColor } = useAppTheme();
   const { x, y, compact, datum, chartHeight, text, color, scale } = props;
   const adjustedText =
-    compact && text.length > RESOLUTION_TEXT_LIMIT ? "Yes" : text;
+    compact && text.length > RESOLUTION_TEXT_LIMIT
+      ? text.slice(0, RESOLUTION_TEXT_LIMIT) + "..."
+      : text;
   const [textWidth, setTextWidth] = useState(0);
   const textRef = useRef<SVGTextElement>(null);
 


### PR DESCRIPTION
## Summary
Changed the ResolutionChip component to show truncated option names instead of replacing them with "Yes" when in compact mode. This ensures users can identify which option resolved even in the feed view.

Fixes #3929

🤖 Generated with [Claude Code](https://claude.ai/code)