### PR TITLE
Remove markdown links note on /create

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -692,7 +692,7 @@
   "longTitleExplanation": "Jedna věta, která shrnuje, co se snažíte předpovědět. Končí otazníkem.",
   "shortTitleExplanation": "To by měla být kratší verze Dlouhého názvu, použitá tam, kde je méně místa pro zobrazení názvu. Měla by končit otazníkem. Příklady: \"NASA 2022 vítěz smlouvy na skafandr?\" nebo \"EU HDP od roku 2025 do 2035?\"",
   "backgroundInformation": "Základní informace",
-  "backgroundInfoExplanation": "Poskytněte základní informace k vaší otázce ve věcném a nestranném tónu. Odkazy by měly být přidány na relevantní a užitečné zdroje pomocí <link>markdown syntaxi</link>: <markdown>[Název odkazu](https://link-url.com)</markdown>.",
+  "backgroundInfoExplanation": "Poskytněte základní informace k vaší otázce ve věcném a nestranném tónu. Odkazy by měly být přidány na relevantní a užitečné zdroje.",
   "resolutionCriteriaExplanation": "Dobrá otázka se téměř vždy vyřeší jednoznačně. Pokud máte zdroj dat, podle kterého se otázka vyřeší, přidejte jej sem. Pokud bude třeba provést jednoduchou matematiku k vyřešení této otázky, definujte rovnici v markdown: <markdown>\\[ y = ax^2+b \\]</markdown>.",
   "choicesSeparatedBy": "Možnosti (oddělené čárkou)",
   "projects": "projekty",

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1028,7 +1028,7 @@
   "longTitleExplanation": "A single sentence that encapsulates what you're trying to predict.  Ends in a question mark.",
   "shortTitleExplanation": "This should be a shorter version of the Long Title, used where there is less space to display a title. It should end with a question mark. Examples: \"NASA 2022 spacesuit contract winner?\" or \"EU GDP from 2025 to 2035?\"",
   "backgroundInformation": "Background Information",
-  "backgroundInfoExplanation": "Provide background information for your question in a factual and unbiased tone. Links should be added to relevant and helpful resources using <link>markdown syntax</link>: <markdown>[Link title](https://link-url.com)</markdown>.",
+  "backgroundInfoExplanation": "Provide background information for your question in a factual and unbiased tone. Links should be added to relevant and helpful resources.",
   "resolutionCriteriaExplanation": "A good question will almost always resolve unambiguously. If you have a data source by which the question will resolve, link to it here. If there is some simple math that will need to be done to resolve this question, define the equation in markdown: <markdown>\\[ y = ax^2+b \\]</markdown>.",
   "choices": "Choices",
   "choicesSeparatedBy": "Choices (separated by ,)",

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -694,7 +694,7 @@
   "longTitleExplanation": "Una oración que encapsula lo que estás tratando de predecir. Termina con un signo de interrogación.",
   "shortTitleExplanation": "Debe ser una versión más corta del Título Largo, utilizada donde hay menos espacio para mostrar un título. Debe terminar con un signo de interrogación. Ejemplos: \"¿Ganador del contrato de trajes espaciales de la NASA 2022?\" o \"¿PIB de la UE de 2025 a 2035?\"",
   "backgroundInformation": "Información de Fondo",
-  "backgroundInfoExplanation": "Proporciona información de fondo para tu pregunta en un tono objetivo y sin sesgos. Los enlaces deben agregarse a recursos relevantes y útiles utilizando la <link>sintaxis markdown</link>: <markdown>[Título del Enlace](https://link-url.com)</markdown>.",
+  "backgroundInfoExplanation": "Proporciona información de fondo para tu pregunta en un tono objetivo y sin sesgos. Los enlaces deben agregarse a recursos relevantes y útiles.",
   "resolutionCriteriaExplanation": "Una buena pregunta casi siempre se resolverá de manera inequívoca. Si tienes una fuente de datos con la que se resolverá la pregunta, enlázala aquí. Si es necesario realizar algunos cálculos simples para resolver esta pregunta, define la ecuación en markdown: <markdown>\\[ y = ax^2+b \\]</markdown>.",
   "choicesSeparatedBy": "Opciones (separadas por ,)",
   "projects": "proyectos",

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -780,7 +780,7 @@
   "longTitleExplanation": "Uma frase única que encapsula o que você está tentando prever. Termina com um ponto de interrogação.",
   "shortTitleExplanation": "Esta deve ser uma versão mais curta do Título Longo, usada onde há menos espaço para exibir um título. Deve terminar com um ponto de interrogação. Exemplos: \"Vencedor do contrato de trajes espaciais da NASA 2022?\" ou \"PIB da UE de 2025 a 2035?\"",
   "backgroundInformation": "Informações de Fundo",
-  "backgroundInfoExplanation": "Forneça informações de fundo para sua pergunta em um tom factual e imparcial. Links devem ser adicionados a recursos relevantes e úteis usando <link>markdown syntax</link>: <markdown>[Título do Link](https://link-url.com)</markdown>.",
+  "backgroundInfoExplanation": "Forneça informações de fundo para sua pergunta em um tom factual e imparcial. Links devem ser adicionados a recursos relevantes e úteis.",
   "resolutionCriteriaExplanation": "Uma boa pergunta quase sempre se resolve de forma inequívoca. Se você tem uma fonte de dados pela qual a pergunta será resolvida, link para ela aqui. Se houver alguma matemática simples que precisará ser feita para resolver esta pergunta, defina a equação em markdown: <markdown>\\[ y = ax^2+b \\]</markdown>.",
   "choices": "Escolhas",
   "choicesSeparatedBy": "Escolhas (separadas por ,)",

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -842,7 +842,7 @@
   "longTitleExplanation": "單句完整總結您試圖預測的內容。以問號結尾。",
   "shortTitleExplanation": "此處應為長標題的較短版本，用於空間有限的標題展示。應以問號結尾。例子：“NASA 2022太空衣合約得獎者？”或“2025至2035的歐盟GDP？”",
   "backgroundInformation": "背景信息",
-  "backgroundInfoExplanation": "以事實和不偏不倚的語氣提供問題的背景信息。鏈接應使用<link>Markdown語法</link>添加至相關和有用的資源：<markdown>[鏈接標題](https://link-url.com)</markdown>。",
+  "backgroundInfoExplanation": "以事實和不偏不倚的語氣提供問題的背景信息。鏈接應添加至相關和有用的資源。",
   "resolutionCriteriaExplanation": "一個好的問題幾乎總是能夠毫不含糊地解決。如果您有解析問題的數據來源，請在此處鏈接。如果需要進行一些簡單的數學運算來解析這個問題，請使用markdown定義方程：<markdown>\\[ y = ax^2+b \\]</markdown>。",
   "choices": "選擇",
   "choicesSeparatedBy": "選擇（以,分隔）",

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -683,7 +683,7 @@
   "longTitleExplanation": "一個單句概括你想預測的內容。以問號結尾。",
   "shortTitleExplanation": "這應該是長���題的縮短版本，用於顯示空間較小的地方。應以問號結尾。例如：「NASA 2022太空服合約獲勝者？」或「2025年至2035年歐盟GDP？」",
   "backgroundInformation": "背景資訊",
-  "backgroundInfoExplanation": "以客觀和中立的語氣提供問題的背景資訊。應使用<link>markdown語法</link>添加相關和有用資源的連結：<markdown>[連結標題](https://link-url.com)</markdown>。",
+  "backgroundInfoExplanation": "以客觀和中立的語氣提供問題的背景資訊。應添加相關和有用資源的連結。",
   "resolutionCriteriaExplanation": "一個好的問題幾乎總是能夠明確解決。如果你有用於解決問題的數據源，請在此處連結。如果需要進行一些簡單的數學計算來解決這個問題，請用markdown定義方程式：<markdown>\\[ y = ax^2+b \\]</markdown>。",
   "choicesSeparatedBy": "選項（以逗號分隔）",
   "projects": "專案",

--- a/front_end/src/app/(main)/questions/components/group_form.tsx
+++ b/front_end/src/app/(main)/questions/components/group_form.tsx
@@ -9,7 +9,6 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { forEach, isNil } from "lodash";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -647,10 +646,7 @@ const GroupForm: React.FC<Props> = ({
         <InputContainer
           labelText={t("backgroundInformation")}
           isNativeFormControl={false}
-          explanation={t.rich("backgroundInfoExplanation", {
-            link: (chunks) => <Link href="/help/markdown">{chunks}</Link>,
-            markdown: (chunks) => <MarkdownText>{chunks}</MarkdownText>,
-          })}
+          explanation={t("backgroundInfoExplanation")}
         >
           <MarkdownEditorField
             control={form.control}

--- a/front_end/src/app/(main)/questions/components/question_form.tsx
+++ b/front_end/src/app/(main)/questions/components/question_form.tsx
@@ -4,7 +4,6 @@ import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { isNil } from "lodash";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { FC, useCallback, useEffect, useRef, useState } from "react";
@@ -706,10 +705,7 @@ const QuestionForm: FC<Props> = ({
         )}
         <InputContainer
           labelText={t("backgroundInformation")}
-          explanation={t.rich("backgroundInfoExplanation", {
-            link: (chunks) => <Link href="/help/markdown">{chunks}</Link>,
-            markdown: (chunks) => <MarkdownText>{chunks}</MarkdownText>,
-          })}
+          explanation={t("backgroundInfoExplanation")}
           isNativeFormControl={false}
         >
           <MarkdownEditorField


### PR DESCRIPTION
Closes #4462

Remove the obsolete markdown syntax reference from the background info explanation on the question creation page. The WYSIWYG editor makes this note unnecessary.

Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined background information guidance text across all supported languages by removing markdown syntax examples. Users now see simplified, clearer instructions focused on adding relevant and helpful resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->