### PR TITLE
Sentry: exclude non-metaculus errors

### DIFF
--- a/front_end/src/sentry/options.ts
+++ b/front_end/src/sentry/options.ts
@@ -6,6 +6,7 @@ import type {
 
 import {
   beforeSentryAlertSend,
+  SENTRY_DENY_URLS,
   SENTRY_IGNORE_ERRORS,
 } from "@/utils/core/errors";
 
@@ -27,7 +28,8 @@ export function buildSentryOptions<
 
       return 0.1;
     },
-    ignoreErrors: SENTRY_IGNORE_ERRORS as (string | RegExp)[],
+    ignoreErrors: SENTRY_IGNORE_ERRORS,
+    denyUrls: SENTRY_DENY_URLS,
     beforeSend: beforeSentryAlertSend,
   } as T;
 }

--- a/front_end/src/utils/core/errors.ts
+++ b/front_end/src/utils/core/errors.ts
@@ -165,6 +165,14 @@ export const SENTRY_IGNORE_ERRORS: string[] = [
   "Can't find variable: logMutedMessage",
 ];
 
+export const SENTRY_DENY_URLS: (string | RegExp)[] = [
+  /^app:\/\/\//,
+  /extensions\//i,
+  /^chrome:\/\//i,
+  /^chrome-extension:\/\//i,
+  /^moz-extension:\/\//i,
+];
+
 export function beforeSentryAlertSend(event: ErrorEvent, hint: EventHint) {
   const error = hint.originalException;
 


### PR DESCRIPTION
Sometime we get a lot of noisy sentry alerts coming from non-site places like chrome extensions, 3rd party apps and etc. This PR adds such to the denylist

Example:
- https://metaculus.sentry.io/issues/7191000638/?referrer=slack&notification_uuid=973ef026-ac9a-4988-891d-f058195ab86c&environment=production&alert_rule_id=15493011&alert_type=issue
- https://metaculus.sentry.io/issues/7191000635/?referrer=slack&notification_uuid=381bf995-994b-46ca-9b50-6084a39ffec3&environment=production&alert_rule_id=15493011&alert_type=issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to exclude specific URLs from error tracking, providing more granular control over error monitoring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->