### PR TITLE
quickfix/coherence-leaderboard-graceful-exit

### DIFF
--- a/scoring/management/commands/update_coherence_tournament_leaderboard.py
+++ b/scoring/management/commands/update_coherence_tournament_leaderboard.py
@@ -564,6 +564,10 @@ def run_update_coherence_spring_2026_cup(cache: bool = False) -> None:
         users, questions, cache=cache
     )
 
+    if not timestamps:
+        logger.info("No head-to-head data found. Exiting.")
+        return
+
     # TODO: set up support for yearly updates for all non-metac bots
 
     # choose baseline player if not already chosen


### PR DESCRIPTION
exit hth leaderboard update early if there are no matches to analyze

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tournament leaderboard update process now handles cases more robustly when no competitive matchup data is available, preventing potential processing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->