### PR TITLE
Preserve draft edits when duplicating posts

### DIFF
--- a/front_end/src/app/(main)/questions/create/[content_type]/page.tsx
+++ b/front_end/src/app/(main)/questions/create/[content_type]/page.tsx
@@ -67,7 +67,9 @@ export default async function QuestionCreator(props: Props) {
     ? communitiesResponse.results[0]
     : undefined;
 
-  const shouldUseDraftValue = mode === "create" && isNil(post);
+  // When mode is "create", always use draft values to persist edits
+  // This handles both new posts and duplicated posts
+  const shouldUseDraftValue = mode === "create";
 
   const componentProps = {
     post,


### PR DESCRIPTION
This PR fixes a bug where duplicating a post and editing it would lose all edits on page refresh.

**Changes:**
- Changed `shouldUseDraftValue` condition from `mode === "create" && isNil(post)` to `mode === "create"`, so duplicated posts also persist draft edits to localStorage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced draft value persistence in the question creation interface to consistently apply when creating new questions or working with duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->