### PR TITLE
Unify consumer notebooks representation

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_layout/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_layout/index.tsx
@@ -20,7 +20,6 @@ const QuestionLayout: React.FC<PropsWithChildren<Props>> = ({
   return (
     <QuestionLayoutProvider>
       <QuestionVariantComposer
-        postData={postData}
         consumer={
           <ConsumerQuestionLayout
             postData={postData}

--- a/front_end/src/app/(main)/questions/[id]/components/question_layout/question_info.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_layout/question_info.tsx
@@ -46,7 +46,6 @@ const QuestionInfo: React.FC<Props> = ({
       )}
 
       <QuestionVariantComposer
-        postData={postData}
         forecaster={<PostScoreData post={postData} />}
         consumer={
           <div className="hidden sm:block">
@@ -65,7 +64,6 @@ const QuestionInfo: React.FC<Props> = ({
       <BackgroundInfo post={postData} />
 
       <QuestionVariantComposer
-        postData={postData}
         consumer={
           isGroupOfQuestionsPost(postData) &&
           postData.group_of_questions.graph_type ===

--- a/front_end/src/app/(main)/questions/[id]/components/question_variant_composer.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_variant_composer.tsx
@@ -5,15 +5,12 @@ import { useFeatureFlagVariantKey } from "posthog-js/react";
 import { ReactNode } from "react";
 
 import { useAuth } from "@/contexts/auth_context";
-import { PostWithForecasts } from "@/types/post";
 import { CurrentUser, InterfaceType } from "@/types/users";
-import { isConditionalPost, isNotebookPost } from "@/utils/questions/helpers";
 
 type Variant = "forecaster" | "consumer";
 const FLAG_KEY = "logged_out_question_view_variant";
 
 export type QuestionVariantComposerProps = {
-  postData: PostWithForecasts;
   consumer: ReactNode;
   forecaster: ReactNode;
 };
@@ -26,7 +23,6 @@ function getVariantFromUser(user: CurrentUser | null): Variant | null {
 }
 
 export const QuestionVariantComposer = ({
-  postData,
   consumer,
   forecaster,
 }: QuestionVariantComposerProps) => {
@@ -38,10 +34,7 @@ export const QuestionVariantComposer = ({
     return <>{forcedByUser === "consumer" ? consumer : forecaster}</>;
   }
 
-  const isEligibleLoggedOut =
-    isNil(user) && !isNotebookPost(postData) && !isConditionalPost(postData);
-
-  if (isEligibleLoggedOut) {
+  if (isNil(user)) {
     const v = flagVariant === "forecaster" ? "forecaster" : "consumer";
     return <>{v === "consumer" ? consumer : forecaster}</>;
   }

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/index.tsx
@@ -15,7 +15,6 @@ const QuestionView: React.FC<Props> = ({
 }) => {
   return (
     <QuestionVariantComposer
-      postData={postData}
       consumer={<ConsumerQuestionView postData={postData} />}
       forecaster={
         <ForecasterQuestionView

--- a/front_end/src/components/posts_feed/paginated_feed.tsx
+++ b/front_end/src/components/posts_feed/paginated_feed.tsx
@@ -139,7 +139,6 @@ const PaginatedPostsFeed: FC<Props> = ({
 
     return (
       <QuestionVariantComposer
-        postData={post}
         consumer={
           <ConsumerPostCard
             post={post}


### PR DESCRIPTION
This PR makes notebooks look the same for authenticated and anonymous users.

Before for anonymous:

<img width="787" height="318" alt="image" src="https://github.com/user-attachments/assets/f8e3c4e6-0a6c-42dd-8e4e-297acd252164" />

After for anonymous:

<img width="778" height="184" alt="image" src="https://github.com/user-attachments/assets/eefc07fd-8eea-4be4-af4b-78f9869acf2b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified how the question variant selector receives data and streamlined variant selection logic.
  * Removed internal data forwarding no longer needed by the selector.

* **Chores**
  * No user-facing behavior changes; consumers and forecasters continue to work as before.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->