### PR TITLE
Fail fast on embed screenshots for missing questions

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/image-preview/route.ts
+++ b/front_end/src/app/(main)/questions/[id]/image-preview/route.ts
@@ -4,6 +4,7 @@ import {
   ENFORCED_THEME_PARAM,
   HIDE_ZOOM_PICKER,
 } from "@/constants/global_search_params";
+import ServerPostsApi from "@/services/api/posts/posts.server";
 import { logError } from "@/utils/core/errors";
 import { getPublicSettings } from "@/utils/public_settings.server";
 
@@ -13,6 +14,12 @@ export async function GET(
 ) {
   const params = await props.params;
   const { id } = params;
+
+  const post = await ServerPostsApi.getPostAnonymous(Number(id));
+  if (!post) {
+    return NextResponse.json({ error: "Question not found" }, { status: 404 });
+  }
+
   const width = 1200;
   const height = 630;
   const theme = request.nextUrl.searchParams.get("theme") ?? "dark";

--- a/screenshot/app.py
+++ b/screenshot/app.py
@@ -114,7 +114,13 @@ async def screenshot(request_data: ScreenshotRequest = Body(...)):
         if width and height:
             await page.set_viewport_size({"width": width, "height": height})
 
-        await page.goto(url, wait_until="load", timeout=PAGE_LOAD_TIMEOUT_MS)
+        response = await page.goto(url, wait_until="load", timeout=PAGE_LOAD_TIMEOUT_MS)
+
+        if response and response.status >= 400:
+            raise HTTPException(
+                status_code=response.status,
+                detail=f"Target page returned HTTP {response.status} for {url}",
+            )
 
         # Wait for a particular element in the page, specified by the request
         if request_data.selector_to_wait:
@@ -129,6 +135,8 @@ async def screenshot(request_data: ScreenshotRequest = Body(...)):
         await screenshot_element.wait_for(state="visible", timeout=DEFAULT_TIMEOUT_MS)
 
         buffer = await screenshot_element.screenshot(timeout=DEFAULT_TIMEOUT_MS)
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception(f"Screenshot generation failed for {url}")
         raise HTTPException(


### PR DESCRIPTION
The image-preview route was sending any question ID to the screenshot service without verifying the question exists. For deleted/private questions, the embed page returns a 404, but Playwright would wait the full 5s timeout for screenshot selectors that never render.

This PR solve that by:
- adding early existence check in the image-preview route before calling the screenshot service – deleted/private questions now return 404 instantly instead of timing out
- handling HTTP error responses in the screenshot service itself – if the target page returns 4xx/5xx, it fails immediately instead of waiting for selectors that will never appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Returns a clear 404 when a requested question is missing, preventing further processing and showing an explicit "Question not found" error.
  * Stops and surfaces meaningful HTTP errors when page navigation for screenshots fails, ensuring failures are reported with appropriate status codes and clearer error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->