### PR TITLE
Added private label for tournaments page cards

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/index_tournament_card.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/index_tournament_card.tsx
@@ -8,6 +8,7 @@ import React, { useMemo } from "react";
 import { TournamentPreview } from "@/types/projects";
 import cn from "@/utils/core/cn";
 
+import PrivateBadge from "./private_badge";
 import TournamentCardShell from "./tournament_card_shell";
 
 type Props = {
@@ -49,6 +50,7 @@ const IndexTournamentCard: React.FC<Props> = ({ item }) => {
                 />
               </div>
             )}
+            {!item.default_permission && <PrivateBadge />}
           </div>
 
           <div className="min-w-0 flex-1">
@@ -92,6 +94,7 @@ const IndexTournamentCard: React.FC<Props> = ({ item }) => {
               />
             </div>
           )}
+          {!item.default_permission && <PrivateBadge />}
         </div>
 
         <div className="px-3 pb-4 pt-4 lg:px-4 lg:pb-6">

--- a/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/live_tournament_card.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/live_tournament_card.tsx
@@ -11,6 +11,7 @@ import { safeTs } from "@/utils/formatters/date";
 import { formatMoneyUSD } from "@/utils/formatters/number";
 import { formatTournamentRelativeDelta } from "@/utils/projects/helpers";
 
+import PrivateBadge from "./private_badge";
 import TournamentCardShell from "./tournament_card_shell";
 import GradientProgressLine from "../../../tournament/components/gradient_progress_line";
 
@@ -51,6 +52,7 @@ const LiveTournamentCard: React.FC<Props> = ({
             />
           </div>
         )}
+        {!item.default_permission && <PrivateBadge />}
       </div>
 
       <div className="flex items-center justify-center gap-2 px-3 pb-0 pt-3 text-xs lg:justify-between lg:px-4 lg:pb-[5px]">

--- a/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/private_badge.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/private_badge.tsx
@@ -1,0 +1,14 @@
+import { useTranslations } from "next-intl";
+import React from "react";
+
+const PrivateBadge: React.FC = () => {
+  const t = useTranslations();
+
+  return (
+    <div className="absolute bottom-1.5 right-1.5 w-fit rounded-sm bg-black/30 px-1 py-0.5 text-xs font-bold text-gray-0">
+      {t("private")}
+    </div>
+  );
+};
+
+export default PrivateBadge;

--- a/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/question_series_card.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/question_series_card.tsx
@@ -7,6 +7,7 @@ import React from "react";
 
 import { TournamentPreview } from "@/types/projects";
 
+import PrivateBadge from "./private_badge";
 import TournamentCardShell from "./tournament_card_shell";
 
 type Props = { item: TournamentPreview };
@@ -35,6 +36,7 @@ const QuestionSeriesCard: React.FC<Props> = ({ item }) => {
             />
           </div>
         )}
+        {!item.default_permission && <PrivateBadge />}
       </div>
 
       <div className="px-3 pb-3 pt-3 lg:px-4 lg:pb-5">


### PR DESCRIPTION
<img width="278" height="258" alt="image" src="https://github.com/user-attachments/assets/f4b10efd-af34-4b16-a05b-6f5b64f402fb" />

related #4386


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Private" badge that displays on tournament and question series cards to visually indicate when items are not publicly accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->