### PR TITLE
Fixed Integration Tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-          key: playwright-${{ runner.os }}-${{ hashFiles('front_end/package-lock.json') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('uv.lock') }}
           restore-keys: |
             playwright-${{ runner.os }}
       - name: Install Playwright deps


### PR DESCRIPTION
Fixed the issue with integration tests — the Playwright browser cache key was still hashing front_end/package-lock.json instead of uv.lock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline caching configuration to optimize build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->