### PR TITLE
Timeline Hover is missing for consumer view Binary and Continuous questions

### DIFF
--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -122,7 +122,6 @@ const NumericChart: FC<Props> = ({
   questionStatus,
   resolution,
   cursorTooltip,
-  isConsumerView,
   questionType,
 }) => {
   const { theme, getThemeColor } = useAppTheme();
@@ -700,10 +699,8 @@ const NumericChart: FC<Props> = ({
                       {useSimplifiedCursor ? (
                         <CursorChip
                           shouldRender={
-                            isConsumerView
-                              ? false
-                              : (isCursorActive && !isNil(resolution)) ||
-                                isNil(resolution)
+                            (isCursorActive && !isNil(resolution)) ||
+                            isNil(resolution)
                           }
                           colorOverride={colorOverride ?? colorPalette.chip}
                           isEmbedded={isEmbedded}

--- a/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
@@ -182,15 +182,12 @@ const DetailedContinuousChartCard: FC<Props> = ({
 
   const isEmbed = useIsEmbedMode();
 
-  const tooltipIsConsumerView = isConsumerView && !isEmbed;
-
   const cursorTooltip = useMemo(() => {
     return (
       <QuestionPredictionTooltip
         communityPrediction={cpCursorElement}
         userPrediction={userCursorElement}
         totalForecasters={cursorData.forecasterCount}
-        isConsumerView={tooltipIsConsumerView}
         questionStatus={question.status}
       />
     );
@@ -198,7 +195,6 @@ const DetailedContinuousChartCard: FC<Props> = ({
     cpCursorElement,
     userCursorElement,
     cursorData.forecasterCount,
-    tooltipIsConsumerView,
     question.status,
   ]);
 
@@ -236,16 +232,10 @@ const DetailedContinuousChartCard: FC<Props> = ({
       openTime={getPostDrivenTime(question.open_time)}
       unit={question.unit}
       inboundOutcomeCount={question.inbound_outcome_count}
-      simplifiedCursor={
-        question.type !== QuestionType.Binary || (!user && !isEmbed)
-      }
+      simplifiedCursor={false}
       title={timelineTitle}
       forecastAvailability={forecastAvailability}
-      cursorTooltip={
-        question.type === QuestionType.Binary && !user && !isEmbed
-          ? undefined
-          : cursorTooltip
-      }
+      cursorTooltip={cursorTooltip}
       isConsumerView={isConsumerView}
       isEmbedded={isEmbed}
       height={chartHeight}


### PR DESCRIPTION
Closes #4165

This PR restores the timeline hover tooltip for consumer view Binary and Continuous questions, unifying tooltip appearance between forecaster and consumer views.

### Before

<img width="2400" height="1896" alt="before-consumer-chip-tooltip" src="https://github.com/user-attachments/assets/fee26866-9944-4c3c-9348-4b2c5490f3b1" />

### After

<img width="2400" height="1896" alt="binary-chip-on-line" src="https://github.com/user-attachments/assets/02f36e87-e18d-4fc2-a004-9bfad4dd5452" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed consumer-specific view handling from chart components: cursor chip rendering is no longer disabled for consumer view and cursor tooltip is consistently provided.
  * Simplified and standardized cursor behavior across views (cursor rendering now depends only on cursor activity and resolution).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->