### PR TITLE
quickfix/7266731296/aggregation-serialization-empty-key-reference

### DIFF
--- a/questions/serializers/aggregate_forecasts.py
+++ b/questions/serializers/aggregate_forecasts.py
@@ -68,14 +68,14 @@ def serialize_question_aggregations(
     Please note: aggregate_forecasts need to be in "start_time" ascending order!
     """
 
-    serialized_data: dict[str, dict] = {
-        question.default_aggregation_method: {
+    serialized_data: dict[str, dict] = defaultdict(
+        lambda: {
             "history": [],
             "latest": None,
             "score_data": {},
             "movement": None,
         }
-    }
+    )
 
     if aggregate_forecasts is not None:
         aggregate_forecasts_by_method: dict[
@@ -84,13 +84,6 @@ def serialize_question_aggregations(
 
         for aggregate in aggregate_forecasts:
             aggregate_forecasts_by_method[aggregate.method].append(aggregate)
-            if aggregate.method not in serialized_data:
-                serialized_data[aggregate.method] = {
-                    "history": [],
-                    "latest": None,
-                    "score_data": {},
-                    "movement": None,
-                }
 
         # Debug method for building aggregation history from scratch
         # Will be replaced in favour of aggregation explorer


### PR DESCRIPTION
fixes sentry issue 7266731296
there is a reference to a non-extent key in serialized_data when minimize is false and there is no data
changing serialized data to a default dict should solve the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified internal data structure initialization for aggregate forecast handling, improving code maintainability without affecting user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->