### PR TITLE
Changes to FAQ, mainly adding Comment of the Week

### DIFF
--- a/front_end/src/app/(main)/faq/page.tsx
+++ b/front_end/src/app/(main)/faq/page.tsx
@@ -3235,19 +3235,22 @@ export default async function FAQ() {
           </h3>
           <p>
             For certain projects, Metaculus employs{" "}
-            <Link href="/pro-forecasters">Pro Forecasters</Link> who have
-            demonstrated excellent forecasting ability and who have a history of
-            clearly describing their rationales. Pros forecast on private and
-            public sets of questions to produce well-calibrated forecasts and
-            descriptive rationales for our partners. We primarily recruit
-            members of the Metaculus community with the best track records for
-            our Pro team, but forecasters who have demonstrated excellent
-            forecasting ability elsewhere may be considered as well.
+            <Link href="/services/pro-forecasters/">Pro Forecasters</Link> who
+            have demonstrated excellent forecasting ability and who have a
+            history of clearly describing their rationales. Pros forecast on
+            private and public sets of questions to produce well-calibrated
+            forecasts and descriptive rationales for our partners. We primarily
+            recruit members of the Metaculus community with the best track
+            records for our Pro team, but forecasters who have demonstrated
+            excellent forecasting ability elsewhere may be considered as well.
           </p>
           <p>
             If you&apos;re interested in hiring Metaculus Pro Forecasters for a
             project, reach out to us by completing our{" "}
-            <Link href="/contact">contact form</Link>.
+            <Link href="/services/pro-forecasters/#contact-us">
+              contact form
+            </Link>
+            .
           </p>
 
           <p>
@@ -3260,15 +3263,15 @@ export default async function FAQ() {
             <li>
               <strong>Excellent forecasting ability:</strong> Our Pro selection
               methodology uses the{" "}
-              <Link href="/leaderboards">Metaculus Leaderboards</Link>,
-              combining the Peer Accuracy, Baseline Accuracy, and Comments
-              leaderboards to produce a weighted average score across those
-              leaderboards and across different leaderboard periods. Pros are
-              selected from forecasters who have the highest score on this
-              combined metric, representing the very best forecasters from all
-              of Metaculus. Note that while the Peer score is weighted highest
-              in this combined metric, the weighting is such that forecasters
-              must have good scores in all categories.
+              <Link href="/leaderboard">Metaculus Leaderboards</Link>, combining
+              the Peer Accuracy, Baseline Accuracy, and Comments leaderboards to
+              produce a weighted average score across those leaderboards and
+              across different leaderboard periods. Pros are selected from
+              forecasters who have the highest score on this combined metric,
+              representing the very best forecasters from all of Metaculus. Note
+              that while the Peer score is weighted highest in this combined
+              metric, the weighting is such that forecasters must have good
+              scores in all categories.
             </li>
 
             <li>

--- a/front_end/src/app/(main)/faq/page_es.tsx
+++ b/front_end/src/app/(main)/faq/page_es.tsx
@@ -3646,8 +3646,8 @@ export default function FAQ() {
           </h3>
           <p>
             Para ciertos proyectos, Metaculus emplea{" "}
-            <Link href="/pro-forecasters">Pro Forecasters</Link> que han
-            demostrado una excelente capacidad de pronóstico y que tienen un
+            <Link href="/services/pro-forecasters/">Pro Forecasters</Link> que
+            han demostrado una excelente capacidad de pronóstico y que tienen un
             historial de describir con claridad sus razonamientos. Los Pros
             pronostican en conjuntos privados y públicos de preguntas para
             producir pronósticos bien calibrados y de alta calidad para
@@ -3657,7 +3657,10 @@ export default function FAQ() {
           <p>
             Si te interesa contratar Pro Forecasters de Metaculus para un
             proyecto, contáctanos completando nuestro{" "}
-            <Link href="/contact">formulario de contacto</Link>.
+            <Link href="/services/pro-forecasters/#contact-us">
+              formulario de contacto
+            </Link>
+            .
           </p>
 
           <p>
@@ -3671,7 +3674,7 @@ export default function FAQ() {
             <li>
               <strong>Excelente capacidad de pronóstico:</strong> Nuestra
               metodología de selección utiliza los{" "}
-              <Link href="/leaderboards">Leaderboards de Metaculus</Link>,
+              <Link href="/leaderboard">Leaderboards de Metaculus</Link>,
               combinando los leaderboards de Peer Accuracy, Baseline Accuracy y
               Comments para producir un puntaje promedio ponderado (a través de
               esos leaderboards y de distintos períodos). Los Pros se

--- a/front_end/src/app/(main)/faq/page_pt.tsx
+++ b/front_end/src/app/(main)/faq/page_pt.tsx
@@ -3693,7 +3693,7 @@ M834 80h400000v40h-400000z"
           </h3>
           <p>
             Para certos projetos, o Metaculus emprega{" "}
-            <Link href="/pro-forecasters">Pro Forecasters</Link> que
+            <Link href="/services/pro-forecasters/">Pro Forecasters</Link> que
             demonstraram excelente habilidade de previsão e têm um histórico de
             descrever claramente seus raciocínios. Os Pros fazem previsões em
             conjuntos privados e públicos de perguntas para produzir previsões
@@ -3704,7 +3704,10 @@ M834 80h400000v40h-400000z"
           <p>
             Se você tem interesse em contratar Pro Forecasters do Metaculus para
             um projeto, entre em contato conosco preenchendo nosso{" "}
-            <Link href="/contact">formulário de contato</Link>.
+            <Link href="/services/pro-forecasters/#contact-us">
+              formulário de contato
+            </Link>
+            .
           </p>
 
           <p>
@@ -3717,7 +3720,7 @@ M834 80h400000v40h-400000z"
             <li>
               <strong>Excelente capacidade de previsão:</strong> Nossa
               metodologia de seleção usa os{" "}
-              <Link href="/leaderboards">Leaderboards do Metaculus</Link>,
+              <Link href="/leaderboard">Leaderboards do Metaculus</Link>,
               combinando os leaderboards de Peer Accuracy, Baseline Accuracy e
               Comments para produzir uma pontuação média ponderada (ao longo
               desses leaderboards e de diferentes períodos). Os Pros são


### PR DESCRIPTION
Closes #3513

This PR udpates FAQ sections.

- Created new Features section with "What is NewsMatch?" and "What is Top Comments of the Week?"
- Updated "What are Metaculus Pro Forecasters" section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized FAQ (EN/ES/PT) to add a consolidated "Features/Recursos/Funciones" section highlighting NewsMatch and Top Comments of the Week.
  * Removed or consolidated duplicated NewsMatch/Community Insights blocks and adjusted navigation/anchors.
  * Updated Pro Forecasters content: standardized wording, new service link, replaced email with a contact form, and converted numbered criteria into clearer bulleted selection/explanation points.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->