### PR TITLE
Add desktop tab bar with shared active-tab state

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -1819,6 +1819,7 @@
   "loadMore": "Načíst více",
   "noPrivateNotes": "Žádné soukromé poznámky",
   "privateNotes": "Soukromé poznámky",
+  "questionLinks": "Odkazy otázky",
   "justNow": "právě teď",
   "cmmButtonShort": "Mysl",
   "FABRegisterBot": "Zaregistrujte se, abyste přihlásili svého robota do turnaje",

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1943,6 +1943,7 @@
   "loadMore": "Load More",
   "noPrivateNotes": "No private notes yet",
   "privateNotes": "Private Notes",
+  "questionLinks": "Question Links",
   "justNow": "just now",
   "cmmButtonShort": "Mind",
   "myForecastingBots": "My Forecasting Bots",

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -1818,6 +1818,7 @@
   "loadMore": "Cargar más",
   "noPrivateNotes": "Aún no hay notas privadas",
   "privateNotes": "Notas privadas",
+  "questionLinks": "Enlaces de preguntas",
   "justNow": "justo ahora",
   "cmmButtonShort": "Mente",
   "FABRegisterBot": "Regístrate para inscribir tu bot en el torneo",

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -1816,6 +1816,7 @@
   "loadMore": "Carregar Mais",
   "noPrivateNotes": "Ainda não há notas privadas",
   "privateNotes": "Notas Privadas",
+  "questionLinks": "Links da pergunta",
   "justNow": "agora mesmo",
   "cmmButtonShort": "Mente",
   "FABRegisterBot": "Inscreva-se para registrar seu bot no torneio",

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -1815,6 +1815,7 @@
   "loadMore": "載入更多",
   "noPrivateNotes": "尚無私人筆記",
   "privateNotes": "私人筆記",
+  "questionLinks": "問題連結",
   "justNow": "剛剛",
   "cmmButtonShort": "心智",
   "FABRegisterBot": "註冊以參加賽事",

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -1820,6 +1820,7 @@
   "loadMore": "加載更多",
   "noPrivateNotes": "尚無私人筆記",
   "privateNotes": "私人筆記",
+  "questionLinks": "问题链接",
   "justNow": "刚刚",
   "cmmButtonShort": "心情",
   "FABRegisterBot": "注册您的机器人以参加锦标赛",

--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/item_view/key_factor_header.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/item_view/key_factor_header.tsx
@@ -18,7 +18,7 @@ const KeyFactorHeader: FC<Props> = ({ label, username, linkAnchor }) => {
   const questionLayout = useQuestionLayoutSafe();
 
   const handleActivate = () => {
-    questionLayout?.setMobileActiveTab("comments");
+    questionLayout?.setActiveTab("comments");
 
     const target = document.getElementById(linkAnchor.replace("#", ""));
     if (target) {

--- a/front_end/src/app/(main)/questions/[id]/components/question_layout/consumer_question_layout/consumer_tabs.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_layout/consumer_question_layout/consumer_tabs.tsx
@@ -7,14 +7,14 @@ import { Tabs } from "@/components/ui/tabs/index";
 import { useQuestionLayout } from "../question_layout_context";
 
 const ConsumerTabs: React.FC<PropsWithChildren> = ({ children }) => {
-  const { mobileActiveTab, setMobileActiveTab } = useQuestionLayout();
+  const { activeTab, setActiveTab } = useQuestionLayout();
 
   return (
     <Tabs
       defaultValue="comments"
       className="-mb-5"
-      value={mobileActiveTab}
-      onChange={setMobileActiveTab}
+      value={activeTab}
+      onChange={setActiveTab}
     >
       {children}
     </Tabs>

--- a/front_end/src/app/(main)/questions/[id]/components/question_layout/question_layout_context.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_layout/question_layout_context.tsx
@@ -35,31 +35,43 @@ type QuestionLayoutContextValue = {
   requestReplyToComment: (commentId: number) => void;
   clearReplyToComment: () => void;
 
-  // Mobile tab state
-  mobileActiveTab?: string;
-  setMobileActiveTab: (tab: string) => void;
+  // Active tab state (shared between mobile + desktop tab bars)
+  activeTab?: string;
+  setActiveTab: (tab: string) => void;
 };
+
+const TAB_HASH_VALUES = new Set([
+  "comments",
+  "timeline",
+  "scores",
+  "key-factors",
+  "info",
+  "question-links",
+  "private-notes",
+]);
 
 const QuestionLayoutContext = createContext({} as QuestionLayoutContextValue);
 
 export const QuestionLayoutProvider = ({ children }: PropsWithChildren) => {
   const hash = useHash();
   const [keyFactorsExpanded, setKeyFactorsExpanded] = useState<boolean>();
-  const [mobileActiveTab, setMobileActiveTab] = useState<string>();
+  const [activeTab, setActiveTab] = useState<string>();
   const [keyFactorOverlay, setKeyFactorOverlay] =
     useState<KeyFactorOverlayState>(null);
 
-  // Expand key factors section if URL hash points to it
   useEffect(() => {
+    if (!hash) return;
     if (hash === "key-factors") {
       setKeyFactorsExpanded(true);
-      setMobileActiveTab("key-factors");
+    }
+    if (TAB_HASH_VALUES.has(hash)) {
+      setActiveTab(hash);
     }
   }, [hash]);
 
   const requestKeyFactorsExpand = useCallback(() => {
     setKeyFactorsExpanded(true);
-    setMobileActiveTab("key-factors");
+    setActiveTab("key-factors");
   }, []);
 
   const openKeyFactorOverlay = useCallback((kf: KeyFactor) => {
@@ -96,8 +108,8 @@ export const QuestionLayoutProvider = ({ children }: PropsWithChildren) => {
       replyToCommentId,
       requestReplyToComment,
       clearReplyToComment,
-      mobileActiveTab,
-      setMobileActiveTab,
+      activeTab,
+      setActiveTab,
     }),
     [
       keyFactorsExpanded,
@@ -109,7 +121,7 @@ export const QuestionLayoutProvider = ({ children }: PropsWithChildren) => {
       replyToCommentId,
       requestReplyToComment,
       clearReplyToComment,
-      mobileActiveTab,
+      activeTab,
     ]
   );
 

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tab_bar.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tab_bar.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { FC } from "react";
+
+import { Tabs, TabsList, TabsTab } from "@/components/ui/tabs";
+import { PostWithForecasts } from "@/types/post";
+import cn from "@/utils/core/cn";
+
+import { useQuestionLayout } from "../question_layout/question_layout_context";
+
+type TabKey =
+  | "comments"
+  | "key-factors"
+  | "info"
+  | "question-links"
+  | "private-notes";
+
+type TabDef = {
+  key: TabKey;
+  label: string;
+  count?: number;
+};
+
+type Props = {
+  post: PostWithForecasts;
+  variant: "consumer" | "forecaster";
+  className?: string;
+};
+
+const tabClassName = (isActive: boolean) =>
+  cn(
+    "border-[1.25px] border-solid rounded-full font-medium transition-colors",
+    "text-base leading-6 px-[15px] py-[5px] sm:text-base sm:leading-6 sm:px-[15px] sm:py-[5px]",
+    isActive
+      ? "bg-blue-500/60 border-transparent text-blue-900 dark:bg-blue-500-dark/60 dark:text-blue-900-dark"
+      : "bg-gray-0 border-blue-500/20 text-blue-900 dark:bg-gray-0-dark dark:border-blue-500-dark/20 dark:text-blue-900-dark"
+  );
+
+const QuestionPageShellTabBar: FC<Props> = ({ post, variant, className }) => {
+  const t = useTranslations();
+  const { activeTab, setActiveTab } = useQuestionLayout();
+
+  const commentCount = post.comment_count ?? 0;
+  const keyFactorsCount = post.key_factors?.length ?? 0;
+
+  const tabs: TabDef[] =
+    variant === "forecaster"
+      ? [
+          { key: "comments", label: t("comments"), count: commentCount },
+          {
+            key: "key-factors",
+            label: t("keyFactors"),
+            count: keyFactorsCount,
+          },
+          { key: "info", label: t("info") },
+          { key: "question-links", label: t("questionLinks") },
+          { key: "private-notes", label: t("privateNotes") },
+        ]
+      : [
+          { key: "comments", label: t("comments"), count: commentCount },
+          {
+            key: "key-factors",
+            label: t("keyFactors"),
+            count: keyFactorsCount,
+          },
+          { key: "info", label: t("info") },
+        ];
+
+  const defaultValue: TabKey = "comments";
+  const active =
+    activeTab && tabs.some((tab) => tab.key === activeTab)
+      ? activeTab
+      : defaultValue;
+
+  return (
+    <Tabs
+      defaultValue={defaultValue}
+      value={active}
+      onChange={setActiveTab}
+      className={cn("bg-transparent dark:bg-transparent", className)}
+    >
+      <TabsList contained className="gap-[10px]">
+        {tabs.map((tab) => (
+          <TabsTab
+            key={tab.key}
+            value={tab.key}
+            scrollOnSelect={false}
+            dynamicClassName={tabClassName}
+          >
+            {tab.count !== undefined
+              ? `${tab.label} (${tab.count})`
+              : tab.label}
+          </TabsTab>
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+};
+
+export default QuestionPageShellTabBar;


### PR DESCRIPTION
Related to #4638

Builds the QuestionPageShellTabBar component for the question page desktop layout and refactors the active-tab state in QuestionLayoutContext to be shared across both mobile and desktop tab surfaces.

<img width="1954" height="296" alt="image" src="https://github.com/user-attachments/assets/5b9edbf1-d00a-4114-b325-80eb7473ae36" />
