### PR TITLE
Fix layout shift caused by dynamically loaded Bulletins component

### DIFF
--- a/front_end/src/app/(main)/components/bulletins.tsx
+++ b/front_end/src/app/(main)/components/bulletins.tsx
@@ -60,7 +60,7 @@ const Bulletins: FC = () => {
   }, [shouldHide, fetchBulletins]);
 
   return (
-    <div className="mt-12 flex w-full flex-col items-center justify-center bg-transparent">
+    <div className="flex w-full flex-col items-center justify-center bg-transparent">
       {!shouldHide &&
         bulletins.map((bulletin) => (
           <Bulletin key={bulletin.id} text={bulletin.text} id={bulletin.id} />

--- a/front_end/src/app/(main)/components/impersonation_banner.tsx
+++ b/front_end/src/app/(main)/components/impersonation_banner.tsx
@@ -20,7 +20,7 @@ const ImpersonationBanner: FC = () => {
   if (!user?.is_bot) return;
 
   return (
-    <div className="text-md -mb-12 mt-12 flex w-full items-center justify-center gap-4 border-b border-t border-orange-400 bg-orange-50 p-2 text-sm leading-6 text-orange-900 dark:border-orange-400-dark dark:bg-orange-50-dark dark:text-orange-900-dark sm:px-6">
+    <div className="text-md flex w-full items-center justify-center gap-4 border-b border-t border-orange-400 bg-orange-50 p-2 text-sm leading-6 text-orange-900 dark:border-orange-400-dark dark:bg-orange-50-dark dark:text-orange-900-dark sm:px-6">
       <span>{t("impersonationBannerText")}</span>
       <Button
         onClick={handleStop}

--- a/front_end/src/app/(main)/layout.tsx
+++ b/front_end/src/app/(main)/layout.tsx
@@ -32,7 +32,7 @@ export default async function RootLayout({
   const isImpersonating = authManager.isImpersonating();
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col pt-header">
       <GlobalHeader />
 
       {isImpersonating && <ImpersonationBanner />}


### PR DESCRIPTION
Fixes #4110

- Added padding to the root layout to accommodate the header.
- Removed top margin from the bulletins component for better alignment.
- Adjusted the impersonation banner to eliminate negative margin, enhancing its positioning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted vertical spacing and padding throughout the application layout structure for better visual presentation. Refined margins in multiple components including banners and bulletin sections. Enhanced top padding in the main application layout to improve alignment and spacing consistency across the entire user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->