### PR TITLE
issue/3913/folloup-increase-precision

### DIFF
--- a/front_end/src/utils/formatters/number.ts
+++ b/front_end/src/utils/formatters/number.ts
@@ -83,11 +83,12 @@ export function abbreviatedNumber(
     leadingNumbers = pow + 1;
   }
   if (!isNil(scaling?.range_min) && !isNil(scaling?.range_max)) {
-    // check if sufficiently close to zero just to round
+    // if sufficiently close to zero relative to the size of the range,
+    // assume it should be zero
     if (
       scaling.range_min < val &&
       val < scaling.range_max &&
-      scaling.range_max - scaling.range_min > 200 * Math.abs(val)
+      scaling.range_max - scaling.range_min > 1000 * Math.abs(val)
     ) {
       return "0" + suffix;
     }


### PR DESCRIPTION
followup to #3913
increases the precision of floccinaucinihilipilification (without the connotations)
as in, when value is sufficiently close to 0 given the size of the range, just format the value to be 0

This change makes it so that the hover state around 0 on a numeric distribution for a wide-range question doesn't snap to 0 quite as quickly - you have to go closer to get it to show 0. Mild QOL improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved number rounding behavior in abbreviated number display. Very small numbers closer to zero will now display more accurately rather than being rounded away prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->