### PR TITLE
quickfix/groupofquestions-admin-post_id-dne

### DIFF
--- a/questions/admin.py
+++ b/questions/admin.py
@@ -823,8 +823,8 @@ class GroupOfQuestionsAdmin(CustomTranslationAdmin):
     def save_model(self, request, obj: GroupOfQuestions, form, change):
         super().save_model(request, obj, form, change)
 
-        if obj.post_id:
-            run_post_generate_history_snapshot.send(obj.post_id, request.user.id)
+        if obj.post:
+            run_post_generate_history_snapshot.send(obj.post.id, request.user.id)
 
 
 @admin.register(Forecast)


### PR DESCRIPTION
fixes broken reference to post_id in admin GroupOfQuestions save method
see thread: https://metaculus.slack.com/archives/C01Q9AQBVHB/p1770304281249169
error: https://metaculus.sentry.io/issues/7244825010/?referrer=slack&notification_uuid=0d47b2b1-57c5-4778-bca4-02fbaf057330&environment=dev&alert_rule_id=15490368&alert_type=issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed history snapshot generation for grouped questions with associated posts to ensure proper tracking when post relationships exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->