### PR TITLE
Continuous table label column sometimes too wide

### DIFF
--- a/front_end/src/components/forecast_maker/continuous_group_accordion/group_forecast_accordion.tsx
+++ b/front_end/src/components/forecast_maker/continuous_group_accordion/group_forecast_accordion.tsx
@@ -162,17 +162,17 @@ const GroupForecastAccordion: FC<Props> = ({
       </div>
       {!!activeOptions.length && (
         <div className="mb-0.5 mt-2 flex w-full gap-0.5 text-left text-xs font-bold text-blue-700 dark:text-blue-700-dark">
-          <div className="flex shrink grow items-center overflow-hidden bg-blue-600/15 py-1 dark:bg-blue-400/15">
+          <div className="flex max-w-[90px] shrink grow basis-0 items-center overflow-hidden bg-blue-600/15 py-1 dark:bg-blue-400/15 sm:max-w-[110px]">
             <span className="line-clamp-2 pl-4">{groupVariable}</span>
           </div>
-          <div className="flex max-w-[105px] shrink grow-[3] items-center gap-0.5 text-center sm:max-w-[422px]">
-            <div className="w-[105px] bg-blue-600/15 py-1 dark:bg-blue-400/15">
+          <div className="flex min-w-0 shrink grow items-center gap-0.5 text-center">
+            <div className="w-[105px] shrink-0 bg-blue-600/15 py-1 dark:bg-blue-400/15">
               {t("median")}
               {homogeneousUnit && !isUnitCompact(homogeneousUnit) && (
                 <div>({homogeneousUnit})</div>
               )}
             </div>
-            <div className="hidden h-full bg-blue-600/15 dark:bg-blue-400/15 sm:flex sm:w-[325px] sm:shrink-0 sm:grow-0 sm:py-1">
+            <div className="hidden h-full bg-blue-600/15 dark:bg-blue-400/15 sm:flex sm:min-w-0 sm:flex-1 sm:py-1">
               <div className="m-auto">{t("pdf")}</div>
             </div>
           </div>

--- a/front_end/src/components/forecast_maker/continuous_group_accordion/group_forecast_accordion_item.tsx
+++ b/front_end/src/components/forecast_maker/continuous_group_accordion/group_forecast_accordion_item.tsx
@@ -179,7 +179,7 @@ const AccordionItem: FC<PropsWithChildren<AccordionItemProps>> = memo(
                 isResolved={isResolvedOption}
                 isDirty={!isResolvedOption && isDirty}
               >
-                <div className="flex h-full shrink grow items-center overflow-hidden">
+                <div className="flex h-full max-w-[90px] shrink grow basis-0 items-center overflow-hidden sm:max-w-[110px]">
                   <TruncatedTextTooltip
                     text={title}
                     showTooltip={!open}
@@ -188,7 +188,7 @@ const AccordionItem: FC<PropsWithChildren<AccordionItemProps>> = memo(
                   />
                 </div>
                 {(!open || !isLargeScreen) && (
-                  <div className="flex h-full min-w-[105px] max-w-[105px] shrink-0 grow-[3] items-center justify-center gap-0.5 sm:min-w-[420px] sm:max-w-[420px]">
+                  <div className="flex h-full min-w-[105px] max-w-[105px] shrink-0 grow-[3] items-center justify-center gap-0.5 sm:min-w-0 sm:max-w-none sm:flex-1">
                     <AccordionResolutionCell
                       formatedResolution={formatedResolution}
                       resolution={resolution}
@@ -203,7 +203,7 @@ const AccordionItem: FC<PropsWithChildren<AccordionItemProps>> = memo(
                         wasWithdrawn && !isDirty ? withdrawnLabel : undefined
                       }
                     />
-                    <div className="hidden h-full shrink-0 grow-0 items-center sm:block sm:w-[325px]">
+                    <div className="hidden h-full min-w-0 shrink grow items-center sm:block">
                       <ContinuousAreaChart
                         data={continuousAreaChartData}
                         graphType="pmf"
@@ -219,7 +219,7 @@ const AccordionItem: FC<PropsWithChildren<AccordionItemProps>> = memo(
                     </div>
                   </div>
                 )}
-                <div className="flex h-full w-[43px] shrink-0 grow-0 items-center justify-center">
+                <div className="ml-auto flex h-full w-[43px] shrink-0 grow-0 items-center justify-center">
                   <div className="flex size-[26px] items-center justify-center rounded-full border border-blue-400 bg-blue-100 dark:border-blue-400-dark dark:bg-blue-100-dark">
                     <FontAwesomeIcon
                       icon={faChevronDown}


### PR DESCRIPTION
Closes #3553

Before:

<img width="1137" height="567" alt="image" src="https://github.com/user-attachments/assets/5bf482bd-177c-43f8-9b01-60b9755a1748" />

After:

<img width="1146" height="485" alt="image" src="https://github.com/user-attachments/assets/9d698e65-309d-47c5-9ee7-ceead1e1e6cd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved responsive layout and sizing for forecast components across different screen sizes, enhancing visual consistency and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->