### PR TITLE
Self-host tweet proxy to eliminate external API calls and enable caching

### DIFF
--- a/front_end/src/app/(api)/tweet/[id]/route.ts
+++ b/front_end/src/app/(api)/tweet/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchTweet } from "react-tweet/api";
+
+const CACHE_MAX_AGE = 86400; // 24 hours
+const CACHE_STALE_WHILE_REVALIDATE = 604800; // 7 days
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const cacheHeaders = {
+    "Cache-Control": `public, max-age=${CACHE_MAX_AGE}, stale-while-revalidate=${CACHE_STALE_WHILE_REVALIDATE}`,
+  };
+
+  try {
+    const result = await fetchTweet(id, {
+      next: { revalidate: CACHE_MAX_AGE },
+    } as RequestInit);
+
+    if (result.notFound || result.tombstone) {
+      return NextResponse.json({ data: null }, { status: 404 });
+    }
+
+    return NextResponse.json(
+      { data: result.data ?? null },
+      { headers: cacheHeaders }
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to fetch tweet";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/front_end/src/components/markdown_editor/embedded_twitter/index.tsx
+++ b/front_end/src/components/markdown_editor/embedded_twitter/index.tsx
@@ -9,7 +9,7 @@ const TweetEmbed: React.FC<{ id: string }> = ({ id }) => {
   return (
     <div className="tweet-embed" data-embed="tweet">
       <div className="tweet-embed-scroll">
-        <Tweet id={id} />
+        <Tweet id={id} apiUrl={`/tweet/${id}`} />
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #4240 

This PR fixes the N+1 external API calls to `react-tweet.vercel.app` by adding a self-hosted Next.js route that proxies tweet data with server-side caching (24h TTL). Previously every page visit re-fetched all tweets from scratch since the Vercel proxy sends max-age=0. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to retrieve individual tweet data with caching and error handling.
  * Updated embedded tweet component to fetch tweet data via the new API endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->