### PR TITLE
Add probability on hover for embeds

### DIFF
--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -463,6 +463,8 @@ const NumericChart: FC<Props> = ({
       }
     : { top: 10, bottom: BOTTOM_PADDING, left: 10, right: rightPad };
 
+  const useSimplifiedCursor = simplifiedCursor && !isEmbedded;
+
   return (
     <>
       <div
@@ -695,7 +697,7 @@ const NumericChart: FC<Props> = ({
                   data={[highlightedPoint]}
                   dataComponent={
                     <VictoryPortal>
-                      {simplifiedCursor ? (
+                      {useSimplifiedCursor ? (
                         <CursorChip
                           shouldRender={
                             isConsumerView

--- a/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
@@ -180,13 +180,17 @@ const DetailedContinuousChartCard: FC<Props> = ({
     setIsChartReady(true);
   }, []);
 
+  const isEmbed = useIsEmbedMode();
+
+  const tooltipIsConsumerView = isConsumerView && !isEmbed;
+
   const cursorTooltip = useMemo(() => {
     return (
       <QuestionPredictionTooltip
         communityPrediction={cpCursorElement}
         userPrediction={userCursorElement}
         totalForecasters={cursorData.forecasterCount}
-        isConsumerView={isConsumerView}
+        isConsumerView={tooltipIsConsumerView}
         questionStatus={question.status}
       />
     );
@@ -194,11 +198,10 @@ const DetailedContinuousChartCard: FC<Props> = ({
     cpCursorElement,
     userCursorElement,
     cursorData.forecasterCount,
-    isConsumerView,
+    tooltipIsConsumerView,
     question.status,
   ]);
 
-  const isEmbed = useIsEmbedMode();
   const shouldOverlayCp =
     isEmbed &&
     !hideCP &&
@@ -233,11 +236,13 @@ const DetailedContinuousChartCard: FC<Props> = ({
       openTime={getPostDrivenTime(question.open_time)}
       unit={question.unit}
       inboundOutcomeCount={question.inbound_outcome_count}
-      simplifiedCursor={question.type !== QuestionType.Binary || !user}
+      simplifiedCursor={
+        question.type !== QuestionType.Binary || (!user && !isEmbed)
+      }
       title={timelineTitle}
       forecastAvailability={forecastAvailability}
       cursorTooltip={
-        question.type === QuestionType.Binary && !user
+        question.type === QuestionType.Binary && !user && !isEmbed
           ? undefined
           : cursorTooltip
       }


### PR DESCRIPTION
This PR adds probability on hover display for embeds.

Before:

<img width="634" height="460" alt="image" src="https://github.com/user-attachments/assets/8bc4b957-e1da-4188-aa88-a02d574c8fae" />

After:

<img width="612" height="409" alt="image" src="https://github.com/user-attachments/assets/74843003-1258-486e-811b-347360d92a9d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor and tooltip behavior in charts to correctly handle embedded and non-embedded viewing modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->