### PR TITLE
Forecast Timelines with hidden CP but shown user predictions are missing the x axis labels

### DIFF
--- a/front_end/src/components/charts/continuous_area_chart.tsx
+++ b/front_end/src/components/charts/continuous_area_chart.tsx
@@ -131,6 +131,11 @@ const ContinuousAreaChart: FC<Props> = ({
   const discrete = question.type === QuestionType.Discrete;
   const paddingTop = graphType === "cdf" || discrete ? TOP_PADDING : 0;
 
+  const hasUserData = useMemo(
+    () => data.some((d) => d.type === "user"),
+    [data]
+  );
+
   const charts = useMemo(() => {
     const parsedData = hideCP
       ? [...data].filter((el) => el.type === "user")
@@ -732,7 +737,11 @@ const ContinuousAreaChart: FC<Props> = ({
           )}
           <VictoryAxis
             tickValues={xScale.ticks}
-            tickFormat={hideLabels || hideCP ? () => "" : xScale.tickFormat}
+            tickFormat={
+              hideLabels || (hideCP && !hasUserData)
+                ? () => ""
+                : xScale.tickFormat
+            }
             style={{
               ticks: {
                 strokeWidth: 1,

--- a/front_end/src/components/charts/group_chart.tsx
+++ b/front_end/src/components/charts/group_chart.tsx
@@ -247,6 +247,10 @@ const GroupChart: FC<Props> = ({
     () => Object.values(choiceItems).some(({ highlighted }) => highlighted),
     [choiceItems]
   );
+  const hasUserForecasts = useMemo(
+    () => choiceItems.some(({ userTimestamps }) => userTimestamps.length > 0),
+    [choiceItems]
+  );
 
   const prevWidth = usePrevious(chartWidth);
   const isMarkerHovered = !isNil(activeTimelineMarkerId);
@@ -435,7 +439,9 @@ const GroupChart: FC<Props> = ({
               <VictoryAxis
                 tickValues={xScale.ticks}
                 tickFormat={
-                  hideCP || isCursorActive ? () => "" : xScale.tickFormat
+                  (hideCP && !hasUserForecasts) || isCursorActive
+                    ? () => ""
+                    : xScale.tickFormat
                 }
                 tickLabelComponent={
                   <XTickLabel

--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -148,6 +148,10 @@ const MultipleChoiceChart: FC<Props> = ({
   const [isCursorActive, setIsCursorActive] = useState(false);
 
   const [zoom, setZoom] = useState<TimelineChartZoomOption>(defaultZoom);
+  const hasUserForecasts = useMemo(
+    () => choiceItems.some(({ userTimestamps }) => userTimestamps.length > 0),
+    [choiceItems]
+  );
   const { xScale, yScale, graphs, xDomain, yDomain, userScatters } = useMemo(
     () =>
       buildChartData({
@@ -406,7 +410,7 @@ const MultipleChoiceChart: FC<Props> = ({
             <VictoryAxis
               tickValues={xScale.ticks}
               tickFormat={
-                hideCP ||
+                (hideCP && !hasUserForecasts) ||
                 isCursorActive ||
                 !!forecastAvailability?.isEmpty ||
                 !!forecastAvailability?.cpRevealsOn

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -650,7 +650,7 @@ const NumericChart: FC<Props> = ({
                   offsetY={isEmbedded ? BOTTOM_PADDING - 5 : BOTTOM_PADDING}
                   tickValues={xScale.ticks}
                   tickFormat={
-                    hideCP
+                    hideCP && points.length === 0
                       ? () => ""
                       : isCursorActive
                         ? () => ""


### PR DESCRIPTION
Closes #3692

This PR fixes forecast timelines were hiding the x-axis date labels whenever the Community Prediction was toggled off, even when the user's own predictions were still visible on the chart. This made it impossible to read the timeline dates while reviewing personal forecasts.

Before:

<img width="748" height="225" alt="image" src="https://github.com/user-attachments/assets/5fa82571-b346-4230-b647-0979e5dabc4a" />


After:

<img width="736" height="226" alt="image" src="https://github.com/user-attachments/assets/9a8d163b-0030-4502-bbf2-a844fc23f49c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved axis label visibility logic across chart components to conditionally display labels based on data availability, ensuring labels appear when user data is present while remaining hidden when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->