### PR TITLE
feat: track PDF/CDF toggle analytics on continuous input

### DIFF
--- a/front_end/src/components/forecast_maker/continuous_input/continuous_input_container.tsx
+++ b/front_end/src/components/forecast_maker/continuous_input/continuous_input_container.tsx
@@ -11,6 +11,7 @@ import {
   ContinuousForecastInputType,
 } from "@/types/charts";
 import { QuestionType, NumericUserForecast } from "@/types/question";
+import { sendAnalyticsEvent } from "@/utils/analytics";
 import cn from "@/utils/core/cn";
 import { isForecastActive } from "@/utils/forecasts/helpers";
 
@@ -63,8 +64,13 @@ const ContinuousInputContainer: FC<ContinuousInputContainerProps> = ({
       } else {
         setTableGraphType(graphType);
       }
+      sendAnalyticsEvent("continuous_input_graph_type_toggled", {
+        graph_type: graphType,
+        input_mode: forecastInputMode,
+        question_type: questionType,
+      });
     },
-    [forecastInputMode]
+    [forecastInputMode, questionType]
   );
 
   return (


### PR DESCRIPTION
closes #4428

Fires a `continuous_input_graph_type_toggled` event with `graph_type`, `input_mode`, and `question_type` properties whenever a user switches between PDF/PMF and CDF views on the continuous forecast input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forecast input responsiveness by fixing callback dependency handling.

* **Chores**
  * Enhanced analytics tracking for graph type interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->