### PR TITLE
get question community prediction endpoint

### DIFF
--- a/questions/serializers/common.py
+++ b/questions/serializers/common.py
@@ -937,6 +937,46 @@ class QuestionApproveSerializer(serializers.Serializer):
     scheduled_resolve_time = serializers.DateTimeField(required=True)
 
 
+class QuestionsCommunityPredictionsSerializer(serializers.Serializer):
+    question_ids = serializers.ListField(
+        child=serializers.IntegerField(), required=True
+    )
+    # timestamp applies the same datetime to every question_id.
+    # timestamps (parallel list) takes priority when provided.
+    timestamp = serializers.DateTimeField(required=False, default=None)
+    timestamps = serializers.ListField(
+        child=serializers.DateTimeField(), required=False, default=None
+    )
+
+    def validate(self, data):
+        question_ids = data.get("question_ids", [])
+        if not question_ids:
+            raise serializers.ValidationError(
+                "question_ids is required and must be non-empty"
+            )
+        timestamps = data.get("timestamps")
+        timestamp = data.get("timestamp")
+        if timestamps is not None:
+            if len(timestamps) != len(question_ids):
+                raise serializers.ValidationError(
+                    f"timestamps length ({len(timestamps)}) must match "
+                    f"question_ids length ({len(question_ids)})"
+                )
+        elif timestamp is None:
+            raise serializers.ValidationError(
+                "either timestamp or timestamps is required"
+            )
+        return data
+
+    def get_per_question_timestamps(self) -> list[datetime]:
+        timestamps = self.validated_data.get("timestamps")
+        if timestamps is not None:
+            return timestamps
+        return [self.validated_data["timestamp"]] * len(
+            self.validated_data["question_ids"]
+        )
+
+
 def serialize_question_movement(
     question: Question,
     f1: AggregateForecast,

--- a/questions/urls.py
+++ b/questions/urls.py
@@ -29,6 +29,11 @@ urlpatterns = [
         views.legacy_question_api_view,
         name="oldapi-get-question-post",
     ),
+    path(
+        "questions/community-predictions/",
+        views.questions_community_predictions,
+        name="questions-community-predictions",
+    ),
 ]
 old_api = [
     path(

--- a/questions/views.py
+++ b/questions/views.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import get_object_or_404
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.response import Response
 from rest_framework.serializers import DateTimeField
 
@@ -12,10 +12,12 @@ from posts.models import Post
 from posts.services.common import get_post_permission_for_user
 from posts.utils import get_post_slug
 from projects.permissions import ObjectPermission
+from utils.the_math.aggregations import get_aggregations_at_time
 from .constants import QuestionStatus
 from .models import Question
 from .serializers.common import (
     validate_question_resolution,
+    QuestionsCommunityPredictionsSerializer,
     OldForecastWriteSerializer,
     ForecastWriteSerializer,
     ForecastWithdrawSerializer,
@@ -246,3 +248,54 @@ def legacy_question_api_view(request, pk: int):
     return Response(
         {"question_id": pk, "post_id": post.pk, "post_slug": get_post_slug(post)}
     )
+
+
+@api_view(["GET", "POST"])
+@permission_classes([IsAdminUser])
+def questions_community_predictions(request) -> Response:
+    src = request.data if request.method == "POST" else request.query_params
+    serializer = QuestionsCommunityPredictionsSerializer(data=src)
+    serializer.is_valid(raise_exception=True)
+
+    question_ids: list[int] = serializer.validated_data["question_ids"]
+    per_entry_timestamps = serializer.get_per_question_timestamps()
+
+    # Fetch questions
+    questions_by_id: dict[int, Question] = {
+        q.id: q for q in Question.objects.filter(id__in=question_ids)
+    }
+
+    # Compute aggregations
+    results = []
+    for qid, ts in zip(question_ids, per_entry_timestamps):
+        question = questions_by_id.get(qid)
+        if not question:
+            continue
+
+        method = question.default_aggregation_method
+        aggs = get_aggregations_at_time(
+            question=question,
+            time=ts,
+            aggregation_methods=[method],
+            include_stats=True,
+            include_bots=question.include_bots_in_aggregates,
+        )
+        agg = aggs.get(method)
+
+        if agg:
+            results.append(
+                {
+                    "metaculus_id": qid,
+                    "timestamp": ts.isoformat(),
+                    "method": method,
+                    "pmf": agg.get_pmf(),
+                    "interval_lower_bounds": agg.interval_lower_bounds,
+                    "centers": agg.centers,
+                    "interval_upper_bounds": agg.interval_upper_bounds,
+                    "means": agg.means,
+                    "forecaster_count": agg.forecaster_count,
+                    "error": None,
+                }
+            )
+
+    return Response({"results": results})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin-only API endpoint that enables retrieval of aggregated community predictions across multiple questions simultaneously. Supports optional timestamp filtering to query predictions from specific points in time. Returns comprehensive forecasting metrics including probability distributions, confidence intervals, means, and forecaster counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->