### PR TITLE
Fix: Change default comment notification trigger from 10 to 1

### DIFF
--- a/front_end/src/components/post_subscribe/subscribe_button/utils.ts
+++ b/front_end/src/components/post_subscribe/subscribe_button/utils.ts
@@ -9,7 +9,7 @@ import { PostSubscription, PostSubscriptionType } from "@/types/post";
 export const getDefaultSubscriptionProps = () =>
   ({
     [PostSubscriptionType.NEW_COMMENTS]: {
-      comments_frequency: 10,
+      comments_frequency: 1,
     },
     [PostSubscriptionType.STATUS_CHANGE]: {},
     [PostSubscriptionType.MILESTONE]: {


### PR DESCRIPTION
When following a question, the default comment notification count was set to 10. This changes it to 1 comment as requested.

Fixes #4136

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Adjusted default comment notification frequency so new comments notify more promptly by lowering the default delay, which affects initial Notebook and Question subscriptions.
  * No other defaults or control flow were changed; existing user-controlled notification settings remain intact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->