### PR TITLE
Filter the PostDropdownMenu item set for desktop & polish mobile meta/action rows

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
@@ -1,14 +1,18 @@
 "use client";
 
+import { faEllipsis } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import { useTranslations } from "next-intl";
 import { FC } from "react";
 
 import ForecastersCounter from "@/app/(main)/questions/components/forecaster_counter";
 import TrophyIcon from "@/components/icons/trophy";
+import { PostDropdownMenu } from "@/components/post_actions";
 import CommentStatus from "@/components/post_card/basic_post_card/comment_status";
 import PostVoter from "@/components/post_card/basic_post_card/post_voter";
 import PostStatus from "@/components/post_status";
+import Button from "@/components/ui/button";
 import Chip from "@/components/ui/chip";
 import useContainerSize from "@/hooks/use_container_size";
 import { PostWithForecasts } from "@/types/post";
@@ -20,10 +24,11 @@ import { extractPostResolution } from "@/utils/questions/resolution";
 
 type Props = {
   post: PostWithForecasts;
+  variant: "forecaster" | "consumer";
   className?: string;
 };
 
-const MetaRow: FC<Props> = ({ post, className }) => {
+const MetaRow: FC<Props> = ({ post, className, variant }) => {
   const t = useTranslations();
   const resolutionData = extractPostResolution(post);
   const { ref, width } = useContainerSize<HTMLDivElement>();
@@ -70,70 +75,113 @@ const MetaRow: FC<Props> = ({ post, className }) => {
       : "orange";
 
   return (
-    <div
-      ref={ref}
-      className={cn(
-        "flex items-center justify-between gap-6 px-4 lg:px-8",
-        className
-      )}
-    >
-      <div className="flex shrink-0 items-center gap-1.5">
-        <PostVoter post={post} />
-        <CommentStatus
-          totalCount={post.comment_count ?? 0}
-          unreadCount={post.unread_comment_count ?? 0}
-          url={getPostLink(post)}
-          className="bg-gray-200 dark:bg-gray-200-dark"
-          compact={false}
-        />
-        <PostStatus post={post} resolution={resolutionData} compact={false} />
-        <ForecastersCounter
-          forecasters={post.nr_forecasters}
-          compact={compactCounters}
-        />
+    <div className={cn("px-4 lg:px-8", className)}>
+      {/* Mobile row */}
+      <div
+        className={cn(
+          "relative flex items-center gap-1.5 md:hidden",
+          variant === "consumer" ? "justify-center" : "justify-start"
+        )}
+      >
+        <div className="flex items-center gap-1.5">
+          {variant === "forecaster" && <PostVoter post={post} />}
+          <CommentStatus
+            totalCount={post.comment_count ?? 0}
+            unreadCount={post.unread_comment_count ?? 0}
+            url={getPostLink(post)}
+            className="bg-gray-200 text-xs leading-4 dark:bg-gray-200-dark"
+            compact={true}
+          />
+          {variant === "forecaster" && (
+            <PostStatus
+              post={post}
+              resolution={resolutionData}
+              compact={true}
+            />
+          )}
+          <ForecastersCounter
+            forecasters={post.nr_forecasters}
+            compact={variant === "forecaster"}
+            boldCount
+            className="text-xs leading-4"
+          />
+        </div>
+        <div className="absolute right-0">
+          <PostDropdownMenu
+            post={post}
+            hideShare={variant === "consumer"}
+            button={
+              <Button className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-blue-400 bg-white p-0 text-blue-700 transition-colors hover:bg-gray-100 active:bg-gray-200 dark:border-blue-400-dark dark:bg-gray-0-dark dark:text-blue-700-dark dark:hover:bg-gray-100-dark dark:active:bg-gray-200-dark">
+                <FontAwesomeIcon icon={faEllipsis} className="text-base" />
+              </Button>
+            }
+          />
+        </div>
       </div>
 
-      <div className="flex min-w-0 items-center gap-2">
-        {visibleChips.map((element) => (
-          <Chip
-            color={chipColor(element)}
-            key={element.id}
-            href={getProjectLink(element)}
-            className="min-w-0 overflow-hidden text-sm font-medium leading-4 [&>*]:min-w-0"
-            onClick={() =>
-              sendAnalyticsEvent("questionTagClicked", {
-                event_category: element.name,
-              })
-            }
-          >
-            {getChipContent(element)}
-          </Chip>
-        ))}
+      {/* Desktop row */}
+      <div
+        ref={ref}
+        className="hidden items-center justify-between gap-6 md:flex"
+      >
+        <div className="flex shrink-0 items-center gap-1.5">
+          <PostVoter post={post} />
+          <CommentStatus
+            totalCount={post.comment_count ?? 0}
+            unreadCount={post.unread_comment_count ?? 0}
+            url={getPostLink(post)}
+            className="bg-gray-200 dark:bg-gray-200-dark"
+            compact={false}
+          />
+          <PostStatus post={post} resolution={resolutionData} compact={false} />
+          <ForecastersCounter
+            forecasters={post.nr_forecasters}
+            compact={compactCounters}
+          />
+        </div>
 
-        {hiddenChips.length > 0 && (
-          <Popover className="relative shrink-0">
-            <PopoverButton className="inline-flex cursor-pointer select-none items-center justify-center gap-1 rounded bg-gray-300 p-1.5 text-sm font-medium leading-4 text-gray-900 hover:bg-gray-400 dark:bg-gray-300-dark dark:text-gray-900-dark dark:hover:bg-gray-400-dark">
-              {t("nMore", { count: hiddenChips.length })}
-            </PopoverButton>
-            <PopoverPanel className="absolute right-0 top-full z-10 mt-1 flex max-w-[250px] flex-wrap gap-2 rounded border border-gray-300 bg-gray-0 p-3 shadow-lg dark:border-gray-300-dark dark:bg-gray-0-dark">
-              {hiddenChips.map((element) => (
-                <Chip
-                  color={chipColor(element)}
-                  key={element.id}
-                  href={getProjectLink(element)}
-                  className="overflow-hidden text-sm font-medium leading-4"
-                  onClick={() => {
-                    sendAnalyticsEvent("questionTagClicked", {
-                      event_category: element.name,
-                    });
-                  }}
-                >
-                  {getChipContent(element)}
-                </Chip>
-              ))}
-            </PopoverPanel>
-          </Popover>
-        )}
+        <div className="flex min-w-0 items-center gap-2">
+          {visibleChips.map((element) => (
+            <Chip
+              color={chipColor(element)}
+              key={element.id}
+              href={getProjectLink(element)}
+              className="min-w-0 overflow-hidden text-sm font-medium leading-4 [&>*]:min-w-0"
+              onClick={() =>
+                sendAnalyticsEvent("questionTagClicked", {
+                  event_category: element.name,
+                })
+              }
+            >
+              {getChipContent(element)}
+            </Chip>
+          ))}
+
+          {hiddenChips.length > 0 && (
+            <Popover className="relative shrink-0">
+              <PopoverButton className="inline-flex cursor-pointer select-none items-center justify-center gap-1 rounded bg-gray-300 p-1.5 text-sm font-medium leading-4 text-gray-900 hover:bg-gray-400 dark:bg-gray-300-dark dark:text-gray-900-dark dark:hover:bg-gray-400-dark">
+                {t("nMore", { count: hiddenChips.length })}
+              </PopoverButton>
+              <PopoverPanel className="absolute right-0 top-full z-10 mt-1 flex max-w-[250px] flex-wrap gap-2 rounded border border-gray-300 bg-gray-0 p-3 shadow-lg dark:border-gray-300-dark dark:bg-gray-0-dark">
+                {hiddenChips.map((element) => (
+                  <Chip
+                    color={chipColor(element)}
+                    key={element.id}
+                    href={getProjectLink(element)}
+                    className="overflow-hidden text-sm font-medium leading-4"
+                    onClick={() => {
+                      sendAnalyticsEvent("questionTagClicked", {
+                        event_category: element.name,
+                      });
+                    }}
+                  >
+                    {getChipContent(element)}
+                  </Chip>
+                ))}
+              </PopoverPanel>
+            </Popover>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/action_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/action_row.tsx
@@ -68,7 +68,14 @@ const ActionRow: FC<Props> = ({ post, variant }) => {
   const isFollowPrimary = !(variant === "consumer" && isPredictable);
 
   return (
-    <div className="flex w-full flex-wrap items-center gap-2 py-3">
+    <div
+      className={cn(
+        "w-full flex-wrap items-center gap-2 py-3",
+        variant === "forecaster"
+          ? "hidden lg:flex"
+          : "flex justify-center lg:justify-start"
+      )}
+    >
       {/* Consumer: Predict (primary position) */}
       {variant === "consumer" && isPredictable && (
         <QuestionPredictButton
@@ -77,11 +84,12 @@ const ActionRow: FC<Props> = ({ post, variant }) => {
         />
       )}
 
-      {/* Follow */}
+      {/* Follow — hidden on mobile for consumer */}
       <PillButton
         variant={isFollowPrimary || isSubscribed ? "primary" : "secondary"}
         onClick={isSubscribed ? handleCustomize : handleSubscribe}
         disabled={isLoading}
+        className={cn(variant === "consumer" && "hidden lg:flex")}
       >
         <FontAwesomeIcon
           icon={isSubscribed ? faBell : faBellRegular}
@@ -108,8 +116,11 @@ const ActionRow: FC<Props> = ({ post, variant }) => {
         </PillButton>
       </SharePostMenu>
 
-      {/* Embed */}
-      <PillButton className="capitalize" onClick={() => openEmbedModal(true)}>
+      {/* Embed — hidden on mobile for consumer */}
+      <PillButton
+        className={cn("capitalize", variant === "consumer" && "hidden lg:flex")}
+        onClick={() => openEmbedModal(true)}
+      >
         <FontAwesomeIcon icon={faCode} />
         {t("embed")}
       </PillButton>
@@ -122,8 +133,10 @@ const ActionRow: FC<Props> = ({ post, variant }) => {
         />
       )}
 
-      {/* … overflow */}
-      <div className="ml-auto">
+      {/* … overflow — hidden on mobile for consumer */}
+      <div
+        className={cn("ml-auto", variant === "consumer" && "hidden lg:block")}
+      >
         <PostDropdownMenu
           post={post}
           button={

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/action_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/action_row.tsx
@@ -70,10 +70,10 @@ const ActionRow: FC<Props> = ({ post, variant }) => {
   return (
     <div
       className={cn(
-        "w-full flex-wrap items-center gap-2 py-3",
+        "relative w-full flex-wrap items-center gap-2 py-3",
         variant === "forecaster"
-          ? "hidden lg:flex"
-          : "flex justify-center lg:justify-start"
+          ? "hidden md:flex"
+          : "flex justify-center md:justify-start"
       )}
     >
       {/* Consumer: Predict (primary position) */}
@@ -89,7 +89,7 @@ const ActionRow: FC<Props> = ({ post, variant }) => {
         variant={isFollowPrimary || isSubscribed ? "primary" : "secondary"}
         onClick={isSubscribed ? handleCustomize : handleSubscribe}
         disabled={isLoading}
-        className={cn(variant === "consumer" && "hidden lg:flex")}
+        className={cn(variant === "consumer" && "hidden md:flex")}
       >
         <FontAwesomeIcon
           icon={isSubscribed ? faBell : faBellRegular}
@@ -118,7 +118,7 @@ const ActionRow: FC<Props> = ({ post, variant }) => {
 
       {/* Embed — hidden on mobile for consumer */}
       <PillButton
-        className={cn("capitalize", variant === "consumer" && "hidden lg:flex")}
+        className={cn("capitalize", variant === "consumer" && "hidden md:flex")}
         onClick={() => openEmbedModal(true)}
       >
         <FontAwesomeIcon icon={faCode} />
@@ -135,7 +135,11 @@ const ActionRow: FC<Props> = ({ post, variant }) => {
 
       {/* … overflow — hidden on mobile for consumer */}
       <div
-        className={cn("ml-auto", variant === "consumer" && "hidden lg:block")}
+        className={cn(
+          variant === "consumer"
+            ? "hidden md:absolute md:right-0 md:block lg:static lg:ml-auto"
+            : "ml-auto"
+        )}
       >
         <PostDropdownMenu
           post={post}

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/index.tsx
@@ -7,8 +7,6 @@ import KeyFactorsQuestionConsumerSection from "@/app/(main)/questions/[id]/compo
 import { PostStatusBox } from "@/app/(main)/questions/[id]/components/post_status_box";
 import MetaRow from "@/app/(main)/questions/[id]/components/question_page_shell/meta_row";
 import TitleRow from "@/app/(main)/questions/[id]/components/question_page_shell/title_row";
-import ForecastersCounter from "@/app/(main)/questions/components/forecaster_counter";
-import CommentStatus from "@/components/post_card/basic_post_card/comment_status";
 import {
   GroupOfQuestionsGraphType,
   PostStatus,
@@ -17,7 +15,6 @@ import {
 } from "@/types/post";
 import { QuestionType } from "@/types/question";
 import cn from "@/utils/core/cn";
-import { getPostLink } from "@/utils/navigation";
 import {
   checkGroupOfQuestionsPostType,
   isGroupOfQuestionsPost,
@@ -66,27 +63,18 @@ const ConsumerQuestionView: React.FC<Props> = ({ postData }) => {
   return (
     <div className="flex flex-col">
       <PostStatusBox post={postData} className="mb-5 rounded lg:mb-6" />
-      <div className="mb-6 flex items-center justify-center gap-[6px] md:hidden">
-        <CommentStatus
-          totalCount={postData.comment_count ?? 0}
-          unreadCount={postData.unread_comment_count ?? 0}
-          url={getPostLink(postData)}
-          className="bg-gray-200 px-2 dark:bg-gray-200-dark"
-        />
-        <ForecastersCounter
-          forecasters={postData.nr_forecasters}
-          compact={false}
-        />
-      </div>
-
-      <MetaRow post={postData} className="-mx-4 mb-2 hidden md:flex lg:-mx-8" />
+      <MetaRow
+        post={postData}
+        variant="consumer"
+        className="-mx-4 mb-2 lg:-mx-8"
+      />
       <TitleRow post={postData} variant="consumer" />
 
-      <div className="flex w-full justify-start">
+      <div className="order-2 lg:order-none">
         <ActionRow post={postData} variant="consumer" />
       </div>
 
-      <div className="mt-6 sm:mt-8">
+      <div className="order-1 mt-6 sm:mt-8 lg:order-none">
         {showClosedMessageMultipleChoice && (
           <p className="m-0 mb-8 text-center text-sm leading-[20px] text-gray-700 dark:text-gray-700-dark">
             {t("predictionClosedMessage")}

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/index.tsx
@@ -70,11 +70,11 @@ const ConsumerQuestionView: React.FC<Props> = ({ postData }) => {
       />
       <TitleRow post={postData} variant="consumer" />
 
-      <div className="order-2 lg:order-none">
+      <div className="order-2 md:order-none">
         <ActionRow post={postData} variant="consumer" />
       </div>
 
-      <div className="order-1 mt-6 sm:mt-8 lg:order-none">
+      <div className="order-1 mt-6 sm:mt-8 md:order-none">
         {showClosedMessageMultipleChoice && (
           <p className="m-0 mb-8 text-center text-sm leading-[20px] text-gray-700 dark:text-gray-700-dark">
             {t("predictionClosedMessage")}

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/binary_question_prediction.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/binary_question_prediction.tsx
@@ -56,7 +56,7 @@ const BinaryQuestionPrediction: React.FC<Props> = ({
   );
 
   return (
-    <div className="mx-auto mb-7 space-y-7 pt-5 lg:px-10">
+    <div className="mx-auto mb-0 space-y-7 pt-5 lg:mb-7 lg:px-10">
       <PredictionBinaryInfo
         showMyPrediction
         question={question}

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/index.tsx
@@ -29,7 +29,11 @@ const QuestionHeader: FC<{ post: PostWithForecasts }> = ({ post }) => {
         <PostStatusBox post={post} className="mb-5 rounded lg:mb-6" />
       </div>
       <div className="flex flex-1 flex-col gap-4">
-        <MetaRow post={post} className="-mx-4 mb-2 hidden md:flex lg:-mx-8" />
+        <MetaRow
+          post={post}
+          variant="forecaster"
+          className="-mx-4 mb-2 lg:-mx-8"
+        />
         <TitleRow
           post={post}
           variant="forecaster"

--- a/front_end/src/app/(main)/questions/components/forecaster_counter.tsx
+++ b/front_end/src/app/(main)/questions/components/forecaster_counter.tsx
@@ -10,12 +10,14 @@ import { abbreviatedNumber } from "@/utils/formatters/number";
 type Props = {
   forecasters?: number;
   compact?: boolean;
+  boldCount?: boolean;
   className?: string;
 };
 
 const ForecastersCounter: FC<Props> = ({
   forecasters,
   compact = false,
+  boldCount = false,
   className,
 }) => {
   const t = useTranslations();
@@ -45,11 +47,13 @@ const ForecastersCounter: FC<Props> = ({
       />
       {/* Compact version - just shows number */}
       {compact && (
-        <span className="align-middle tabular-nums">
+        <span
+          className={cn("align-middle tabular-nums", boldCount && "font-bold")}
+        >
           {forecastersFormatted}
         </span>
       )}
-      {/* Full version - shows descriptive text */}
+      {/* Full version - shows descriptive text with label */}
       {!compact && (
         <RichText>
           {(tags) => (
@@ -58,7 +62,12 @@ const ForecastersCounter: FC<Props> = ({
                 count: forecasters,
                 count_formatted: forecastersFormatted,
                 ...tags,
-                strong: (chunks) => chunks,
+                strong: (chunks) =>
+                  boldCount ? (
+                    <span className="font-bold">{chunks}</span>
+                  ) : (
+                    chunks
+                  ),
               })}
             </span>
           )}

--- a/front_end/src/components/post_actions/post_dropdown_menu.tsx
+++ b/front_end/src/components/post_actions/post_dropdown_menu.tsx
@@ -53,7 +53,7 @@ export const PostDropdownMenu: FC<Props> = ({ post, button, hideShare }) => {
     // Curators can edit approved posts that are not yet open
     (isCurator && isApproved && isUpcoming);
 
-  const isLargeScreen = useBreakpoint("lg");
+  const isMediumScreen = useBreakpoint("md");
 
   const canResolve =
     isQuestionPost(post) &&
@@ -127,7 +127,7 @@ export const PostDropdownMenu: FC<Props> = ({ post, button, hideShare }) => {
 
   const menuItems: MenuItemProps[] = [
     // Mobile menu items
-    ...(!isLargeScreen
+    ...(!isMediumScreen
       ? [
           ...(!hideShare
             ? [

--- a/front_end/src/components/post_actions/post_dropdown_menu.tsx
+++ b/front_end/src/components/post_actions/post_dropdown_menu.tsx
@@ -29,9 +29,10 @@ import { canChangeQuestionResolution } from "@/utils/questions/resolution";
 type Props = {
   post: Post;
   button?: React.ReactNode;
+  hideShare?: boolean;
 };
 
-export const PostDropdownMenu: FC<Props> = ({ post, button }) => {
+export const PostDropdownMenu: FC<Props> = ({ post, button, hideShare }) => {
   const t = useTranslations();
   const { user } = useAuth();
   const router = useRouter();
@@ -128,12 +129,16 @@ export const PostDropdownMenu: FC<Props> = ({ post, button }) => {
     // Mobile menu items
     ...(!isLargeScreen
       ? [
-          {
-            id: "share",
-            name: t("share"),
-            className: "capitalize",
-            items: shareMenuItems,
-          },
+          ...(!hideShare
+            ? [
+                {
+                  id: "share",
+                  name: t("share"),
+                  className: "capitalize",
+                  items: shareMenuItems,
+                },
+              ]
+            : []),
           {
             id: "subscription",
             name: isSubscribed ? t("followingButton") : t("followButton"),


### PR DESCRIPTION
Related to https://github.com/Metaculus/metaculus/issues/4638

This PR filters the `PostDropdownMenu` item set for desktop and polishes the mobile layout of the meta and action rows for both consumer and forecaster question page variants.

Implemented:
- **Desktop dropdown**: Share / Follow / Embed removed from the overflow `…` menu — they now live as standalone pills in the action row. Only permission-gated items remain (Resolve, Edit, Boost, Duplicate, etc.)
- **Mobile meta row**: variant-aware layout — consumer items centered, forecaster items left-aligned; `…` button absolutely positioned to the far right in both cases; Embed and Follow accessible via the mobile `…` dropdown
- **Mobile forecaster meta**: Vote · Comment count · Post status · Forecaster count (icon only, bold)
- **Mobile consumer meta**: Comment count · Forecaster count (label + bold number); `…` dropdown includes Follow + Embed
- **Mobile action row**: forecaster row fully hidden; consumer row shows Predict (primary) + Share centered below the prediction widget
- **ForecastersCounter**: added `boldCount` prop; consumer mobile shows the full label with bold count at 12px / 16px
- Removed `mb-7` from the binary prediction block on mobile to reduce gap above the action row


https://github.com/user-attachments/assets/98f3501e-225c-4d3f-9ed5-358a423645c3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved question page layouts with enhanced mobile responsiveness and optimized content organization.
  * Refined visibility and positioning of interactive elements based on screen size.
  * Enhanced metadata presentation with improved styling consistency.

* **Style**
  * Adjusted spacing and margins for better visual presentation across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->