### PR TITLE
Safari 'at' method problem

### DIFF
--- a/front_end/src/polyfills.ts
+++ b/front_end/src/polyfills.ts
@@ -10,3 +10,13 @@ if (!Array.prototype.at) {
     return i < 0 || i >= len ? undefined : this[i];
   };
 }
+
+if (!String.prototype.at) {
+  String.prototype.at = function (n: number) {
+    const s = String(this);
+    const len = s.length;
+    let i = Math.trunc(n) || 0;
+    if (i < 0) i += len;
+    return i < 0 || i >= len ? undefined : s.charAt(i);
+  };
+}


### PR DESCRIPTION
This PR adds a polyfil for 'at' method.

We were experiencing an issue with 'at' method in Safari 15.2, because it support start from 15.4

<img width="756" height="469" alt="image" src="https://github.com/user-attachments/assets/6464b9b5-49a9-4627-b243-eb98e8fe26ba" />


<img width="806" height="262" alt="image" src="https://github.com/user-attachments/assets/85286438-e756-4a5d-985b-f6afebeec80a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `at()` method on strings, enabling access to characters by index (including negative indices). Behavior matches existing array `at()` semantics for consistent indexing and out-of-range handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->