### PR TITLE
fix: update Coefficient Giving link to correct .org domain (#4383)

### DIFF
--- a/front_end/src/app/(main)/pro-forecasters/constants/pro_forecasters.tsx
+++ b/front_end/src/app/(main)/pro-forecasters/constants/pro_forecasters.tsx
@@ -36,7 +36,7 @@ export const PRO_FORECASTERS: ProForecaster[] = [
     description: (
       <>
         Isabel previously worked as a Research Fellow at{" "}
-        <ProForecasterLink href="https://www.coefficientgiving.com/">
+        <ProForecasterLink href="https://coefficientgiving.org">
           Coefficient Giving
         </ProForecasterLink>
         , serving on the Cause Prioritization Team within the{" "}


### PR DESCRIPTION
Updates the Coefficient Giving link in Isabel's profile on the pro-forecasters page from `https://www.coefficientgiving.com/` to `https://coefficientgiving.org` (correct .org domain, no www prefix).

Closes #4383

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Isabel Pro Forecaster resource link to the correct URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->