### PR TITLE
Fix/4182/mc options edit before launch

### DIFF
--- a/questions/models.py
+++ b/questions/models.py
@@ -319,10 +319,11 @@ class Question(TimeStampedModel, TranslatedModel):  # type: ignore
         elif self.id and not self.user_forecasts.exists():
             # we're still before forecasts, make
             # sure that the options matches current options
-            self.options_history[-1][1] = self.options
+            last_entry = self.options_history[-1]
+            self.options_history[-1] = (last_entry[0], self.options or [])
             update_fields = kwargs.get("update_fields", None)
             if update_fields is not None:
-                update_fields.append("options_history")
+                kwargs["update_fields"] = list(update_fields) + ["options_history"]
 
         return super().save(**kwargs)
 


### PR DESCRIPTION
closes https://github.com/Metaculus/metaculus/issues/4182
add backend support for changing options from the UI before the question has forecasts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Non-multiple-choice questions now clear obsolete answer options reliably.
  * Multiple-choice questions initialize option history when missing, ensuring past options are preserved.
  * Option history is synchronized correctly before any user forecasts are recorded so displayed options remain consistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->