### PR TITLE
Added `/app-version/` trailing slash

### DIFF
--- a/front_end/src/app/(main)/components/version_checker.tsx
+++ b/front_end/src/app/(main)/components/version_checker.tsx
@@ -76,7 +76,7 @@ const ERROR_THRESHOLD = 3;
 
 const fetchServerVersion = async () => {
   try {
-    const response = await fetch("/app-version");
+    const response = await fetch("/app-version/");
 
     if (!response.ok) {
       consecutiveErrors++;


### PR DESCRIPTION
Since this is the most frequently called endpoint, we want to avoid unnecessary `/app-version` -> `/app-version/` redirects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the server version detection endpoint to resolve API compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->