### PR TITLE
Fixed LeaderboardInline error in the admin page

### DIFF
--- a/projects/admin.py
+++ b/projects/admin.py
@@ -130,6 +130,9 @@ class LeaderboardInline(admin.TabularInline):
     def has_add_permission(self, request, obj=None):
         return False
 
+    def has_change_permission(self, request, obj=None):
+        return False
+
 
 class ProjectUserPermissionInline(admin.TabularInline):
     model = ProjectUserPermission


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled change permissions for leaderboard entries in the admin interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->