### PR TITLE
Embed cutoff fix

### DIFF
--- a/front_end/src/components/charts/primitives/chart_value_box.tsx
+++ b/front_end/src/components/charts/primitives/chart_value_box.tsx
@@ -213,7 +213,10 @@ const ChartValueBox: FC<{
   const adjustedX =
     isCursorActive || isDistributionChip
       ? x
-      : chartWidth - rightPadding + textWidth / 2 + CHIP_OFFSET;
+      : Math.min(
+          chartWidth - rightPadding + textWidth / 2 + CHIP_OFFSET,
+          chartWidth - textWidth / 2 - 2
+        );
   const hasResolution = !!resolution && !isCursorActive;
 
   const chipFill =


### PR DESCRIPTION
This PR fixes the problem with label cutoff in embeds.

Before:

<img width="730" height="293" alt="image" src="https://github.com/user-attachments/assets/8dfaa213-0e77-45c5-bcc3-804260fe46dc" />


After:

<img width="626" height="283" alt="image" src="https://github.com/user-attachments/assets/49a8f12a-b388-4997-b61f-ffecc623d8fa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue with chart value label positioning where text could overflow beyond chart boundaries. The label placement logic has been improved to ensure all values remain properly constrained within the visible chart area, maintaining clean presentation and improving readability across various chart configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->