### PR TITLE
chore: lock package manager min package release dates

### DIFF
--- a/front_end/bunfig.toml
+++ b/front_end/bunfig.toml
@@ -1,0 +1,6 @@
+[install]
+# Only install package versions published at least 3 days ago
+minimumReleaseAge = 259200 # seconds
+
+# Exclude trusted packages from the age gate
+minimumReleaseAgeExcludes = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,3 +94,6 @@ max-complexity = 56
 
 [tool.ruff.format]
 quote-style = "double"
+
+[tool.uv]
+exclude-newer = "3 days"

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.12.3, <3.13"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added dependency version constraints to ensure only established package versions are installed, enhancing project stability by preventing the use of very new or untested package releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->