### PR TITLE
quickfix/coherence-leaderboard-bug

### DIFF
--- a/scoring/management/commands/update_coherence_tournament_leaderboard.py
+++ b/scoring/management/commands/update_coherence_tournament_leaderboard.py
@@ -187,7 +187,7 @@ def run_update_coherence_spring_2026_cup() -> None:
                 uid,
                 # double the score to normalize it such that the baseline is given
                 # a score of 0
-                np.sum(competitor_score_record[uid] * 2.0),
+                np.sum(competitor_score_record[uid]) * 2.0,
                 np.sum(competitor_weight_record[uid]),
             )
         )


### PR DESCRIPTION
use sum instead of average for calculating score
scale score by 2 to represent the normalized version since h2h scores are recriprocal
    and the baseline gets a 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tournament leaderboard score calculation to improve ranking accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->