### PR TITLE
Key Factors in question tiles should link to the question

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/questions_feed_view/key_factor_tile_view.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/questions_feed_view/key_factor_tile_view.tsx
@@ -2,6 +2,7 @@
 
 import { faQuestionCircle } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { FC, PropsWithChildren, ReactNode } from "react";
 
@@ -132,8 +133,12 @@ export const KeyFactorTileBaseRateFreqView: FC<Props> = ({
 };
 
 export const KeyFactorTileQuestionLinkView: FC<
-  Props & { label: string | null; title: string }
-> = ({ className, expanded, onToggle, label, title }) => {
+  Props & {
+    href?: string;
+    label: string | null;
+    title: string;
+  }
+> = ({ className, expanded, href, label, onToggle, title }) => {
   const tooltipText = "This is another Metaculus question.";
 
   return (
@@ -155,14 +160,27 @@ export const KeyFactorTileQuestionLinkView: FC<
       endAdornment={
         <Tooltip tooltipContent={tooltipText} showDelayMs={150}>
           <FontAwesomeIcon
-            onClick={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
             icon={faQuestionCircle}
             className="cursor-pointer text-blue-500 hover:text-blue-800 dark:text-blue-500-dark dark:hover:text-blue-800-dark"
           />
         </Tooltip>
       }
     >
-      {title}
+      {href ? (
+        <Link
+          href={href}
+          className="no-underline hover:underline"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {title}
+        </Link>
+      ) : (
+        title
+      )}
     </KeyFactorTileContainer>
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/questions_feed_view/key_factors_tile_view.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/questions_feed_view/key_factors_tile_view.tsx
@@ -20,6 +20,7 @@ import {
   QuestionWithNumericForecasts,
 } from "@/types/question";
 import cn from "@/utils/core/cn";
+import { getPostLink } from "@/utils/navigation";
 
 import {
   KeyFactorTileBaseRateFreqView,
@@ -174,15 +175,19 @@ const KeyFactorsTileView: React.FC<Props> = ({
   }, []);
 
   const questionLinkDisplay = useMemo(() => {
-    if (!primaryQuestionLink || !otherQuestion) return null;
+    if (!primaryQuestionLink || !otherQuestion || !otherQuestion.post_id) {
+      return null;
+    }
 
     const isBinary = otherQuestion.type === QuestionType.Binary;
     const label = isBinary && binaryLabel ? binaryLabel : null;
+    const questionLinkHref = getPostLink({ id: otherQuestion.post_id });
 
     return (
       <li key={`question-link-tile-${primaryQuestionLink.id}`}>
         <KeyFactorTileQuestionLinkView
           kf={{} as KeyFactor}
+          href={questionLinkHref}
           label={label}
           title={otherQuestion.title}
           expanded={isQuestionLinkExpanded}
@@ -190,13 +195,7 @@ const KeyFactorsTileView: React.FC<Props> = ({
         />
       </li>
     );
-  }, [
-    primaryQuestionLink,
-    otherQuestion,
-    binaryLabel,
-    isQuestionLinkExpanded,
-    onToggleQuestionLink,
-  ]);
+  }, [primaryQuestionLink, otherQuestion, binaryLabel, isQuestionLinkExpanded]);
 
   const items = useMemo(
     () =>


### PR DESCRIPTION
Closes #3851 

This PR makes key factor question-link tiles in the question feed clickable, navigating the user to the linked question page. Previously, the tiles showed a pointer cursor on hover but clicking did nothing. Now the question title is wrapped in a Next.js Link component that points to the corresponding post. The highlight animation part of the original issue is no longer relevant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced question navigation within key factor tiles—titles can now be displayed as clickable links to access related questions
  * Improved interaction handling for question metadata to prevent unintended navigation side effects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->