### PR TITLE
Explicitly configure flyio mtcl.cc domain

### DIFF
--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -235,11 +235,9 @@ jobs:
               --org ${{ vars.FLY_ORG || 'personal' }}
           fi
 
-          # Define app URLs
-          # APP_DOMAIN: fly.dev hostname (used by nginx for host validation)
-          # PUBLIC_APP_URL: vanity URL via Cloudflare Worker (shown in PR comments)
-          APP_DOMAIN="${APP_NAME}.fly.dev"
-          PUBLIC_APP_URL="https://${APP_NAME}-preview.mtcl.cc"
+          # Define app URLs (used for secrets and outputs)
+          APP_DOMAIN="${APP_NAME}-preview.mtcl.cc" 
+          PUBLIC_APP_URL="https://${APP_DOMAIN}"
 
           # Set all secrets and environment variables for the app
           # Secrets are encrypted at rest in Fly.io


### PR DESCRIPTION
Implemented `*-preview.mtcl.cc` domain previews for tmp environments.
More details and architecture -- https://github.com/Metaculus/infra/pull/23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PR preview deployment to use a new preview domain for routing and environment configuration.
  * Public preview URL generation updated to reflect the new domain, ensuring preview links point to the revised preview environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->