### PR TITLE
Fix notebook comments link in the spam report emails

### DIFF
--- a/comments/services/spam_detection.py
+++ b/comments/services/spam_detection.py
@@ -1,7 +1,10 @@
+from typing import cast
+
 from comments.models import Comment
+from posts.models import Post
 from users.models import User, UserSpamActivity
 from users.services.spam_detection import check_and_handle_content_spam
-from utils.frontend import build_frontend_url
+from utils.frontend import build_frontend_url, build_post_url
 
 
 def check_and_handle_comment_spam(author: User, comment: Comment) -> bool:
@@ -16,8 +19,8 @@ def check_and_handle_comment_spam(author: User, comment: Comment) -> bool:
         f"/admin/comments/comment/{comment.id}/change/"
     )
 
-    content_frontend_url = build_frontend_url(
-        f"/questions/{comment.on_post.id}/#comment-{comment.id}"
+    content_frontend_url = (
+        f"{build_post_url(cast(Post, comment.on_post))}#comment-{comment.id}"
     )
 
     return check_and_handle_content_spam(


### PR DESCRIPTION
Should close #2618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Comment permalinks now use the post's canonical URL so links reliably open the correct post type (questions, notebooks, etc.).
  * Permalinks include the comment anchor and consistently navigate users to the proper post view and exact comment location for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->