### PR TITLE
chore: skip heroku release target conditionally

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -97,9 +97,25 @@ jobs:
           sparse-checkout: scripts
           sparse-checkout-cone-mode: false
 
+      - name: Determine deploy targets
+        id: targets
+        run: |
+          TARGETS="${{ needs.build.outputs.heroku_targets }}"
+          HAS_MIGRATIONS="${{ needs.check-migrations.outputs.has_migrations }}"
+
+          if [ "$HAS_MIGRATIONS" == "false" ]; then
+            TARGETS=$(echo "$TARGETS" | sed 's/\brelease\b//' | xargs)
+            echo "⏭️ No migrations detected - skipping release phase"
+          else
+            echo "🗄️ Migrations detected (or check inconclusive) - including release phase"
+          fi
+
+          echo "Deploy targets: $TARGETS"
+          echo "targets=$TARGETS" >> "$GITHUB_OUTPUT"
+
       - name: Deploy to Heroku
         run: |
-          heroku container:release ${{ needs.build.outputs.heroku_targets }} -a ${{ env.HEROKU_APP }}
+          heroku container:release ${{ steps.targets.outputs.targets }} -a ${{ env.HEROKU_APP }}
 
       - name: Wait for release to complete
         run: ./scripts/wait_for_heroku_release.sh "${{ env.HEROKU_APP }}" 90

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -182,7 +182,7 @@ jobs:
             # Mutable tag: {branch} (always points to latest build for this branch)
             type=raw,value=${{ steps.vars.outputs.branch_slug }},priority=600
             # Latest tag (only for production builds)
-            type=raw,value=latest,enable=${{ inputs.include_latest_tag }},priority=200
+            type=raw,value=latest,enable=${{ inputs.include_latest_tag || false }},priority=200
           labels: |
             # Override revision to match actual checkout (PR branch HEAD, not merge commit)
             org.opencontainers.image.revision=${{ steps.vars.outputs.commit_sha }}


### PR DESCRIPTION
Heroku builds randomly fail on release step.
"Lost connection with release dyno. Please retry previous command." -- kind of errors,
and we cant redeploy same image twice, we're forced to change image to redeploy

We already check for awaiting migrations in the deployment steps,
- we can remove release target if there is no migrations pending. As this container only run migration command.
- This should minimize random deployment failing surface, while speeding up deployments if there is no pending migrations.

(tested on dev and skipping release target didn't cause any problems)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved production deployment process with intelligent database migration detection that conditionally adjusts deployment targets, enabling more reliable and seamless application updates
  * Refined Docker build system with enhanced image tag configuration for improved consistency and predictability in containerized application builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->