### PR TITLE
Update tournament closing display logic

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/components/tournament_timeline.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/components/tournament_timeline.tsx
@@ -39,9 +39,19 @@ const TournamentTimeline: FC<Props> = async ({ tournament }) => {
     all_questions_closed,
   } = tournament.timeline;
 
+  const latestScheduledCloseTimestamp = getTimestampFromDateString(
+    tournament.forecasting_end_date || tournament.close_date
+  );
+
+  const nowTs = Date.now();
+  const hasCloseDate = latestScheduledCloseTimestamp > 0;
+  const shouldShowClosedTimeline =
+    all_questions_closed &&
+    (!hasCloseDate || nowTs >= latestScheduledCloseTimestamp);
+
   return (
     <div className="mt-4 flex flex-col gap-x-5 gap-y-4 sm:mt-5 sm:flex-row">
-      {!all_questions_closed ? (
+      {!shouldShowClosedTimeline ? (
         <ActiveTournamentTimeline
           tournament={tournament}
           lastParticipationDayTimestamp={
@@ -49,9 +59,7 @@ const TournamentTimeline: FC<Props> = async ({ tournament }) => {
               ? getTimestampFromDateString(last_cp_reveal_time)
               : null
           }
-          latestScheduledCloseTimestamp={getTimestampFromDateString(
-            tournament.forecasting_end_date || tournament.close_date
-          )}
+          latestScheduledCloseTimestamp={latestScheduledCloseTimestamp}
         />
       ) : (
         <ClosedTournamentTimeline
@@ -59,9 +67,7 @@ const TournamentTimeline: FC<Props> = async ({ tournament }) => {
           latestScheduledResolutionTimestamp={getTimestampFromDateString(
             latest_scheduled_resolve_time
           )}
-          latestActualCloseTimestamp={getTimestampFromDateString(
-            tournament.forecasting_end_date || tournament.close_date
-          )}
+          latestActualCloseTimestamp={latestScheduledCloseTimestamp}
           isAllQuestionsResolved={all_questions_resolved}
           latestActualResolutionTimestamp={getTimestampFromDateString(
             latest_actual_resolve_time

--- a/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/live_tournament_card.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/live_tournament_card.tsx
@@ -115,20 +115,23 @@ function TournamentTimelineBar({
   const closedTs = safeTs(forecastingEndDate ?? closeDate ?? null);
   if (!startTs || !closedTs) return null;
 
-  const isClosed =
+  const now = nowTs ?? Date.now();
+
+  const rawClosed =
     timeline?.all_questions_closed != null
       ? Boolean(timeline.all_questions_closed)
       : !isOngoing;
 
+  const isClosed = rawClosed && now >= closedTs;
   const isResolved = Boolean(timeline?.all_questions_resolved);
 
   if (!isClosed) {
-    return <ActiveMiniBar nowTs={nowTs} startTs={startTs} endTs={closedTs} />;
+    return <ActiveMiniBar nowTs={now} startTs={startTs} endTs={closedTs} />;
   }
 
   return (
     <ClosedMiniBar
-      nowTs={nowTs}
+      nowTs={now}
       isResolved={isResolved}
       closeDate={closeDate ?? null}
       timeline={timeline}


### PR DESCRIPTION
This PR updates tournament closing display logic, so that we do not show tournaments as Closed before their relevant date has been reached

Before:

<img width="810" height="308" alt="image" src="https://github.com/user-attachments/assets/49c1d41b-de17-4432-8a66-0875bbe5ae83" />

After:

<img width="812" height="291" alt="image" src="https://github.com/user-attachments/assets/fa53cdd6-6433-45cf-9996-0a2e35a58cd2" />
