### PR TITLE
issue/4266/fix/coherence-question-picker

### DIFF
--- a/front_end/src/app/(main)/questions/components/question_picker.tsx
+++ b/front_end/src/app/(main)/questions/components/question_picker.tsx
@@ -77,15 +77,22 @@ const QuestionPicker: FC<Props> = ({
     try {
       if (!!filters.search) {
         setIsLoading(true);
+        const allowedQuestionTypes = new Set(filters.forecast_type ?? []);
+        const isAllowedQuestionType = (questionType?: QuestionType) =>
+          !!questionType && allowedQuestionTypes.has(questionType);
         const parsedInput = parseQuestionId(filters.search);
         if (parsedInput.questionId) {
           const question = await ClientPostsApi.getQuestion(
             parsedInput.questionId
           );
-          setPosts([question]);
+          setPosts(isAllowedQuestionType(question.type) ? [question] : []);
         } else if (parsedInput.postId) {
           const post = await ClientPostsApi.getPost(parsedInput.postId);
-          setPosts([post]);
+          setPosts(
+            "question" in post && isAllowedQuestionType(post.question?.type)
+              ? [post]
+              : []
+          );
         }
         if (!parsedInput.questionId && !parsedInput.postId) {
           const { results: posts } = await ClientPostsApi.getPostsWithCP({


### PR DESCRIPTION
closes #4266 
fix erroneous approval of non-approved question types searched by post/question id by filtering out after api return

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Posts are now properly filtered according to your selected question type preferences, ensuring only relevant content is displayed in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->