### PR TITLE
Chart value box fix

### DIFF
--- a/front_end/src/components/charts/primitives/chart_value_box.tsx
+++ b/front_end/src/components/charts/primitives/chart_value_box.tsx
@@ -39,8 +39,7 @@ function getRectX(
         adjustedX -
         (textAlignToSide
           ? PLACEMENT_OFFSET_HORIZONTAL
-          : PLACEMENT_OFFSET_VERTICAL) +
-        textWidth -
+          : PLACEMENT_OFFSET_VERTICAL) -
         TEXT_PADDING / 2
       );
     case "right":


### PR DESCRIPTION
This PR fixes the problem with alignment in chart value box.

Before:

<img width="721" height="618" alt="image" src="https://github.com/user-attachments/assets/3235f076-a1c7-418a-ac99-35e2a372d1cb" />


After:
<img width="708" height="632" alt="image" src="https://github.com/user-attachments/assets/9825d53a-0de0-4a2b-a38f-6ada22ca959e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected positioning of chart value boxes when displayed on the left side of charts, ensuring background rectangles align properly with their text and visual padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->