### PR TITLE
hotfix missed instances of using prediction values method

### DIFF
--- a/posts/services/subscriptions.py
+++ b/posts/services/subscriptions.py
@@ -216,13 +216,13 @@ def notify_post_cp_change(post: Post):
                     break
             if entry is None:
                 continue
-            old_forecast_values = entry.forecast_values
+            old_forecast_values = entry.get_prediction_values()
             current_entry = get_last_forecast_in_the_past(forecast_summary)
 
             if not current_entry:
                 continue
 
-            current_forecast_values = current_entry.forecast_values
+            current_forecast_values = current_entry.get_prediction_values()
             difference = prediction_difference_for_sorting(
                 old_forecast_values,
                 current_forecast_values,

--- a/questions/serializers/common.py
+++ b/questions/serializers/common.py
@@ -941,8 +941,8 @@ def serialize_question_movement(
     threshold: float = 0.0,
 ) -> dict | None:
     divergence = prediction_difference_for_sorting(
-        f1.forecast_values,
-        f2.forecast_values,
+        f1.get_prediction_values(),
+        f2.get_prediction_values(),
         question.type,
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how forecast values are retrieved and used in calculations for change notifications and question movements, potentially affecting the computation of forecast differences and divergence metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->