### PR TITLE
Question editing doesn't allow updating advanced fields

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -2148,5 +2148,6 @@
   "whyTrustMetaculusMarketsComparisonAlt": "Srovnání předpovědí Metaculus oproti predikčním trhům",
   "whyTrustMetaculusLessNoiseTitle": "Méně šumu, více pravdy",
   "whyTrustMetaculusLessNoise": "Předpovědi Metaculus, poháněné davem, prořezávají šum tím, že zakládají každou předpověď na transparentních důkazech, odpovědném skóre a desetiletí doložené přesnosti. Jako veřejný zdroj vybavuje Metaculus politiky, výzkumníky, novináře a širokou veřejnost s jasným, kvantifikovatelným vhledem do nejkritičtějších nejistot světa. Stejný prověřený přístup může být také zaměřen na specifické nejistoty, kterým čelí vaše organizace, a poskytovat strukturované, důkazy podložené předpovědi k podpoře přesnějších strategických rozhodnutí. Navštivte naši <servicesLink>stránku služeb</servicesLink>, abyste se dozvěděli, jak vám Metaculus může pomoci.",
+  "publishTimeLockedDescription": "Čas publikace nelze po vytvoření změnit.",
   "thousandsOfOpenQuestions": "20 000+ otevřených otázek"
 }

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -2141,5 +2141,6 @@
   "whyTrustMetaculusMarketsComparisonAlt": "Comparison of Metaculus forecasts versus prediction markets",
   "whyTrustMetaculusLessNoiseTitle": "Less noise, more truth",
   "whyTrustMetaculusLessNoise": "Metaculus's crowd-powered forecasts cut through the noise by grounding every prediction in transparent evidence, accountable scoring, and a decade of demonstrated accuracy. As a public resource, Metaculus equips policymakers, researchers, journalists, and the broader public with clear, quantifiable insight into the world's most critical uncertainties. The same proven approach can also be directed to the specific uncertainties your organization is facing, providing structured, evidence-based forecasts to support sharper strategic decisions. Visit our <servicesLink>services page</servicesLink> to learn how Metaculus can help you.",
+  "publishTimeLockedDescription": "Publish time cannot be changed after creation.",
   "feedTileSummaryPlaceholder": "Optional: Enter a custom summary text to display on feed tiles (if not provided, a summary will be auto-generated from the notebook content)"
 }

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -2148,5 +2148,6 @@
   "whyTrustMetaculusMarketsComparisonAlt": "Comparación de pronósticos de Metaculus frente a los mercados de predicción",
   "whyTrustMetaculusLessNoiseTitle": "Menos ruido, más verdad",
   "whyTrustMetaculusLessNoise": "Los pronósticos impulsados por la multitud de Metaculus cortan el ruido al basar cada predicción en evidencia transparente, puntuaciones responsables y una década de precisión demostrada. Como recurso público, Metaculus equipa a los responsables de políticas, investigadores, periodistas y al público en general con una visión clara y cuantificable de las incertidumbres más críticas del mundo. El mismo enfoque probado también puede dirigirse a las incertidumbres específicas que enfrenta tu organización, proporcionando pronósticos estructurados y basados en evidencia para apoyar decisiones estratégicas más precisas. Visita nuestra <servicesLink>página de servicios</servicesLink> para aprender cómo Metaculus puede ayudarte.",
+  "publishTimeLockedDescription": "La hora de publicación no puede cambiarse después de la creación.",
   "thousandsOfOpenQuestions": "20,000+ preguntas abiertas"
 }

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -2146,5 +2146,6 @@
   "whyTrustMetaculusMarketsComparisonAlt": "Comparação de previsões do Metaculus versus mercados de previsões",
   "whyTrustMetaculusLessNoiseTitle": "Menos ruído, mais verdade",
   "whyTrustMetaculusLessNoise": "As previsões baseadas na multidão do Metaculus cortam o ruído ao basear cada previsão em evidências transparentes, pontuações responsáveis e uma década de precisão demonstrada. Como recurso público, o Metaculus equipa formuladores de políticas, pesquisadores, jornalistas e o público em geral com insights claros e quantificáveis sobre as incertezas mais críticas do mundo. A mesma abordagem comprovada também pode ser direcionada para as incertezas específicas que sua organização enfrenta, fornecendo previsões estruturadas e baseadas em evidências para apoiar decisões estratégicas mais precisas. Visite nossa <servicesLink>página de serviços</servicesLink> para saber como o Metaculus pode ajudá-lo.",
+  "publishTimeLockedDescription": "O horário de publicação não pode ser alterado após a criação.",
   "thousandsOfOpenQuestions": "20.000+ perguntas abertas"
 }

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -2145,5 +2145,6 @@
   "whyTrustMetaculusMarketsComparisonAlt": "Metaculus 預測與預測市場比較",
   "whyTrustMetaculusLessNoiseTitle": "更少的噪音，更多的真相",
   "whyTrustMetaculusLessNoise": "Metaculus 的群眾驅動預測通過將每一個預測植根於透明的證據、負責的計分和十年的已證準確性，抑制了噪音。作為一種公共資源，Metaculus 為政策制定者、研究人員、記者和廣大公眾提供了對全球最重要不確定性的清晰、可量化的洞察。相同的已證方法也可以應用於您組織面臨的特定不確定性上，提供結構化、基於證據的預測，以支持更精確的戰略決策。訪問我們的服務頁面以了解 Metaculus 如何幫助您。",
+  "publishTimeLockedDescription": "建立後將無法更改發佈時間。",
   "thousandsOfOpenQuestions": "20,000+ 開放問題"
 }

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -2150,5 +2150,6 @@
   "whyTrustMetaculusMarketsComparisonAlt": "比较 Metaculus 预测与预测市场",
   "whyTrustMetaculusLessNoiseTitle": "少噪音，多真相",
   "whyTrustMetaculusLessNoise": "Metaculus 的众包预测通过以透明证据、可追溯的评分以及十年证明的准确性为基础来削减预测中的噪音。作为一个公共资源，Metaculus 为政策制定者、研究人员、记者和更广泛的公众提供了对世界最重要的不确定性进行量化、清晰的洞察。相同经过验证的方法还可用于贵组织所面临的具体不确定性，提供结构化、以证据为依据的预测来支持更明智的战略决策。访问我们的<servicesLink>服务页面</servicesLink>了解 Metaculus 如何协助您。",
+  "publishTimeLockedDescription": "创建后将无法更改发布时间。",
   "thousandsOfOpenQuestions": "20,000+ 开放问题"
 }

--- a/front_end/src/app/(main)/questions/components/question_form.tsx
+++ b/front_end/src/app/(main)/questions/components/question_form.tsx
@@ -962,7 +962,16 @@ const QuestionForm: FC<Props> = ({
           <div className="mb-6 flex w-full flex-col gap-4 md:flex-row">
             <InputContainer
               labelText={"Publish Time"}
-              explanation={t("publishTimeDescription")}
+              explanation={
+                mode === "edit" ? (
+                  <>
+                    <span>{t("publishTimeDescription")} </span>
+                    <span>{t("publishTimeLockedDescription")}</span>
+                  </>
+                ) : (
+                  t("publishTimeDescription")
+                )
+              }
               className="w-full gap-2"
             >
               <DateInput
@@ -970,6 +979,7 @@ const QuestionForm: FC<Props> = ({
                 name="published_at"
                 defaultValue={post?.published_at}
                 errors={form.formState.errors.published_at}
+                disabled={mode === "edit"}
                 className="w-full rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
               />
             </InputContainer>

--- a/front_end/src/components/ui/form_field.tsx
+++ b/front_end/src/components/ui/form_field.tsx
@@ -114,7 +114,10 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <>
         <input
           type={type}
-          className={cn("rounded-s border p-1", className)}
+          className={cn(
+            "rounded-s border p-1 disabled:cursor-not-allowed disabled:border-gray-400 disabled:bg-gray-200 disabled:text-gray-600 disabled:dark:border-gray-400-dark disabled:dark:bg-gray-200-dark disabled:dark:text-gray-600-dark",
+            className
+          )}
           ref={ref}
           name={name}
           {...props}
@@ -134,9 +137,10 @@ type DateInputProps<T extends FieldValues = FieldValues> = {
   defaultValue?: PathValue<T, Path<T>>;
   errors?: ErrorResponse;
   className?: string;
+  disabled?: boolean;
 };
 export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
-  ({ control, name, errors, defaultValue, className }, ref) => {
+  ({ control, name, errors, defaultValue, className, disabled }, ref) => {
     const { field } = useController({ control, name, defaultValue });
 
     return (
@@ -155,6 +159,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
             field.onChange(value);
           }}
           onBlur={field.onBlur}
+          disabled={disabled}
           withFormValidation
         />
         {errors && <FormError name={name} errors={errors} />}


### PR DESCRIPTION
Closes #3910 

This PR fixes the issue by disabling the Publish Time field on the question edit form. Previously, the field appeared editable but saving didn't actually update the value, causing a confusing silent failure. Now the field is visually disabled in edit mode with a helper message explaining that publish time cannot be changed after creation. The creation form remains unaffected. Disabled styling was also added to the shared Input and DateInput components.

Before:

<img width="876" height="492" alt="image" src="https://github.com/user-attachments/assets/3d1cfae9-6db9-4d6b-9009-3a4b403fa02f" />

After:

<img width="847" height="359" alt="image" src="https://github.com/user-attachments/assets/3f77a5df-6703-4457-b26b-8c351667be91" />

