### PR TITLE
Feed project tiles: adjusted empty forecasters tile

### DIFF
--- a/front_end/src/components/posts_feed/feed_tournament_tile.tsx
+++ b/front_end/src/components/posts_feed/feed_tournament_tile.tsx
@@ -116,7 +116,7 @@ const FeedTournamentTile: FC<Props> = ({ tile, feedPage }) => {
             <span>{statusLabel}</span>
           </span>
         )}
-        {project.forecasters_count && (
+        {project.forecasters_count > 0 && (
           <span className="flex items-center gap-2">
             <FontAwesomeIcon
               icon={faUsers}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tournament feed tiles now hide the forecasters count section when there are no forecasters, eliminating unnecessary empty UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->