### PR TITLE
AIB leaderboard M spacing weird

### DIFF
--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/aggregation_rank_tooltip.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/aggregation_rank_tooltip.tsx
@@ -21,8 +21,8 @@ const AggregationRankTooltip: FC<Props> = ({ aggregationMethod }) => {
         : "leaderboardCpInfo"; // Default fallback
 
   return (
-    <div className="flex flex-1 items-center justify-center">
-      <div className="relative text-blue-700 dark:text-blue-700-dark">
+    <div className="flex flex-1 items-center justify-start">
+      <div className="relative pr-1 text-blue-700 dark:text-blue-700-dark">
         <span className="font-league-gothic text-xl">M</span>
         <Tooltip
           showDelayMs={200}
@@ -39,7 +39,7 @@ const AggregationRankTooltip: FC<Props> = ({ aggregationMethod }) => {
               }
             </RichText>
           }
-          className="absolute right-[-18px] top-[0.5px] inline-flex h-full items-center justify-center font-sans"
+          className="absolute left-full top-1/2 ml-0 inline-flex -translate-y-1/2 items-center justify-center font-sans text-base leading-none"
           tooltipClassName="font-sans text-center text-gray-800 dark:text-gray-800-dark border-blue-400 dark:border-blue-400-dark bg-gray-0 dark:bg-gray-0-dark"
         >
           <span className="leading-none">ⓘ</span>

--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/excluded_entry_tooltop.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/excluded_entry_tooltop.tsx
@@ -7,12 +7,12 @@ const ExcludedEntryTooltip: FC = () => {
   const t = useTranslations();
   return (
     <div className="justify-left flex flex-1 items-center">
-      <div className="relative text-blue-700 dark:text-blue-700-dark">
+      <div className="relative w-4 text-blue-700 dark:text-blue-700-dark">
         <Tooltip
           showDelayMs={200}
           placement={"right"}
           tooltipContent={t("entryExcluded")}
-          className="absolute right-[-18px] top-[0.5px] inline-flex h-full items-center justify-center font-sans"
+          className="absolute left-0 top-1/2 inline-flex -translate-y-1/2 items-center justify-center font-sans text-base leading-none"
           tooltipClassName="font-sans text-center text-gray-800 dark:text-gray-800-dark border-blue-400 dark:border-blue-400-dark bg-gray-0 dark:bg-gray-0-dark"
         >
           <span className="leading-none">ⓘ</span>

--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/prize_unfinalized_tooltip.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/prize_unfinalized_tooltip.tsx
@@ -6,14 +6,14 @@ import Tooltip from "@/components/ui/tooltip";
 const UnfinalizedPrizeTooltip: FC = () => {
   const t = useTranslations();
   return (
-    <div className="justify-left flex flex-1 items-center">
+    <div className="inline-flex items-center justify-end">
       <span className="mr-1">{t("prize")}</span>
-      <div className="relative text-blue-700 dark:text-blue-700-dark">
+      <div className="relative w-4 text-blue-700 dark:text-blue-700-dark">
         <Tooltip
           showDelayMs={200}
           placement={"right"}
           tooltipContent={t("unfinalizedPrizeTooltip")}
-          className="absolute right-[-18px] top-[0.5px] inline-flex h-full items-center justify-center font-sans"
+          className="absolute left-0 top-1/2 inline-flex -translate-y-1/2 items-center justify-center font-sans text-base leading-none"
           tooltipClassName="font-sans text-center text-gray-800 dark:text-gray-800-dark border-blue-400 dark:border-blue-400-dark bg-gray-0 dark:bg-gray-0-dark"
         >
           <span className="leading-none">ⓘ</span>


### PR DESCRIPTION
Closes #3821

This PR fixes the broken spacing around the "M" rank icon and info tooltips on tournament leaderboards.

Before:

<img width="682" height="473" alt="image" src="https://github.com/user-attachments/assets/295f019c-7455-43b8-864a-9efa010bf15d" />

After:

<img width="706" height="450" alt="image" src="https://github.com/user-attachments/assets/7e0605ba-19c0-49e2-879b-2d58abf3f584" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined tooltip positioning and alignment on leaderboard components for improved visual consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->