### PR TITLE
fix: remove quotation marks from notebook example text

### DIFF
--- a/front_end/src/app/(main)/questions/create/page.tsx
+++ b/front_end/src/app/(main)/questions/create/page.tsx
@@ -187,7 +187,7 @@ const Creator: React.FC<{ searchParams: Promise<SearchParams> }> = async (
         <QuestionTypePicker
           url={createHref("/questions/create/notebook")}
           questionType={t("notebook")}
-          questionExample={`"${t("notebookExample")}"`}
+          questionExample={t("notebookExample")}
         />
       </div>
     </>


### PR DESCRIPTION
The notebook type shows descriptive text, not a question example, so it should not have quotation marks around it. This makes it consistent with its purpose as a description rather than an example question.

Fixes #491

---
Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the example text shown for notebook question types so it no longer includes stray quotation marks, improving clarity in the UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->