### PR TITLE
fix: update CP immediately after predicting

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/index.tsx
@@ -1,8 +1,11 @@
-import { Fragment } from "react";
+"use client";
+
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 
 import DetailedGroupCard from "@/components/detailed_question_card/detailed_group_card";
 import DetailedQuestionCard from "@/components/detailed_question_card/detailed_question_card";
 import ForecastMaker from "@/components/forecast_maker";
+import ClientPostsApi from "@/services/api/posts/posts.client";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import {
   isGroupOfQuestionsPost,
@@ -20,25 +23,58 @@ const ForecasterQuestionView: React.FC<Props> = ({
   postData,
   preselectedGroupQuestionId,
 }) => {
-  const isResolved = postData.status === PostStatus.RESOLVED;
-  const isGroup = isGroupOfQuestionsPost(postData);
+  const [currentPost, setCurrentPost] = useState(postData);
+  const latestRequestIdRef = useRef(0);
+
+  // Sync local state when the server prop changes (e.g., after a
+  // revalidatePath-driven re-render).
+  useEffect(() => {
+    setCurrentPost(postData);
+  }, [postData]);
+
+  // Refetch fresh post data (including updated CP) after a prediction is
+  // submitted, so sibling components (DetailedQuestionCard /
+  // DetailedGroupCard) render the updated CP immediately instead of waiting
+  // for revalidatePath to land.
+  const handlePredictionSubmit = useCallback(async () => {
+    const requestId = ++latestRequestIdRef.current;
+    try {
+      const freshPost = await ClientPostsApi.getPost(postData.id);
+      // Ignore stale responses if a newer request has been issued meanwhile.
+      if (requestId === latestRequestIdRef.current) {
+        setCurrentPost(freshPost);
+      }
+    } catch (err) {
+      // Surface the error for observability; the CP will still update on
+      // the next revalidation / page load.
+      console.error("Failed to refresh post after prediction submit:", err);
+    }
+  }, [postData.id]);
+
+  const isResolved = currentPost.status === PostStatus.RESOLVED;
+  const isGroup = isGroupOfQuestionsPost(currentPost);
 
   return (
     <Fragment>
-      <QuestionHeader post={postData} />
-      {isQuestionPost(postData) && (
+      <QuestionHeader post={currentPost} />
+      {isQuestionPost(currentPost) && (
         <DetailedQuestionCard
-          post={postData}
-          keyFactors={postData.key_factors}
+          post={currentPost}
+          keyFactors={currentPost.key_factors}
         />
       )}
       {isGroup && (
         <DetailedGroupCard
-          post={postData}
+          post={currentPost}
           preselectedQuestionId={preselectedGroupQuestionId}
         />
       )}
-      {(!isResolved || isGroup) && <ForecastMaker post={postData} />}
+      {(!isResolved || isGroup) && (
+        <ForecastMaker
+          post={currentPost}
+          onPredictionSubmit={handlePredictionSubmit}
+        />
+      )}
     </Fragment>
   );
 };

--- a/front_end/src/components/forecast_maker/index.tsx
+++ b/front_end/src/components/forecast_maker/index.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { FC, useCallback, useEffect, useState } from "react";
+import { FC } from "react";
 
 import PredictionStatusMessage from "@/components/forecast_maker/prediction_status_message";
 import { useAuth } from "@/contexts/auth_context";
-import ClientPostsApi from "@/services/api/posts/posts.client";
 import { PostWithForecasts } from "@/types/post";
 import {
   canPredictQuestion,
@@ -25,42 +24,23 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
   const t = useTranslations();
   const { user } = useAuth();
 
-  const [currentPost, setCurrentPost] = useState(post);
-
-  // Sync local state when the prop changes (e.g., from server re-renders)
-  useEffect(() => {
-    setCurrentPost(post);
-  }, [post]);
-
-  // Wrap onPredictionSubmit to fetch fresh post data (with updated CP)
-  // after a prediction is submitted, matching the reaffirm flow pattern
-  const handlePredictionSubmit = useCallback(async () => {
-    try {
-      const freshPost = await ClientPostsApi.getPost(currentPost.id);
-      setCurrentPost(freshPost);
-    } catch {
-      // Silently fail - the CP will update on next page load
-    }
-    onPredictionSubmit?.();
-  }, [currentPost.id, onPredictionSubmit]);
-
   const { group_of_questions: groupOfQuestions, conditional, question } = post;
   const canPredict = canPredictQuestion(post, user);
   const isPrePrediction = isPostPrePrediction(post);
   const predictLabel = isPrePrediction ? t("prePredict") : t("predict");
 
-  const predictionMessage = <PredictionStatusMessage post={currentPost} />;
+  const predictionMessage = <PredictionStatusMessage post={post} />;
 
   if (groupOfQuestions) {
     return (
       <ForecastMakerGroup
-        post={currentPost}
+        post={post}
         questions={groupOfQuestions.questions}
         groupVariable={groupOfQuestions.group_variable}
         canPredict={canPredict}
         predictLabel={predictLabel}
         predictionMessage={predictionMessage}
-        onPredictionSubmit={handlePredictionSubmit}
+        onPredictionSubmit={onPredictionSubmit}
       />
     );
   }
@@ -68,12 +48,12 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
   if (conditional) {
     return (
       <ForecastMakerConditional
-        post={currentPost}
+        post={post}
         conditional={conditional}
         canPredict={canPredict}
         predictLabel={predictLabel}
         predictionMessage={predictionMessage}
-        onPredictionSubmit={handlePredictionSubmit}
+        onPredictionSubmit={onPredictionSubmit}
       />
     );
   }
@@ -84,9 +64,9 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
         question={question}
         canPredict={canPredict}
         predictLabel={predictLabel}
-        post={currentPost}
+        post={post}
         predictionMessage={predictionMessage}
-        onPredictionSubmit={handlePredictionSubmit}
+        onPredictionSubmit={onPredictionSubmit}
       />
     );
   }

--- a/front_end/src/components/forecast_maker/index.tsx
+++ b/front_end/src/components/forecast_maker/index.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { FC } from "react";
+import { FC, useCallback, useEffect, useState } from "react";
 
 import PredictionStatusMessage from "@/components/forecast_maker/prediction_status_message";
 import { useAuth } from "@/contexts/auth_context";
+import ClientPostsApi from "@/services/api/posts/posts.client";
 import { PostWithForecasts } from "@/types/post";
 import {
   canPredictQuestion,
@@ -23,23 +24,43 @@ type Props = {
 const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
   const t = useTranslations();
   const { user } = useAuth();
+
+  const [currentPost, setCurrentPost] = useState(post);
+
+  // Sync local state when the prop changes (e.g., from server re-renders)
+  useEffect(() => {
+    setCurrentPost(post);
+  }, [post]);
+
+  // Wrap onPredictionSubmit to fetch fresh post data (with updated CP)
+  // after a prediction is submitted, matching the reaffirm flow pattern
+  const handlePredictionSubmit = useCallback(async () => {
+    try {
+      const freshPost = await ClientPostsApi.getPost(currentPost.id);
+      setCurrentPost(freshPost);
+    } catch {
+      // Silently fail - the CP will update on next page load
+    }
+    onPredictionSubmit?.();
+  }, [currentPost.id, onPredictionSubmit]);
+
   const { group_of_questions: groupOfQuestions, conditional, question } = post;
   const canPredict = canPredictQuestion(post, user);
   const isPrePrediction = isPostPrePrediction(post);
   const predictLabel = isPrePrediction ? t("prePredict") : t("predict");
 
-  const predictionMessage = <PredictionStatusMessage post={post} />;
+  const predictionMessage = <PredictionStatusMessage post={currentPost} />;
 
   if (groupOfQuestions) {
     return (
       <ForecastMakerGroup
-        post={post}
+        post={currentPost}
         questions={groupOfQuestions.questions}
         groupVariable={groupOfQuestions.group_variable}
         canPredict={canPredict}
         predictLabel={predictLabel}
         predictionMessage={predictionMessage}
-        onPredictionSubmit={onPredictionSubmit}
+        onPredictionSubmit={handlePredictionSubmit}
       />
     );
   }
@@ -47,12 +68,12 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
   if (conditional) {
     return (
       <ForecastMakerConditional
-        post={post}
+        post={currentPost}
         conditional={conditional}
         canPredict={canPredict}
         predictLabel={predictLabel}
         predictionMessage={predictionMessage}
-        onPredictionSubmit={onPredictionSubmit}
+        onPredictionSubmit={handlePredictionSubmit}
       />
     );
   }
@@ -63,9 +84,9 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
         question={question}
         canPredict={canPredict}
         predictLabel={predictLabel}
-        post={post}
+        post={currentPost}
         predictionMessage={predictionMessage}
-        onPredictionSubmit={onPredictionSubmit}
+        onPredictionSubmit={handlePredictionSubmit}
       />
     );
   }


### PR DESCRIPTION
Closes #4437

## Summary
- After submitting a prediction, fetch fresh post data (including updated CP) from the API, matching the reaffirm flow pattern
- Previously, the predict flow relied solely on revalidatePath which didn't reliably update the client-side CP display

## Test plan
- [ ] Predict on a binary question and verify the CP updates immediately
- [ ] Predict on a continuous question and verify the CP updates
- [ ] Predict on a multiple choice question and verify the CP updates
- [ ] Reaffirm a prediction and verify it still works correctly

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prediction components now refresh and use the latest post data before submitting, reducing stale-data submissions.
* **New Features**
  * After submitting a prediction, related question and group views update immediately so changes appear without waiting for a full refresh.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->