### PR TITLE
Update tournaments ordering

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/live_tournament_card.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/live_tournament_card.tsx
@@ -11,6 +11,7 @@ import { bucketRelativeMs } from "@/utils/formatters/date";
 
 import TournamentCardShell from "./tournament_card_shell";
 import GradientProgressLine from "../../../tournament/components/gradient_progress_line";
+import { safeTs } from "../../helpers";
 
 type Props = {
   item: TournamentPreview;
@@ -257,12 +258,6 @@ function ClosedChip({
       />
     </div>
   );
-}
-
-function safeTs(iso?: string | null): number | null {
-  if (!iso) return null;
-  const t = new Date(iso).getTime();
-  return Number.isFinite(t) ? t : null;
 }
 
 function clamp01(x: number) {

--- a/front_end/src/app/(main)/(tournaments)/tournaments/helpers/index.ts
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/helpers/index.ts
@@ -37,3 +37,9 @@ export function selectTournamentsForSection(
       (t.type !== TournamentType.Index || !!t.prize_pool)
   );
 }
+
+export function safeTs(iso?: string | null): number | null {
+  if (!iso) return null;
+  const t = new Date(iso).getTime();
+  return Number.isFinite(t) ? t : null;
+}


### PR DESCRIPTION
This PR updates tournaments page ordering.

- First order by tournament status so that open tournaments are at the top.
- Second by the order field in the admin page.
- Third by the percentage of tournament duration that has passed (e.g., a 10-year tournament starting its 2nd year is ranked higher than a 1-year tournament in its 6th month).