### PR TITLE
quickfix ticks - don't round to zero in log scaled range

### DIFF
--- a/front_end/src/utils/formatters/number.ts
+++ b/front_end/src/utils/formatters/number.ts
@@ -61,7 +61,11 @@ export function abbreviatedNumber(
     return toScientificNotation(val, 2, 1, false);
   }
 
-  if (!isNil(scaling?.range_min) && !isNil(scaling?.range_max)) {
+  if (
+    isNil(scaling?.zero_point) &&
+    !isNil(scaling?.range_min) &&
+    !isNil(scaling?.range_max)
+  ) {
     // if sufficiently close to zero relative to the size of the range,
     // assume it should be zero
     if (


### PR DESCRIPTION
don't try to round to zero if there is a zero point b/c it would be outside of the range

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue with number formatting where zero-value approximations were incorrectly applied in certain edge cases. The formatter now properly respects custom zero-point configurations, ensuring accurate number display across different formatting scenarios. This prevents unintended zero-approximation behavior when specific zero points are defined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->