### PR TITLE
Build the title row (and bump the title size)

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
@@ -7,6 +7,7 @@ import QuestionTitle from "@/app/(main)/questions/[id]/components/question_view/
 import ConditionalTile from "@/components/conditional_tile";
 import { PostWithForecasts } from "@/types/post";
 import { QuestionWithForecasts } from "@/types/question";
+import cn from "@/utils/core/cn";
 import {
   isConditionalPost,
   isContinuousQuestion,
@@ -18,16 +19,26 @@ type Variant = "forecaster" | "consumer";
 type Props = {
   post: PostWithForecasts;
   variant: Variant;
+  className?: string;
 };
 
-const TitleRow: FC<Props> = ({ post, variant }) => {
+const TitleRow: FC<Props> = ({ post, variant, className }) => {
   if (isConditionalPost(post)) {
-    return <ConditionalTile post={post} withNavigation withCPRevealBtn />;
+    return (
+      <div className={className}>
+        <ConditionalTile post={post} withNavigation withCPRevealBtn />
+      </div>
+    );
   }
 
   if (variant === "forecaster" && isQuestionPost(post)) {
     return (
-      <div className="flex w-full items-stretch justify-between gap-2 xs:gap-4 sm:gap-8">
+      <div
+        className={cn(
+          "flex w-full items-stretch justify-between gap-2 xs:gap-4 sm:gap-8",
+          className
+        )}
+      >
         <div className="flex flex-1 flex-col">
           <div className="lg:order-0 order-1 flex items-center">
             <QuestionTitle className="text-2xl font-bold tracking-tight sm:text-3xl lg:text-4xl">
@@ -55,7 +66,12 @@ const TitleRow: FC<Props> = ({ post, variant }) => {
   }
 
   return (
-    <QuestionTitle className="text-2xl font-bold tracking-tight sm:text-3xl lg:text-4xl">
+    <QuestionTitle
+      className={cn(
+        "text-2xl font-bold tracking-tight sm:text-3xl lg:text-4xl",
+        className
+      )}
+    >
       {post.title}
     </QuestionTitle>
   );

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { FC } from "react";
+
+import QuestionHeaderCPStatus from "@/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status";
+import QuestionTitle from "@/app/(main)/questions/[id]/components/question_view/shared/question_title";
+import ConditionalTile from "@/components/conditional_tile";
+import { PostWithForecasts } from "@/types/post";
+import { QuestionWithForecasts } from "@/types/question";
+import {
+  isConditionalPost,
+  isContinuousQuestion,
+  isQuestionPost,
+} from "@/utils/questions/helpers";
+
+type Variant = "forecaster" | "consumer";
+
+type Props = {
+  post: PostWithForecasts;
+  variant: Variant;
+};
+
+const TitleRow: FC<Props> = ({ post, variant }) => {
+  if (isConditionalPost(post)) {
+    return <ConditionalTile post={post} withNavigation withCPRevealBtn />;
+  }
+
+  if (variant === "forecaster" && isQuestionPost(post)) {
+    return (
+      <div className="flex w-full items-stretch justify-between gap-2 xs:gap-4 sm:gap-8">
+        <div className="flex flex-1 flex-col">
+          <div className="lg:order-0 order-1 flex items-center">
+            <QuestionTitle className="text-2xl font-bold tracking-tight sm:text-3xl lg:text-4xl">
+              {post.title}
+            </QuestionTitle>
+            <div className="md:hidden">
+              <QuestionHeaderCPStatus
+                question={post.question as QuestionWithForecasts}
+                size="md"
+                hideLabel={isContinuousQuestion(post.question)}
+              />
+            </div>
+          </div>
+        </div>
+        {!isContinuousQuestion(post.question) && (
+          <div className="hidden md:block">
+            <QuestionHeaderCPStatus
+              question={post.question as QuestionWithForecasts}
+              size="lg"
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <QuestionTitle className="text-2xl font-bold tracking-tight sm:text-3xl lg:text-4xl">
+      {post.title}
+    </QuestionTitle>
+  );
+};
+
+export default TitleRow;

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/index.tsx
@@ -6,6 +6,7 @@ import useCoherenceLinksContext from "@/app/(main)/components/coherence_links_pr
 import KeyFactorsQuestionConsumerSection from "@/app/(main)/questions/[id]/components/key_factors/key_factors_question_consumer_section";
 import { PostStatusBox } from "@/app/(main)/questions/[id]/components/post_status_box";
 import MetaRow from "@/app/(main)/questions/[id]/components/question_page_shell/meta_row";
+import TitleRow from "@/app/(main)/questions/[id]/components/question_page_shell/title_row";
 import ForecastersCounter from "@/app/(main)/questions/components/forecaster_counter";
 import CommentStatus from "@/components/post_card/basic_post_card/comment_status";
 import {
@@ -26,7 +27,6 @@ import {
 import QuestionActionButton from "./action_buttons";
 import ConsumerQuestionPrediction from "./prediction";
 import { isDisplayableQuestionLink } from "../../key_factors/utils";
-import QuestionTitle from "../shared/question_title";
 
 type Props = {
   postData: PostWithForecasts;
@@ -80,7 +80,7 @@ const ConsumerQuestionView: React.FC<Props> = ({ postData }) => {
       </div>
 
       <MetaRow post={postData} className="-mx-4 mb-2 hidden md:flex lg:-mx-8" />
-      <QuestionTitle className="text-center">{postData.title}</QuestionTitle>
+      <TitleRow post={postData} variant="consumer" />
 
       <div className="mt-6 sm:mt-8">
         {showClosedMessageMultipleChoice && (

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/index.tsx
@@ -29,7 +29,11 @@ const QuestionHeader: FC<{ post: PostWithForecasts }> = ({ post }) => {
       </div>
       <div className="flex flex-1 flex-col gap-4">
         <MetaRow post={post} className="-mx-4 mb-2 hidden md:flex lg:-mx-8" />
-        <TitleRow post={post} variant="forecaster" />
+        <TitleRow
+          post={post}
+          variant="forecaster"
+          className="lg:order-0 order-1"
+        />
       </div>
     </div>
   );

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/index.tsx
@@ -5,19 +5,10 @@ import { FC, useEffect } from "react";
 
 import { PostStatusBox } from "@/app/(main)/questions/[id]/components/post_status_box";
 import MetaRow from "@/app/(main)/questions/[id]/components/question_page_shell/meta_row";
+import TitleRow from "@/app/(main)/questions/[id]/components/question_page_shell/title_row";
 import QuestionHeaderInfo from "@/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_info";
-import ConditionalTile from "@/components/conditional_tile";
 import { useContentTranslatedBannerContext } from "@/contexts/translations_banner_context";
 import { PostWithForecasts } from "@/types/post";
-import { QuestionWithForecasts } from "@/types/question";
-import {
-  isContinuousQuestion,
-  isConditionalPost,
-  isQuestionPost,
-} from "@/utils/questions/helpers";
-
-import QuestionHeaderCPStatus from "./question_header_cp_status";
-import QuestionTitle from "../../shared/question_title";
 
 const QuestionHeader: FC<{ post: PostWithForecasts }> = ({ post }) => {
   const { setBannerIsVisible } = useContentTranslatedBannerContext();
@@ -38,33 +29,7 @@ const QuestionHeader: FC<{ post: PostWithForecasts }> = ({ post }) => {
       </div>
       <div className="flex flex-1 flex-col gap-4">
         <MetaRow post={post} className="-mx-4 mb-2 hidden md:flex lg:-mx-8" />
-        {isConditionalPost(post) ? (
-          <ConditionalTile post={post} withNavigation withCPRevealBtn />
-        ) : (
-          <div className="lg:order-0 order-1 flex items-start gap-4">
-            <QuestionTitle>{post.title}</QuestionTitle>
-            {isQuestionPost(post) && (
-              <>
-                <div className="md:hidden">
-                  <QuestionHeaderCPStatus
-                    question={post.question as QuestionWithForecasts}
-                    size="md"
-                    hideLabel={isContinuousQuestion(post.question)}
-                  />
-                </div>
-                {!isContinuousQuestion(post.question) && (
-                  <div className="ml-auto hidden md:block">
-                    <QuestionHeaderCPStatus
-                      question={post.question as QuestionWithForecasts}
-                      size="lg"
-                    />
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-        )}
-        <QuestionHeaderInfo post={post} className="mb-8 md:hidden" />
+        <TitleRow post={post} variant="forecaster" />
       </div>
     </div>
   );


### PR DESCRIPTION
Related to https://github.com/Metaculus/metaculus/issues/4638

This PR extracts and builds the new Title Row layout for the updated question page shell infrastructure. Implemented features & fixes:

- Added the new `TitleRow` component handling title structures for both forecaster and consumer variants
- Bumped the title font size to match the new design
- Implemented a side-by-side layout for the title and continuous prediction (CP) status widget explicitly for the Forecaster desktop view
- Cleaned the Consumer view layout to display a title-only row without an inline CP widget
- Preserved existing wrapper capabilities to ensure conditional posts flawlessly render using their specific conditional tile design

### Before

- Forecaster view

<img width="740" height="135" alt="image" src="https://github.com/user-attachments/assets/9a6a1193-9c1f-4448-8204-db3765ed1fa3" />

- Consumer view 

<img width="736" height="127" alt="image" src="https://github.com/user-attachments/assets/c04e07c6-f8ed-4661-b147-8c21f78a00b2" />

### After

- Forecaster view

<img width="745" height="174" alt="image" src="https://github.com/user-attachments/assets/afc9c891-147b-47af-9b2d-1535ccdae50e" />

- Consumer view 

<img width="756" height="154" alt="image" src="https://github.com/user-attachments/assets/62da39b4-e495-47d5-b6df-36dcd83cbe69" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated question title and header rendering logic into a reusable component for improved code maintainability and consistency across different question views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->