### PR TITLE
Sort-less state in the My Predictions feed

### DIFF
--- a/front_end/src/app/(main)/questions/components/feed_filters/my_predictions.tsx
+++ b/front_end/src/app/(main)/questions/components/feed_filters/my_predictions.tsx
@@ -86,6 +86,7 @@ const MyPredictionsFilters: FC<Props> = ({ panelClassname }) => {
       optionValue: string | string[] | null;
       replaceInfo?: FilterReplaceInfo;
     },
+    order: QuestionOrder,
     deleteParam: (
       name: string,
       withNavigation?: boolean,
@@ -102,10 +103,9 @@ const MyPredictionsFilters: FC<Props> = ({ panelClassname }) => {
       QuestionOrder.WeeklyMovementDesc,
       QuestionOrder.DivergenceDesc,
       QuestionOrder.ScoreDesc,
-      QuestionOrder.ScoreDesc,
       QuestionOrder.LastPredictionTimeAsc,
       QuestionOrder.HotAsc,
-    ].includes(params.get(POST_ORDER_BY_FILTER) as QuestionOrder);
+    ].includes(order);
 
     if (didRemoveUserFilter && isUserSpecificOrder) {
       // clear user specific order if user filter is removed
@@ -153,6 +153,7 @@ const MyPredictionsFilters: FC<Props> = ({ panelClassname }) => {
       onOrderChange={handleOrderChange}
       onPopOverFilterChange={handleFilterChange}
       defaultOrder={QuestionOrder.WeeklyMovementDesc}
+      alwaysKeepOrderInUrl
       panelClassname={panelClassname}
     />
   );

--- a/front_end/src/app/(main)/questions/page.tsx
+++ b/front_end/src/app/(main)/questions/page.tsx
@@ -11,6 +11,7 @@ import AwaitedWeeklyTopCommentsFeed from "@/components/weekly_top_comments_feed"
 import {
   POST_COMMENTS_FEED_FILTER,
   POST_COMMUNITIES_FILTER,
+  POST_FORECASTER_ID_FILTER,
   POST_PAGE_FILTER,
   POST_WEEKLY_TOP_COMMENTS_FILTER,
 } from "@/constants/posts_feed";
@@ -35,12 +36,17 @@ export default async function Questions(props: {
   const user = await ServerProfileApi.getMyProfile();
 
   const searchParams = await props.searchParams;
+  const isMyPredictionsFeed =
+    typeof searchParams[POST_FORECASTER_ID_FILTER] === "string" &&
+    searchParams[POST_FORECASTER_ID_FILTER] === user?.id.toString();
   const isCommunityFeed = searchParams[POST_COMMUNITIES_FILTER];
   const isWeeklyTopCommentsFeed = searchParams[POST_WEEKLY_TOP_COMMENTS_FILTER];
   const isCommentsFeed = searchParams[POST_COMMENTS_FEED_FILTER];
   const filters = generateFiltersFromSearchParams(searchParams, {
     // Default Feed ordering should be hotness
-    defaultOrderBy: QuestionOrder.HotDesc,
+    defaultOrderBy: isMyPredictionsFeed
+      ? QuestionOrder.WeeklyMovementDesc
+      : QuestionOrder.HotDesc,
     defaultForMainFeed: true,
     filterForConsumerView:
       isNil(user) || user.interface_type === InterfaceType.ConsumerView,

--- a/front_end/src/components/posts_filters.tsx
+++ b/front_end/src/components/posts_filters.tsx
@@ -48,6 +48,7 @@ type Props = {
       optionValue: string | string[] | null;
       replaceInfo?: FilterReplaceInfo;
     },
+    order: QuestionOrder,
     deleteParam: (
       name: string,
       withNavigation?: boolean,
@@ -65,6 +66,7 @@ type Props = {
   inputConfig?: { mode: "client" | "server"; debounceTime?: number };
   showRandomButton?: boolean;
   panelClassname?: string;
+  alwaysKeepOrderInUrl?: boolean;
 };
 
 const PostsFilters: FC<Props> = ({
@@ -76,6 +78,7 @@ const PostsFilters: FC<Props> = ({
   onOrderChange,
   showRandomButton,
   panelClassname,
+  alwaysKeepOrderInUrl,
 }) => {
   const t = useTranslations();
   const {
@@ -146,7 +149,7 @@ const PostsFilters: FC<Props> = ({
 
     clearPopupFilters(withNavigation);
 
-    if (order === defaultOrder) {
+    if (order === defaultOrder && !alwaysKeepOrderInUrl) {
       deleteParam(POST_ORDER_BY_FILTER, withNavigation);
     } else {
       setParam(POST_ORDER_BY_FILTER, order, withNavigation);
@@ -165,6 +168,7 @@ const PostsFilters: FC<Props> = ({
   ) => {
     onPopOverFilterChange?.(
       { filterId, optionValue, replaceInfo },
+      order,
       deleteParam
     );
 


### PR DESCRIPTION
Closes #4140

This PR fixes the My Predictions feed losing its sort order when switching away from Movers and back, by keeping the `order_by` parameter in the URL and setting the correct server-side default.

Before:

https://github.com/user-attachments/assets/30b33fb4-4a6f-4626-82a6-84b39c27b2d3

After:

https://github.com/user-attachments/assets/d01a2418-d783-4a2c-9937-ec5ceb3d5e3b


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "My Predictions" feed now defaults to sorting by "Weekly Movement" for better recent-activity visibility.
  * Filter controls can now optionally preserve your selected sort order in the URL so your chosen order persists across filter changes.

* **Bug Fixes / Improvements**
  * Improved filter behavior when applying changes to ensure the correct sort order is used and duplicate sort entries removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->