### PR TITLE
Make twitter embeds smaller

### DIFF
--- a/front_end/src/components/markdown_editor/editor.css
+++ b/front_end/src/components/markdown_editor/editor.css
@@ -11,15 +11,16 @@
     --tweet-container-margin: 0 !important;
   }
   .tweets-wrapper {
-    @apply grid auto-cols-fr grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-2.5;
+    @apply grid gap-2.5;
+    grid-template-columns: 1fr;
+
     & > p {
       @apply m-0;
+      min-width: 0;
     }
+
     .react-tweet-theme {
       @apply !max-w-full;
-    }
-    & > *:last-child:nth-child(2n + 1) {
-      @apply col-span-full;
     }
   }
 }
@@ -129,4 +130,55 @@
 
 div:has(.prism-code) + p:has(> br:only-child) {
   display: none;
+}
+@media (min-width: 1024px) {
+  .markdown-editor.markdown-editor-read .tweets-wrapper {
+    display: block;
+    column-count: 2;
+    column-gap: 0.625rem;
+  }
+
+  .markdown-editor.markdown-editor-read .tweets-wrapper > p {
+    display: inline-block;
+    width: 100%;
+    break-inside: avoid;
+    margin: 0 0 0.625rem 0;
+  }
+
+  .markdown-editor.markdown-editor-read
+    .tweets-wrapper:has(> p:nth-child(2)):not(:has(> p:nth-child(3))) {
+    display: grid !important;
+    column-count: initial !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.625rem;
+    align-items: start;
+  }
+
+  .markdown-editor.markdown-editor-read
+    .tweets-wrapper:has(> p:nth-child(2)):not(:has(> p:nth-child(3)))
+    > p {
+    display: block;
+    width: auto;
+    margin: 0;
+    min-width: 0;
+  }
+}
+
+.tweets-wrapper > p > br {
+  display: none !important;
+}
+
+.tweets-wrapper > p {
+  container-type: inline-size;
+  container-name: tweetItem;
+}
+
+.tweets-wrapper > p .tweet-embed-scroll {
+  max-height: calc(150cqw);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.tweets-wrapper > p .tweet-embed {
+  max-height: calc(150cqw);
 }

--- a/front_end/src/components/markdown_editor/embedded_twitter/index.tsx
+++ b/front_end/src/components/markdown_editor/embedded_twitter/index.tsx
@@ -5,10 +5,20 @@ import createEditorComponent from "../createJsxComponent";
 
 export const EMBEDDED_TWITTER_COMPONENT_NAME = "Tweet";
 
+const TweetEmbed: React.FC<{ id: string }> = ({ id }) => {
+  return (
+    <div className="tweet-embed" data-embed="tweet">
+      <div className="tweet-embed-scroll">
+        <Tweet id={id} />
+      </div>
+    </div>
+  );
+};
+
 export const tweetDescriptor: JsxComponentDescriptor = {
   name: EMBEDDED_TWITTER_COMPONENT_NAME,
   props: [{ name: "id", type: "string", required: true }],
   kind: "text",
   hasChildren: false,
-  Editor: createEditorComponent(Tweet),
+  Editor: createEditorComponent(TweetEmbed),
 };

--- a/front_end/src/components/markdown_editor/initialized_editor.tsx
+++ b/front_end/src/components/markdown_editor/initialized_editor.tsx
@@ -335,6 +335,7 @@ const InitializedMarkdownEditor: FC<
         "content markdown-editor",
         {
           "dark-theme": theme === "dark",
+          "markdown-editor-read": mode === "read",
         },
         className
       )}


### PR DESCRIPTION
Closes #3847 

This PR does the following:
- sets the 1/2 width container even if it's only a single embed
- sets a max height on each container with overflow-y:auto; so it has scrolling enabled

<img width="1242" height="1198" alt="image" src="https://github.com/user-attachments/assets/aef5aa36-6238-4f58-9f08-e33424f45a94" />

<img width="1266" height="1122" alt="image" src="https://github.com/user-attachments/assets/10aeba28-9493-45d1-ba8f-07459a95beea" />
