### PR TITLE
Question Groups display based on option count

### DIFF
--- a/front_end/src/components/consumer_post_card/time_series_chart/index.tsx
+++ b/front_end/src/components/consumer_post_card/time_series_chart/index.tsx
@@ -56,6 +56,16 @@ function getNormalizedTicks(maxValue: number): number[] {
   return [0, maxValue * 0.25, maxValue * 0.5, maxValue * 0.75, maxValue];
 }
 
+const getDomainPaddingX = (chartWidth: number, count: number): number => {
+  if (count <= 2) {
+    return chartWidth * 0.3;
+  }
+  if (count <= 4) {
+    return chartWidth * 0.2;
+  }
+  return chartWidth > 400 ? 80 : 40;
+};
+
 const TimeSeriesChart: FC<Props> = ({
   questions,
   height = 130,
@@ -78,12 +88,17 @@ const TimeSeriesChart: FC<Props> = ({
   const chartData = buildChartData(orderedQuestions, locale);
   const { adjustedChartData, yDomain } = adjustChartData(chartData, chartWidth);
   const shouldDisplayChart = !!chartWidth;
+  const domainPaddingX = useMemo(
+    () => getDomainPaddingX(chartWidth, adjustedChartData.length),
+    [adjustedChartData.length, chartWidth]
+  );
   const { labelVisibilityMap: tickLabelVisibilityMap, widthPerLabel } =
-    adjustLabelsForDisplay(adjustedChartData, chartWidth);
+    adjustLabelsForDisplay(adjustedChartData, chartWidth, domainPaddingX);
 
   const { labelVisibilityMap: barLabelVisibilityMap } = adjustLabelsForDisplay(
     adjustedChartData,
     chartWidth,
+    domainPaddingX,
     true
   );
 
@@ -141,7 +156,7 @@ const TimeSeriesChart: FC<Props> = ({
             bottom: 30,
           }}
           domainPadding={{
-            x: chartWidth > 400 ? 80 : chartData.length > 3 ? 40 : 50,
+            x: domainPaddingX,
             y: 20,
           }}
           domain={yDomain ? { y: yDomain } : undefined}
@@ -401,6 +416,7 @@ function adjustLabelsForDisplay(
     isEmpty: boolean;
   }>,
   chartWidth: number,
+  domainPaddingX: number,
   isBarLabel?: boolean
 ) {
   const labelMargin = 5;
@@ -426,11 +442,12 @@ function adjustLabelsForDisplay(
   if (!charWidth) {
     return { labelVisibilityMap: labels.map(() => true), widthPerLabel: 0 };
   }
-  const chartDomainPadding = chartWidth > 400 ? 60 : 30;
-  const availableWidth = chartWidth - chartDomainPadding;
+  const availableWidth = Math.max(chartWidth - domainPaddingX * 2, 0);
 
   const getLabelX = (index: number) =>
-    (index * availableWidth) / (labels.length - 1) + chartDomainPadding / 2;
+    labels.length <= 1
+      ? chartWidth / 2
+      : (index * availableWidth) / (labels.length - 1) + domainPaddingX;
 
   const getLabelWidth = (label: string) =>
     label.length * charWidth + labelMargin;


### PR DESCRIPTION
Closes #3850

This PR implements logic to dynamically adjusts bar chart horizontal padding based on subquestion count so charts with few options don't look overly spread out.

- 2 or fewer options: 30% padding
- 3–4 options: 20% padding
- 5+: fixed padding (40–80px)

Before:

<img width="781" height="475" alt="image" src="https://github.com/user-attachments/assets/20410b7f-823c-4420-954a-6d2e314efdb9" />

<img width="775" height="503" alt="image" src="https://github.com/user-attachments/assets/96713b52-9d56-4177-ab43-f2e010847166" />


After:

<img width="773" height="472" alt="image" src="https://github.com/user-attachments/assets/f4c0b3cb-80ef-4dda-beeb-059cd3c7984a" />

<img width="743" height="513" alt="image" src="https://github.com/user-attachments/assets/70528fde-ac19-45ee-ae7d-4c654cfe69a3" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time series chart label layout and spacing: consistent horizontal padding, centered single labels, and more reliable tick and bar label positioning so labels remain readable across varying chart widths and data sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->