### PR TITLE
Forecaster number fix

### DIFF
--- a/front_end/src/components/charts/primitives/chart_fan_tooltip.tsx
+++ b/front_end/src/components/charts/primitives/chart_fan_tooltip.tsx
@@ -191,7 +191,7 @@ const ChartFanTooltip: FC<Props> = ({
               {/* Total Forecasters Row */}
               <tr className="border-t border-gray-300 dark:border-gray-300-dark">
                 <th className="px-3 pb-1.5 pt-2 text-left text-sm font-medium capitalize text-gray-800 dark:text-gray-800-dark">
-                  {t("totalForecastersLabel")}
+                  {t("activeForecastersLabel")}
                 </th>
                 <td
                   className="pb-1 pr-3.5 pt-2 text-right text-sm font-normal tabular-nums text-gray-700 dark:text-gray-700-dark"

--- a/front_end/src/components/charts/primitives/question_prediction_tooltip.tsx
+++ b/front_end/src/components/charts/primitives/question_prediction_tooltip.tsx
@@ -62,7 +62,7 @@ const QuestionPredictionTooltip: FC<Props> = ({
         <hr className="relative mx-[-12px] border-gray-300 dark:border-gray-300-dark" />
         <div className="flex w-full items-center justify-between">
           <span className="text-sm font-medium">
-            {t("totalForecastersLabel")}
+            {t("activeForecastersLabel")}
           </span>
           <span className="text-sm tabular-nums">{totalForecasters}</span>
         </div>

--- a/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
@@ -100,10 +100,7 @@ const DetailedContinuousChartCard: FC<Props> = ({
 
     return {
       timestamp: timestamp,
-      forecasterCount:
-        // If there are no mouseover, we should display total forecasters number,
-        // otherwise - only active during that period
-        (cursorTimestamp ? forecast?.forecaster_count : nrForecasters) ?? 0,
+      forecasterCount: forecast?.forecaster_count ?? 0,
       interval_lower_bound: forecast?.interval_lower_bounds?.[0] ?? null,
       center: forecast?.centers?.[0] ?? null,
       interval_upper_bound: forecast?.interval_upper_bounds?.[0] ?? null,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated forecaster count display labels from "Total Forecasters" to "Active Forecasters" across tooltips and chart visualizations
  * Improved accuracy of forecaster counts shown in charts to reflect active forecaster data based on specific forecast timestamps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->