### PR TITLE
followup to not-quite-0

### DIFF
--- a/front_end/src/utils/formatters/number.ts
+++ b/front_end/src/utils/formatters/number.ts
@@ -61,6 +61,18 @@ export function abbreviatedNumber(
     return toScientificNotation(val, 2, 1, false);
   }
 
+  if (!isNil(scaling?.range_min) && !isNil(scaling?.range_max)) {
+    // if sufficiently close to zero relative to the size of the range,
+    // assume it should be zero
+    if (
+      scaling.range_min < val &&
+      val < scaling.range_max &&
+      scaling.range_max - scaling.range_min > 1000 * Math.abs(val)
+    ) {
+      return "0";
+    }
+  }
+
   let suffix = "";
   let leadingNumbers = 1;
   if (pow >= 12) {
@@ -82,17 +94,7 @@ export function abbreviatedNumber(
   } else if (pow >= -3) {
     leadingNumbers = pow + 1;
   }
-  if (!isNil(scaling?.range_min) && !isNil(scaling?.range_max)) {
-    // if sufficiently close to zero relative to the size of the range,
-    // assume it should be zero
-    if (
-      scaling.range_min < val &&
-      val < scaling.range_max &&
-      scaling.range_max - scaling.range_min > 1000 * Math.abs(val)
-    ) {
-      return "0" + suffix;
-    }
-  }
+
   return (
     toScientificNotation(val, sigfigs, leadingNumbers, trailingZeros) + suffix
   );


### PR DESCRIPTION
related #3913
followup to move 0-rounding to before descaling 'val'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced number formatting logic for very small values. Numbers substantially smaller than the scaling range threshold now display as clean "0" without unnecessary formatting suffixes, providing clearer output and improving accuracy for edge cases in numeric display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->