### PR TITLE
enforce maximum pmf value of 0.2 for full-res continuous questions

### DIFF
--- a/questions/serializers/common.py
+++ b/questions/serializers/common.py
@@ -487,9 +487,8 @@ class ForecastWriteSerializer(serializers.ModelSerializer):
                 f"{min_diff} at every step.\n"
             )
         # Check if maximum difference between cdf points is acceptable
-        # (0.59 if inbound outcome count is the default 200)
-        # TODO: switch this value to 0.2 after coordinating
-        max_diff = 0.59 * DEFAULT_INBOUND_OUTCOME_COUNT / inbound_outcome_count
+        # (0.2 if inbound outcome count is the default 200)
+        max_diff = 0.2 * DEFAULT_INBOUND_OUTCOME_COUNT / inbound_outcome_count
         if not all(inbound_pmf <= max_diff):
             errors += (
                 "continuous_cdf must be increasing by no more than "


### PR DESCRIPTION
The CodeRabbit comment below is inaccurate, but keeping it up for documentation purposes. This isn't a bug fix, nor is it associated with quality standards or data consistency.
This is a policy decision that has been waiting to be activated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved continuous probability distribution validation by tightening the maximum allowed difference between consecutive data points, ensuring stricter quality standards for data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->