### PR TITLE
Recursively expand nested comment replies

### DIFF
--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -97,6 +97,16 @@ const CommentChildrenTree: FC<CommentChildrenTreeProps> = ({
   const [childrenExpanded, setChildrenExpanded] = useState(
     (expandedChildren && treeDepth < 5) || forceExpandedChildren
   );
+  const [forceExpandSubtree, setForceExpandSubtree] = useState(
+    forceExpandedChildren
+  );
+
+  useEffect(() => {
+    if (forceExpandedChildren) {
+      setChildrenExpanded(true);
+      setForceExpandSubtree(true);
+    }
+  }, [forceExpandedChildren]);
 
   function getTreeSize(commentChildren: CommentType[]): number {
     let totalChildren = 0;
@@ -128,7 +138,9 @@ const CommentChildrenTree: FC<CommentChildrenTreeProps> = ({
             }
           )}
           onClick={() => {
-            setChildrenExpanded(!childrenExpanded);
+            const nextExpanded = !childrenExpanded;
+            setChildrenExpanded(nextExpanded);
+            setForceExpandSubtree(nextExpanded);
           }}
         >
           <FontAwesomeIcon
@@ -157,7 +169,9 @@ const CommentChildrenTree: FC<CommentChildrenTreeProps> = ({
           <div
             className="absolute inset-y-0 -left-2 top-2 hidden w-4 cursor-pointer after:absolute after:inset-y-0 after:left-2 after:block after:w-px after:border-l after:border-blue-400 after:content-[''] after:hover:border-blue-600 after:dark:border-blue-600/80 after:hover:dark:border-blue-400/80 md:block"
             onClick={() => {
-              setChildrenExpanded(!childrenExpanded);
+              const nextExpanded = !childrenExpanded;
+              setChildrenExpanded(nextExpanded);
+              setForceExpandSubtree(nextExpanded);
             }}
           />
         )}{" "}
@@ -193,7 +207,9 @@ const CommentChildrenTree: FC<CommentChildrenTreeProps> = ({
                   postData={postData}
                   lastViewedAt={lastViewedAt}
                   shouldSuggestKeyFactors={shouldSuggestKeyFactors}
-                  forceExpandedChildren={forceExpandedChildren}
+                  forceExpandedChildren={
+                    forceExpandedChildren || forceExpandSubtree
+                  }
                 />
               </div>
             );


### PR DESCRIPTION
Closes #3775

This PR fixes the "show X replies" button on comment threads to expand the full nested conversation in a single click. Previously, each click only revealed one level of replies, forcing users to click repeatedly through deeply nested threads. The fix propagates the expanded state recursively to all descendant comment nodes, so the entire reply chain unfurls at once. Collapsing also works recursively.

https://github.com/user-attachments/assets/86ece7a7-ee9a-43d5-a27d-b1aae0a23db2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Comment-thread expansion now reliably preserves forced expansion across nested replies so expanded subtrees no longer unexpectedly collapse.
  * Expand/collapse actions stay in sync with forced expansion, ensuring user clicks correctly toggle threads and maintain consistent visibility throughout conversation threads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->