### PR TITLE
feat: disable NewsMatch component from question page sidebar

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_layout/consumer_question_layout/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_layout/consumer_question_layout/index.tsx
@@ -46,10 +46,6 @@ const ConsumerQuestionLayout: React.FC<PropsWithChildren<Props>> = ({
               {hasTimeline && (
                 <TabsTab value="timeline">{t("timeline")}</TabsTab>
               )}
-              {/* NewsMatch disabled - using News type Key Factors instead */}
-              {/* <NewsPresence questionId={postData.id}>
-                <TabsTab value="news">{t("inNews")}</TabsTab>
-              </NewsPresence> */}
               {showScores && <TabsTab value="scores">{t("scores")}</TabsTab>}
               <TabsTab value="key-factors">{t("keyFactors")}</TabsTab>
               <TabsTab value="info">{t("info")}</TabsTab>
@@ -78,14 +74,6 @@ const ConsumerQuestionLayout: React.FC<PropsWithChildren<Props>> = ({
                 />
               </TabsSection>
             )}
-            {/* NewsMatch disabled - using News type Key Factors instead */}
-            {/* <NewsPresence questionId={postData.id}>
-              <TabsSection value="news">
-                <Suspense fallback={null}>
-                  <NewsMatch questionId={postData.id} withoutToggle />
-                </Suspense>
-              </TabsSection>
-            </NewsPresence> */}
             {showScores && (
               <TabsSection value="scores">
                 <PostScoreData

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/index.tsx
@@ -32,16 +32,9 @@ const Sidebar: FC<Props> = ({
         <SidebarQuestionProjects projects={postData.projects} />
 
         {postData.curation_status === PostStatus.APPROVED && (
-          <>
-            {/* NewsMatch disabled - using News type Key Factors instead */}
-            {/* <Suspense fallback={null}>
-              <NewsMatch questionId={postData.id} />
-            </Suspense> */}
-
-            <Suspense fallback={null}>
-              <SimilarQuestions post_id={postData.id} />
-            </Suspense>
-          </>
+          <Suspense fallback={null}>
+            <SimilarQuestions post_id={postData.id} />
+          </Suspense>
         )}
       </section>
     );
@@ -74,16 +67,9 @@ const Sidebar: FC<Props> = ({
       <SidebarQuestionProjects projects={postData.projects} />
 
       {postData.curation_status === PostStatus.APPROVED && (
-        <>
-          {/* NewsMatch disabled - using News type Key Factors instead */}
-          {/* <Suspense fallback={null}>
-            <NewsMatch questionId={postData.id} />
-          </Suspense> */}
-
-          <Suspense fallback={null}>
-            <SimilarQuestions post_id={postData.id} />
-          </Suspense>
-        </>
+        <Suspense fallback={null}>
+          <SimilarQuestions post_id={postData.id} />
+        </Suspense>
       )}
     </section>
   );


### PR DESCRIPTION
## Summary
- Comment out NewsMatch rendering in sidebar (mobile and desktop layouts)
- Comment out NewsMatch tab and content in consumer question layout
- Keep code intact but disabled as per discussion
- News type Key Factors will serve as the main news source instead

Closes #4102

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Disabled News-related UI across question details and sidebar: the News tab and News widgets are removed; remaining tabs (comments, timeline, scores, key factors, info) continue to work and retain layout.
  * Simplified sidebar behavior so only similar-question suggestions display where applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->