### PR TITLE
Settings page crashes for unauthenticated users

### DIFF
--- a/front_end/src/app/(main)/accounts/settings/(general)/page.tsx
+++ b/front_end/src/app/(main)/accounts/settings/(general)/page.tsx
@@ -1,4 +1,4 @@
-import invariant from "ts-invariant";
+import { redirect } from "next/navigation";
 
 import ServerProfileApi from "@/services/api/profile/profile.server";
 
@@ -11,7 +11,7 @@ export const metadata = {
 
 export default async function Settings() {
   const currentUser = await ServerProfileApi.getMyProfile();
-  invariant(currentUser);
+  if (!currentUser) return redirect("/");
 
   return (
     <div className="flex flex-col gap-6">

--- a/front_end/src/app/(main)/accounts/settings/account/page.tsx
+++ b/front_end/src/app/(main)/accounts/settings/account/page.tsx
@@ -1,4 +1,4 @@
-import invariant from "ts-invariant";
+import { redirect } from "next/navigation";
 
 import EmailMeMyData from "@/app/(main)/accounts/settings/account/components/email_me_my_data";
 import ServerAuthApi from "@/services/api/auth/auth.server";
@@ -16,7 +16,7 @@ export const metadata = {
 
 export default async function Settings() {
   const currentUser = await ServerProfileApi.getMyProfile();
-  invariant(currentUser);
+  if (!currentUser) return redirect("/");
 
   const { key: apiKey } = await ServerAuthApi.getApiKey();
 

--- a/front_end/src/app/(main)/accounts/settings/notifications/page.tsx
+++ b/front_end/src/app/(main)/accounts/settings/notifications/page.tsx
@@ -1,4 +1,4 @@
-import invariant from "ts-invariant";
+import { redirect } from "next/navigation";
 
 import EmailNotifications from "@/app/(main)/accounts/settings/notifications/components/email_notifications";
 import QuestionNotifications from "@/app/(main)/accounts/settings/notifications/components/question_notifications";
@@ -11,8 +11,8 @@ export const metadata = {
 
 export default async function Page() {
   const currentUser = await ServerProfileApi.getMyProfile();
+  if (!currentUser) return redirect("/");
   const posts = await ServerPostsApi.getAllSubscriptions();
-  invariant(currentUser);
 
   return (
     <div className="flex flex-col gap-6">


### PR DESCRIPTION
Closes #4236

This PR fixes the account settings page crash for unauthenticated users by adding a redirect to the login page instead of throwing an invariant error.

**Changes:**
- Added null check for `currentUser` in account settings page
- Redirect unauthenticated users to login page instead of crashing
- Fixes high-volume Sentry issue (1,230 events since September)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling on account settings (General, Account, Notifications): users without an active profile are now redirected to the home page instead of encountering runtime errors, resulting in a smoother, more reliable experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->