### PR TITLE
Fixed missing user forecast date for CP change notifications

### DIFF
--- a/posts/services/subscriptions.py
+++ b/posts/services/subscriptions.py
@@ -72,7 +72,6 @@ def _get_question_data_for_cp_change_notification(
                 data.forecast_date = user_forecast.start_time.isoformat()
 
             question_data.append(data)
-            # TODO: forecast date
     else:  # continuous
         data = CPChangeData(question=NotificationQuestionParams.from_question(question))
         median = current_entry.centers[0] if current_entry.centers else None


### PR DESCRIPTION
Fixed missing user forecast date for CP change notifications on Multiple Choice and Continuous questions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forecast data reliability in notifications for binary, multiple-choice, and continuous questions.
  * Fixed forecast date population to consistently appear in notifications when forecast data is present.
  * Enhanced data handling ensures users receive complete and accurate forecast information across all question types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->