### PR TITLE
fix/rename-coherence-bots

### DIFF
--- a/coherence/views.py
+++ b/coherence/views.py
@@ -243,9 +243,13 @@ def post_coherence_bot_forecasts_and_comments(request):
         user = User.objects.filter(
             metadata__coherence_bot_for_user_id=coherence_user_id
         ).first()
+        if user:
+            # update username in case coherence_user's username changed
+            user.username = f"{coherence_user.username}-metac-bot"
+            user.save(update_fields=["username"])
         if not user:
             user = User.objects.create(
-                username=f"{coherence_user.username}-coherence-bot",
+                username=f"{coherence_user.username}-metac-bot",
                 is_bot=True,
                 check_for_spam=False,
                 bot_owner=request.user,


### PR DESCRIPTION
coherence bots should be named {username}-metac-bot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bot username suffix has been updated to a new format for improved identification
  * Existing bot user accounts will be automatically updated to use the new naming convention
  * All new bot users created going forward will use the updated naming format

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->