### PR TITLE
feat: remove Quiz flow entrance from Services page

### DIFF
--- a/front_end/src/app/(main)/services/components/templates/services_page_template.tsx
+++ b/front_end/src/app/(main)/services/components/templates/services_page_template.tsx
@@ -16,7 +16,6 @@ import Button from "../button";
 import CaseStudyCard from "../case_studies/case_study_card";
 import { TCaseStudyCard } from "../case_studies/types";
 import ContactSection from "../contact_section/contact_section";
-import DiscoverServicesBlock from "../discover_services/discover_services_block";
 import HeadingBlock from "../heading_block";
 import PartnersCarousel from "../partners_carousel";
 import SectionHeading from "../section_heading";
@@ -120,10 +119,6 @@ const ServicesPageTemplate: React.FC<Props> = async ({
           purpose={purpose}
         />
         <PartnersCarousel className="my-10 sm:my-12 lg:my-32" />
-
-        {!!process.env.SERVICES_QUIZ_GOOGLE_SHEETS_SPREADSHEET_ID && (
-          <DiscoverServicesBlock />
-        )}
 
         <SectionHeading
           title={solutions.title}


### PR DESCRIPTION
Closes #4604

Removes the "Discover Services" quiz flow entrance section from the `/services` page while keeping the component files intact for potential future use.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the Discover Services section from the services page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->