### PR TITLE
Keep continuous timeline y-axis auto-zoom across time zoom levels

### DIFF
--- a/front_end/src/components/charts/group_chart.tsx
+++ b/front_end/src/components/charts/group_chart.tsx
@@ -970,10 +970,45 @@ function buildChartData({
     zoom,
     minTimestamp: xDomain[0],
     isChartEmpty: !domainTimestamps.length,
-    minValues: areas.map((a) => ({ timestamp: a.x, y: a.y0 })),
-    maxValues: areas.map((a) => ({ timestamp: a.x, y: a.y })),
+    minValues: [
+      ...areas.map((a) => ({ timestamp: a.x, y: a.y0 })),
+      ...graphs
+        .filter((g) => g.active)
+        .flatMap((g) =>
+          (g.scatter ?? []).map((point) => ({
+            timestamp: point.x,
+            y: point.y1 ?? point.y,
+          }))
+        ),
+      ...graphs
+        .filter((g) => g.active && !isNil(g.resolutionPoint))
+        .map((g) => ({
+          timestamp: g.resolutionPoint?.x ?? latestTimestamp,
+          y: g.resolutionPoint?.y,
+        })),
+    ],
+    maxValues: [
+      ...areas.map((a) => ({ timestamp: a.x, y: a.y })),
+      ...graphs
+        .filter((g) => g.active)
+        .flatMap((g) =>
+          (g.scatter ?? []).map((point) => ({
+            timestamp: point.x,
+            y: point.y2 ?? point.y,
+          }))
+        ),
+      ...graphs
+        .filter((g) => g.active && !isNil(g.resolutionPoint))
+        .map((g) => ({
+          timestamp: g.resolutionPoint?.x ?? latestTimestamp,
+          y: g.resolutionPoint?.y,
+        })),
+    ],
     includeClosestBoundOnZoom: questionType === QuestionType.Binary,
     forceAutoZoom,
+    useFullYDomain:
+      questionType === QuestionType.Numeric ||
+      questionType === QuestionType.Date,
   });
 
   const yScale = generateScale({

--- a/front_end/src/components/charts/helpers.ts
+++ b/front_end/src/components/charts/helpers.ts
@@ -4,6 +4,7 @@ import {
   Area,
   BaseChartData,
   Line,
+  LinePoint,
   Scale,
   ScaleDirection,
   TimelineChartZoomOption,
@@ -47,6 +48,7 @@ export function buildNumericChartData({
   forceYTickCount,
   inboundOutcomeCount,
   alwaysShowYTicks,
+  resolutionPoint,
 }: {
   questionType: QuestionType;
   actualCloseTime?: number | null;
@@ -64,6 +66,7 @@ export function buildNumericChartData({
   forceYTickCount?: number;
   inboundOutcomeCount?: number | null;
   alwaysShowYTicks?: boolean;
+  resolutionPoint?: LinePoint | null;
 }): ChartData {
   const line: Line = [];
   const area: Area = [];
@@ -221,9 +224,24 @@ export function buildNumericChartData({
     zoom,
     minTimestamp: xDomain[0],
     isChartEmpty: !domainTimestamps.length,
-    minValues: area.map((d) => ({ timestamp: d.x, y: d.y0 })),
-    maxValues: area.map((d) => ({ timestamp: d.x, y: d.y })),
+    minValues: [
+      ...area.map((d) => ({ timestamp: d.x, y: d.y0 })),
+      ...points.map((d) => ({ timestamp: d.x, y: d.y1 ?? d.y })),
+      ...(resolutionPoint
+        ? [{ timestamp: resolutionPoint.x, y: resolutionPoint.y }]
+        : []),
+    ],
+    maxValues: [
+      ...area.map((d) => ({ timestamp: d.x, y: d.y })),
+      ...points.map((d) => ({ timestamp: d.x, y: d.y2 ?? d.y })),
+      ...(resolutionPoint
+        ? [{ timestamp: resolutionPoint.x, y: resolutionPoint.y }]
+        : []),
+    ],
     includeClosestBoundOnZoom: questionType === QuestionType.Binary,
+    useFullYDomain:
+      questionType === QuestionType.Numeric ||
+      questionType === QuestionType.Date,
   });
   const yScale: Scale = generateScale({
     displayType: questionType,

--- a/front_end/src/components/charts/numeric_timeline.tsx
+++ b/front_end/src/components/charts/numeric_timeline.tsx
@@ -170,6 +170,7 @@ const NumericTimeline: FC<Props> = ({
         forceYTickCount: forFeedPage ? 3 : 5,
         alwaysShowYTicks: true,
         inboundOutcomeCount,
+        resolutionPoint,
       }),
     [
       questionType,
@@ -184,6 +185,7 @@ const NumericTimeline: FC<Props> = ({
       openTime,
       unit,
       inboundOutcomeCount,
+      resolutionPoint,
       forFeedPage,
     ]
   );

--- a/front_end/src/utils/charts/__tests__/axis.test.ts
+++ b/front_end/src/utils/charts/__tests__/axis.test.ts
@@ -310,4 +310,40 @@ describe("generateTimeSeriesYDomain", () => {
       true
     );
   });
+
+  it("should ignore zoom window when useFullYDomain is enabled", () => {
+    const params = {
+      zoom: TimelineChartZoomOption.OneDay,
+      isChartEmpty: false,
+      minValues: [
+        { timestamp: 100, y: 0.2 },
+        { timestamp: 200, y: 0.45 },
+      ],
+      maxValues: [
+        { timestamp: 100, y: 0.75 },
+        { timestamp: 200, y: 0.55 },
+      ],
+      minTimestamp: 150,
+      useFullYDomain: true,
+    };
+
+    const scale = generateTimeSeriesYDomain(params);
+
+    expect(scale.zoomedYDomain).toEqual([0.15, 0.8]);
+  });
+
+  it("should auto zoom for all when useFullYDomain is enabled", () => {
+    const params = {
+      zoom: TimelineChartZoomOption.All,
+      isChartEmpty: false,
+      minValues: [{ timestamp: 100, y: 0.3 }],
+      maxValues: [{ timestamp: 100, y: 0.6 }],
+      minTimestamp: 100,
+      useFullYDomain: true,
+    };
+
+    const scale = generateTimeSeriesYDomain(params);
+
+    expect(scale.zoomedYDomain).toEqual([0.25, 0.65]);
+  });
 });

--- a/front_end/src/utils/charts/axis.ts
+++ b/front_end/src/utils/charts/axis.ts
@@ -112,6 +112,7 @@ type GenerateYDomainParams = {
   zoomDomainPadding?: number;
   includeClosestBoundOnZoom?: boolean;
   forceAutoZoom?: boolean;
+  useFullYDomain?: boolean;
 };
 
 export function generateTimeSeriesYDomain({
@@ -123,24 +124,30 @@ export function generateTimeSeriesYDomain({
   zoomDomainPadding,
   includeClosestBoundOnZoom,
   forceAutoZoom,
+  useFullYDomain,
 }: GenerateYDomainParams): YDomain {
   const originalYDomain: Tuple<number> = [0, 1];
   const fallback = { originalYDomain, zoomedYDomain: originalYDomain };
 
   if (
-    (zoom === TimelineChartZoomOption.All && !forceAutoZoom) ||
+    (zoom === TimelineChartZoomOption.All &&
+      !forceAutoZoom &&
+      !useFullYDomain) ||
     isChartEmpty
   ) {
     return fallback;
   }
 
+  const shouldIncludeValue = (timestamp: number) =>
+    useFullYDomain || timestamp >= minTimestamp;
+
   const min = minValues
-    .filter((d) => d.timestamp >= minTimestamp)
+    .filter((d) => shouldIncludeValue(d.timestamp))
     .map((d) => d.y)
     .filter((value) => !isNil(value));
   const minValue = min.length ? Math.min(...min) : null;
   const max = maxValues
-    .filter((d) => d.timestamp >= minTimestamp)
+    .filter((d) => shouldIncludeValue(d.timestamp))
     .map((d) => d.y)
     .filter((value) => !isNil(value));
   const maxValue = max.length ? Math.max(...max) : null;


### PR DESCRIPTION
Closes #3759

This PR enables y-axis auto-zoom by default for numeric and date question timelines, regardless of the x-axis time zoom selection.
Previously, the y-axis only zoomed when a specific time window (1D, 1W, etc.) was selected, snapping back to the full range on "All" – making charts with wide ranges hard to read. Now numeric/date charts always auto-zoom the y-axis to fit the community prediction quartiles, user predictions, and resolution values.

Before:

https://github.com/user-attachments/assets/f1eea90e-d78a-4847-b71f-157d7618f9d0

After:

https://github.com/user-attachments/assets/77a44e97-6169-4a8a-8e80-df338e7a8572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Charts use a more complete vertical range by incorporating prediction points and resolution markers; Numeric and Date charts now render using the full Y domain for more accurate bounds.

* **Tests**
  * Added test coverage validating the full-domain vertical axis behavior across zoom scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->