### PR TITLE
Add Jesse Damiani to team members list

### DIFF
--- a/front_end/src/app/(main)/about/components/TeamBlock.tsx
+++ b/front_end/src/app/(main)/about/components/TeamBlock.tsx
@@ -337,6 +337,13 @@ const people: Person[] = [
     introduction:
       "Grace is a researcher and evaluator with over a decade of experience in global health. She brings to Metaculus her experience in decision making under uncertainty, mixed methods research, and project delivery. She holds a Master of Science in Public Health from Johns Hopkins. In her spare time, she enjoys crafting/drawing, video/board games, and hiking in beautiful places.",
   },
+  {
+    name: "Jesse Damiani",
+    position: "Communications Strategist",
+    imgSrc: "https://cdn.metaculus.com/jesse.webp",
+    introduction:
+      "Jesse Damiani is a writer, curator, and foresight strategist who founded the Reality Studies newsletter and Urgent Futures podcast. He has taught at NYU, USC, SCI-Arc, and elsewhere, and served as Research Affiliate at Institute for the Future and Director of Emerging Technology & Insight at Southern New Hampshire University. His writing appears in Architectural Design, Flash Art, NBC News, WIRED, and The Yale Review.",
+  },
 ];
 
 const groups: Groups = {
@@ -359,6 +366,7 @@ const groups: Groups = {
     "Cemre Inanc",
     "Kelley Edelmann",
     "Grace McLain",
+    "Jesse Damiani",
   ],
   board: [
     "Anthony Aguirre",


### PR DESCRIPTION
## Summary
Added Jesse Damiani, Communications Strategist, to the Metaculus team members list on the About page.

## Changes
- Added new team member entry for Jesse Damiani with:
  - Position: Communications Strategist
  - Profile image: https://cdn.metaculus.com/jesse.webp
  - Professional biography highlighting his work as a writer, curator, and foresight strategist, including his newsletter, podcast, teaching experience, and published work
- Added Jesse Damiani to the "team" group in the team organization structure

## Implementation Details
The new team member follows the existing `Person` interface structure and is placed in the advisors group alongside other team members like Cemre Inanc, Kelley Edelmann, and Grace McLain.

https://claude.ai/code/session_014ZJLdf34NgAkkoCzj6EjnB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new team member to the roster displayed on the About page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->