### PR TITLE
fix: Update ExpandableContent arrow directions

### DIFF
--- a/front_end/src/components/ui/expandable_content.tsx
+++ b/front_end/src/components/ui/expandable_content.tsx
@@ -1,5 +1,8 @@
 "use client";
-import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
+import {
+  faChevronDown,
+  faChevronRight,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { isNil } from "lodash";
 import dynamic from "next/dynamic";
@@ -91,10 +94,11 @@ const ExpandableContent: FC<PropsWithChildren<Props>> = ({
               }}
               className="pointer-events-auto"
             >
-              <FontAwesomeIcon
-                icon={isExpanded ? faChevronUp : faChevronDown}
-                className="ml-0.5 mr-1.5"
-              />
+              <span className="inline-flex w-4 items-center justify-center">
+                <FontAwesomeIcon
+                  icon={isExpanded ? faChevronDown : faChevronRight}
+                />
+              </span>
 
               {isExpanded ? collapseLabel : expandLabel}
             </Button>


### PR DESCRIPTION
Update ExpandableContent arrow icons per #3481:

- Collapsed state: chevron-right
- Expanded state: chevron-down
- Fixed 16px-wide container around icon to prevent layout shift

Closes #3481

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the chevron icon indicators for expandable content sections to display a right arrow when collapsed and a down arrow when expanded, improving visual clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->