### PR TITLE
Disable notebook tile image compression

### DIFF
--- a/front_end/src/components/post_card/notebook_tile.tsx
+++ b/front_end/src/components/post_card/notebook_tile.tsx
@@ -39,7 +39,7 @@ const NotebookTile: FC<Props> = ({ post }) => {
           alt=""
           width={300}
           height={300}
-          quality={100}
+          unoptimized
           className="h-24 min-w-44 max-w-44 rounded object-cover"
         />
       )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image rendering behavior in notebook tiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->