### PR TITLE
Tournament sorting logic update

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournaments/helpers/tournament_filters.ts
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/helpers/tournament_filters.ts
@@ -95,15 +95,14 @@ export function filterTournaments(
 
 const statusRank = (t: TournamentPreview, nowTs: number): number => {
   const hasQuestions = t.questions_count > 0;
+  const allClosed = hasQuestions && !!t.timeline?.all_questions_closed;
+  const allResolved = hasQuestions && !!t.timeline?.all_questions_resolved;
+  const forecastEndTs = safeTs(t.forecasting_end_date);
+  const forecastEnded = forecastEndTs != null && nowTs >= forecastEndTs;
 
-  if (hasQuestions && t.timeline?.all_questions_resolved) return 2;
-
-  const endTs = safeTs(t.close_date ?? t.forecasting_end_date);
-  const closedByDate = endTs != null ? nowTs >= endTs : false;
-  const closedByTimeline = hasQuestions && !!t.timeline?.all_questions_closed;
-
-  const isOpen = !(closedByDate || closedByTimeline);
-  return isOpen ? 0 : 1;
+  if (allResolved) return 2;
+  if (forecastEnded || allClosed) return 1;
+  return 0;
 };
 
 const orderValue = (t: TournamentPreview): number =>
@@ -111,7 +110,7 @@ const orderValue = (t: TournamentPreview): number =>
 
 const durationPctPassed = (t: TournamentPreview, nowTs: number): number => {
   const startTs = safeTs(t.start_date);
-  const endTs = safeTs(t.close_date ?? t.forecasting_end_date);
+  const endTs = safeTs(t.forecasting_end_date ?? t.close_date);
   if (startTs == null || endTs == null || endTs <= startTs) {
     return Number.POSITIVE_INFINITY;
   }


### PR DESCRIPTION
This PR updates the Featured sort logic for tournaments/series to properly use `forecasting_end_date` instead of `close_date` for determining open/closed status.

- `statusRank` now uses `forecasting_end_date` to determine status:
  - Rank 0 (open): `forecasting_end_date` is in the future AND NOT `all_questions_closed`
  - Rank 1 (closed): `forecasting_end_date` is in the past OR `all_questions_closed`
  - Rank 2 (resolved): `all_questions_resolved`
- `durationPctPassed` now prefers `forecasting_end_date` over `close_date`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced tournament status indicators to more accurately reflect tournament states based on timeline and question resolution.
  * Updated tournament progress tracking calculations for improved accuracy in displaying completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->