### PR TITLE
Fix leaderboard pagination filtering order

### DIFF
--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/project_leaderboard_table/index.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/project_leaderboard_table/index.tsx
@@ -70,6 +70,15 @@ const ProjectLeaderboardTable: FC<Props> = ({
       ? undefined
       : leaderboardDetails.max_coverage;
 
+  const getColumnCount = () => {
+    let count = 3;
+    if (isAdvanced) count += 2;
+    if (!!leaderboardDetails.prize_pool) {
+      count += isAdvanced ? 3 : 1;
+    }
+    return count;
+  };
+
   return (
     <div className="overflow-y-hidden rounded border border-gray-300 bg-gray-0 dark:border-gray-300-dark dark:bg-gray-0-dark">
       <table className="mb-0 w-full border-separate whitespace-nowrap">
@@ -131,27 +140,27 @@ const ProjectLeaderboardTable: FC<Props> = ({
               isAdvanced={isAdvanced}
             />
           )}
-          {leaderboardEntries.length > 0 ? (
-            leaderboardEntries.map((entry) => (
-              <TableRow
-                key={entry.user?.id ?? entry.aggregation_method}
-                rowEntry={entry}
-                userId={userId}
-                maxCoverage={maxCoverage}
-                withPrizePool={!!leaderboardDetails.prize_pool}
-                isAdvanced={isAdvanced}
-              />
-            ))
-          ) : (
-            <tr className="border-b border-gray-300 dark:border-gray-300-dark">
-              <td
-                colSpan={isAdvanced ? 7 : 3}
-                className="max-w-full p-4 text-center text-base italic text-gray-700 dark:text-gray-700-dark"
-              >
-                {t("noQuestionsResolved")}
-              </td>
-            </tr>
-          )}
+          {leaderboardEntries.length > 0
+            ? leaderboardEntries.map((entry) => (
+                <TableRow
+                  key={entry.user?.id ?? entry.aggregation_method}
+                  rowEntry={entry}
+                  userId={userId}
+                  maxCoverage={maxCoverage}
+                  withPrizePool={!!leaderboardDetails.prize_pool}
+                  isAdvanced={isAdvanced}
+                />
+              ))
+            : !leaderboardDetails.userEntry && (
+                <tr className="border-b border-gray-300 dark:border-gray-300-dark">
+                  <td
+                    colSpan={getColumnCount()}
+                    className="max-w-full p-4 text-center text-base italic text-gray-700 dark:text-gray-700-dark"
+                  >
+                    {t("noQuestionsResolved")}
+                  </td>
+                </tr>
+              )}
         </tbody>
       </table>
       {hasMore && (


### PR DESCRIPTION
This PR fixes a UX issue where the leaderboard could show an empty table with only a \"Load More\" button visible, even though valid entries existed.

**Problem:**
The leaderboard was paginating entries BEFORE filtering out excluded ones. This caused a situation where:
1. First 5 entries are all excluded (e.g., hidden bots)
2. All 5 get filtered out during render
3. User sees empty table but \"Load More\" button appears
4. User has to click \"Load More\" to see actual visible entries

**Solution:**
- Filter entries FIRST (remove excluded entries)
- Then apply pagination to the filtered results
- \"Load More\" button now only shows if there are more filtered entries
- Added empty state message when truly no visible entries exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed leaderboard entry filtering to properly exclude entries based on visibility settings.
  * Improved empty state display when no leaderboard entries are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->