### PR TITLE
Fix multi-character sanitization

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
@@ -21,7 +21,7 @@ import ServerProjectsApi from "@/services/api/projects/projects.server";
 import { SearchParams } from "@/types/navigation";
 import { ProjectPermissions } from "@/types/post";
 import { ProjectVisibility, TournamentType } from "@/types/projects";
-import { getValidString } from "@/utils/formatters/string";
+import { getValidString, stripHtmlTags } from "@/utils/formatters/string";
 import { getProjectLink } from "@/utils/navigation";
 import { getPublicSettings } from "@/utils/public_settings.server";
 
@@ -45,7 +45,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   const raw = tournament.subtitle || tournament.description || "";
   const parsedDescription =
-    raw.replace(/<[^>]*>/g, "").split("\n")[0] || defaultDescription;
+    stripHtmlTags(raw).split("\n")[0] || defaultDescription;
 
   const { PUBLIC_APP_URL } = getPublicSettings();
 

--- a/front_end/src/app/(main)/c/[slug]/page.tsx
+++ b/front_end/src/app/(main)/c/[slug]/page.tsx
@@ -12,6 +12,7 @@ import ServerProjectsApi from "@/services/api/projects/projects.server";
 import { SearchParams } from "@/types/navigation";
 import { ProjectVisibility } from "@/types/projects";
 import { QuestionOrder } from "@/types/question";
+import { stripHtmlTags } from "@/utils/formatters/string";
 
 import CommunityHeader from "../../components/headers/community_header";
 import FeedFilters from "../../questions/components/feed_filters";
@@ -31,9 +32,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   if (!community) {
     return {};
   }
-  const parsedDescription = community.description
-    .replace(/<[^>]*>/g, "")
-    .split("\n")[0];
+  const parsedDescription = stripHtmlTags(community.description).split("\n")[0];
 
   return {
     title: community.name,

--- a/front_end/src/app/og/tournament/[slug]/page.tsx
+++ b/front_end/src/app/og/tournament/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import tournamentPlaceholder from "@/app/assets/images/tournament.png";
 import ServerProjectsApi from "@/services/api/projects/projects.server";
 import type { Tournament } from "@/types/projects";
+import { stripHtmlTags } from "@/utils/formatters/string";
 
 export const dynamic = "force-dynamic";
 
@@ -95,8 +96,7 @@ export default async function OgTournamentPage({
 }
 
 const stripFirstLine = (html?: string): string =>
-  (html ?? "")
-    .replace(/<[^>]*>/g, "")
+  stripHtmlTags(html ?? "")
     .split("\n")[0]
     ?.trim() ?? "";
 

--- a/front_end/src/utils/formatters/string.ts
+++ b/front_end/src/utils/formatters/string.ts
@@ -17,3 +17,20 @@ export function getValidString(
 ): string | undefined {
   return str && str.trim() !== "" ? str : undefined;
 }
+
+/**
+ * Safely strips HTML tags from a string by repeatedly applying regex replacement
+ * until no tags remain. This prevents incomplete multi-character sanitization
+ * vulnerabilities where nested or malformed tags could leave dangerous content.
+ */
+export function stripHtmlTags(html: string): string {
+  let previous = "";
+  let current = html;
+
+  while (previous !== current) {
+    previous = current;
+    current = current.replace(/<[^>]*>/g, "");
+  }
+
+  return current;
+}


### PR DESCRIPTION
Closes #4175 

This PR improves HTML sanitization for metadata descriptions.  
Added a shared `stripHtmlTags` helper and replaced ad‑hoc regex stripping in tournament/community/OG metadata.
- add `stripHtmlTags` utility that repeatedly removes tags until clean
- use `stripHtmlTags` in tournament, community, and OG metadata description parsing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated HTML sanitization into a shared utility used across tournament metadata, community descriptions, and social sharing previews. Description previews now strip tags more reliably (including nested/malformed tags), resulting in cleaner, more consistent text shown in page summaries and link previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->