### PR TITLE
quickfix/hide-non-showing-entries

### DIFF
--- a/scoring/views.py
+++ b/scoring/views.py
@@ -142,6 +142,8 @@ def project_leaderboard_view(
     ).data
     entries = leaderboard.entries.order_by("rank", "-score").select_related("user")
     user = request.user
+    if not user.is_staff:
+        entries = entries.filter(Q(excluded=False) | Q(show_when_excluded=True))
 
     # manual annotations will be lost
     leaderboard_data["entries"] = LeaderboardEntrySerializer(entries, many=True).data


### PR DESCRIPTION
if user is not staff, don't even serialize hidden entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated project leaderboard visibility to properly restrict entries for non-staff users, ensuring only appropriate entries are displayed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->