### PR TITLE
feat: add scientific notation support to numeric inputs

### DIFF
--- a/front_end/src/components/ui/abreviated_numeric_input.tsx
+++ b/front_end/src/components/ui/abreviated_numeric_input.tsx
@@ -104,6 +104,15 @@ const parseFormattedNumber = (value: string): number | undefined => {
   // Remove any commas and whitespace
   value = value.replace(/,|\s/g, "").toLowerCase();
 
+  // First, try to parse scientific notation (e.g., 1e5, 2.5e-3, 1.23e+10)
+  // This regex matches: optional sign, digits with optional decimal, 'e', optional sign, digits
+  const scientificMatch = value.match(/^(-?\d*\.?\d+)e([+-]?\d+)$/);
+  if (scientificMatch) {
+    const parsed = parseFloat(value);
+    return isNaN(parsed) ? undefined : parsed;
+  }
+
+  // Then try abbreviated notation (k, m, b, t)
   const multipliers: { [key: string]: number } = {
     k: 1e3,
     m: 1e6,


### PR DESCRIPTION
Updated parseFormattedNumber() in AbreviatedNumericInput to support scientific notation (e.g., 1e5, 2.5e-3, 1.23e+10) while maintaining backward compatibility with existing abbreviated notation (k, m, b, t).

This allows users to easily enter values with many zeroes, such as FLOPs questions during question creation and resolution.

Resolves #743

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Numeric input now accepts scientific notation (e.g., 1e5, 2.5e-3, 1.23e+10) alongside existing abbreviations (k, m, b, t).

* **Improvements**
  * Improved parsing robustness with explicit handling for invalid numeric results to prevent unexpected values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->