### PR TITLE
Suppress unhandled Lexical errors in markdown editor write mode

### DIFF
--- a/front_end/src/components/markdown_editor/initialized_editor.tsx
+++ b/front_end/src/components/markdown_editor/initialized_editor.tsx
@@ -53,6 +53,7 @@ import {
   normalizeLang,
 } from "./plugins/code/languages";
 import { equationPlugin } from "./plugins/equation";
+import { errorRecoveryPlugin } from "./plugins/error_recovery_plugin";
 import { linkPlugin } from "./plugins/link";
 import { mentionsPlugin } from "./plugins/mentions";
 import { trimTrailingParagraphPlugin } from "./plugins/trim_trailing_plugin";
@@ -306,6 +307,7 @@ const InitializedMarkdownEditor: FC<
     ];
     if (editorToolbarPlugin) list.push(editorToolbarPlugin);
     if (mode === "read") list.push(trimTrailingParagraphPlugin());
+    else list.push(errorRecoveryPlugin());
     if (editorDiffSourcePlugin) list.push(editorDiffSourcePlugin);
     return list;
   }, [

--- a/front_end/src/components/markdown_editor/plugins/error_recovery_plugin.tsx
+++ b/front_end/src/components/markdown_editor/plugins/error_recovery_plugin.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { addComposerChild$, realmPlugin } from "@mdxeditor/editor";
+import { useEffect } from "react";
+
+// Minified Lexical errors that are transient and recoverable via state rollback.
+// See https://lexical.dev/docs/error?code=<N> for descriptions.
+const TRANSIENT_ERROR_CODES = new Set([
+  20, // Point.getNode: node not found (stale selection reference)
+  62, // updateEditor: selection lost after node removal
+]);
+
+function isTransientLexicalError(error: Error): boolean {
+  const match = error.message.match(/Lexical error #(\d+)/);
+  if (match) return TRANSIENT_ERROR_CODES.has(Number(match[1]));
+  return error.message.includes("node not found");
+}
+
+/**
+ * MDXEditor hardcodes `onError: (error) => { throw error }` in the Lexical
+ * editor config. This causes transient Lexical errors (e.g. error #20 —
+ * "Point.getNode: node not found") to escape the internal try/catch and
+ * propagate as unhandled errors. This plugin patches `_onError` to suppress
+ * known transient errors in production, letting Lexical's own recovery
+ * (state rollback) work. Unknown errors are delegated to the previous handler.
+ */
+function ErrorRecovery() {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    const prev = editor._onError;
+    editor._onError = (error: Error) => {
+      if (
+        process.env.NODE_ENV !== "production" ||
+        !isTransientLexicalError(error)
+      ) {
+        prev(error);
+        return;
+      }
+      console.warn("[Lexical]", error.message);
+    };
+    return () => {
+      editor._onError = prev;
+    };
+  }, [editor]);
+
+  return null;
+}
+
+export const errorRecoveryPlugin = realmPlugin({
+  init(realm) {
+    realm.pubIn({
+      [addComposerChild$]: () => <ErrorRecovery />,
+    });
+  },
+});


### PR DESCRIPTION
This PR adds an `errorRecoveryPlugin` to the Lexical markdown editor that prevents transient Lexical errors from propagating as unhandled exceptions to Sentry.

MDXEditor hardcodes `onError: (error) => { throw error }` when creating the Lexical editor. When Lexical encounters transient errors (e.g. error #20 – "Point.getNode: node not found" caused by stale selection references), its internal `$beginUpdate` try/catch catches the error, rolls back the editor state, but then calls `_onError` which re-throws – defeating the built-in recovery and sending unhandled errors to Sentry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved markdown editor error handling: editor now more gracefully handles transient runtime errors while editing (non-read modes), reducing interruptions and preventing crashes in production.
  * Read-only mode retains previous trimming behavior while edit mode gains resilient error recovery to improve stability during active edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->