### PR TITLE
fix: decouple Medal Contributions endpoint from initial page load

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
@@ -181,10 +181,16 @@ export default async function TournamentSlug(props: Props) {
                 isQuestionSeries={isQuestionSeries}
               />
               {currentUser && (
-                <ProjectContributions
-                  project={tournament}
-                  userId={currentUser.id}
-                />
+                <Suspense
+                  fallback={
+                    <LoadingIndicator className="mx-auto h-8 w-24 text-gray-600 dark:text-gray-600-dark" />
+                  }
+                >
+                  <ProjectContributions
+                    project={tournament}
+                    userId={currentUser.id}
+                  />
+                </Suspense>
               )}
             </div>
           )}

--- a/front_end/src/app/(main)/c/[slug]/page.tsx
+++ b/front_end/src/app/(main)/c/[slug]/page.tsx
@@ -74,7 +74,16 @@ export default async function IndividualCommunity(props: Props) {
             isQuestionSeries
           />
           {currentUser && (
-            <ProjectContributions project={community} userId={currentUser.id} />
+            <Suspense
+              fallback={
+                <LoadingIndicator className="mx-auto h-8 w-24 text-gray-600 dark:text-gray-600-dark" />
+              }
+            >
+              <ProjectContributions
+                project={community}
+                userId={currentUser.id}
+              />
+            </Suspense>
           )}
         </div>
 


### PR DESCRIPTION
## Summary

Wraps the `ProjectContributions` component in Suspense boundaries to prevent the Medal Contributions API call from blocking the initial page render.

## Changes

- Added Suspense wrapper around ProjectContributions in community page
- Added Suspense wrapper around ProjectContributions in tournament page
- Used LoadingIndicator as fallback during async loading

The page now loads immediately while contributions data loads asynchronously in the background.

Fixes #3039

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicators to contribution sections on tournament and community pages while data is being fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->