### PR TITLE
don't round to 0 if 0 isn't within bounds

### DIFF
--- a/front_end/src/utils/formatters/number.ts
+++ b/front_end/src/utils/formatters/number.ts
@@ -62,9 +62,10 @@ export function abbreviatedNumber(
   }
 
   if (
-    isNil(scaling?.zero_point) &&
     !isNil(scaling?.range_min) &&
-    !isNil(scaling?.range_max)
+    !isNil(scaling?.range_max) &&
+    scaling?.range_min < 0 &&
+    0 < scaling?.range_max
   ) {
     // if sufficiently close to zero relative to the size of the range,
     // assume it should be zero


### PR DESCRIPTION
fixes bug where a sufficiently large range with lower bound close to but not equal to 0 causes the second pixel hover state to display as 0 even though 0 isn't within bounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced number formatting with improved zero-detection logic. The abbreviation function now evaluates whether numeric scaling ranges include zero to determine proper value display, replacing previous detection methods for more consistent numeric formatting throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->