### PR TITLE
Updates to Question Group Scores Table

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/post_score_data/group_resolution_score_data/group_score_cell.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/post_score_data/group_resolution_score_data/group_score_cell.tsx
@@ -9,6 +9,9 @@ type Props = {
   communityScore: number | null | undefined;
 };
 
+const USER_SCORE_CLASS = "text-orange-800 dark:text-orange-800-dark";
+const COMMUNITY_SCORE_CLASS = "text-olive-800 dark:text-olive-800-dark";
+
 const GroupScoreCell: FC<Props> = ({ userScore, communityScore }) => {
   const t = useTranslations();
 
@@ -17,31 +20,44 @@ const GroupScoreCell: FC<Props> = ({ userScore, communityScore }) => {
     return `${sign}${score.toFixed(1)}`;
   };
 
-  const getScoreColor = (score: number) => {
-    if (score > 0) return "text-olive-800 dark:text-olive-800-dark";
-    if (score < 0) return "text-salmon-800 dark:text-salmon-800-dark";
-    return "text-gray-500 dark:text-gray-500-dark";
-  };
+  const hasUserScore = !isNil(userScore);
+  const hasCommunityScore = !isNil(communityScore);
 
   return (
     <div className="flex flex-col items-center justify-center gap-1">
       {/* User Score */}
-      <div className="text-sm leading-4">
-        {!isNil(userScore) ? (
-          <span className={cn("font-semibold", getScoreColor(userScore))}>
+      {hasUserScore && (
+        <div className="text-sm leading-4">
+          <span className={cn("font-semibold", USER_SCORE_CLASS)}>
             {formatScore(userScore)}
           </span>
-        ) : (
-          <span className="text-gray-400 dark:text-gray-500-dark">—</span>
-        )}
-      </div>
+        </div>
+      )}
 
       {/* Community Score */}
-      <div className="text-[10px] font-normal capitalize leading-3 text-gray-600 dark:text-gray-600-dark">
-        {!isNil(communityScore) ? (
+      <div
+        className={cn("transition-all", {
+          "text-[10px] font-normal leading-3": hasUserScore,
+          "flex flex-col items-center gap-0.5 text-sm leading-4": !hasUserScore,
+        })}
+      >
+        {hasCommunityScore ? (
           <>
-            {t("community")}:{" "}
-            <span className={cn("font-bold", getScoreColor(communityScore))}>
+            <span
+              className={cn({
+                "text-gray-600 dark:text-gray-600-dark": hasUserScore,
+                "font-medium capitalize text-gray-500 dark:text-gray-500-dark":
+                  !hasUserScore,
+              })}
+            >
+              {t("community")}:
+            </span>
+            <span
+              className={cn(COMMUNITY_SCORE_CLASS, {
+                "font-semibold": hasUserScore,
+                "text-sm font-semibold": !hasUserScore,
+              })}
+            >
               {formatScore(communityScore)}
             </span>
           </>


### PR DESCRIPTION
Closes #3888 

Before:
<img width="708" height="286" alt="image" src="https://github.com/user-attachments/assets/ff3e2aa5-a3ca-4d24-aae4-8a383a369107" />

After:
<img width="706" height="302" alt="image" src="https://github.com/user-attachments/assets/ddf4d197-8476-43db-8288-37d456d13c6b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User Score section now fully hides when unavailable, improving layout consistency.
  
* **UI/UX Improvements**
  * Community Score styling and layout now dynamically adjust based on User Score presence.
  * Community score label styling refined for better visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->