### PR TITLE
Add tab content adapters

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -700,6 +700,7 @@
   "resolutionCriteriaExplanation": "Dobrá otázka se téměř vždy vyřeší jednoznačně. Jaká je konkrétní událost, která by mohla nastat? Do jakého data by musela nastat, aby se otázka vyřešila jako Ano? Pokud máte zdroj dat, podle kterého se otázka vyřeší, přidejte jej sem.",
   "choicesSeparatedBy": "Možnosti (oddělené čárkou)",
   "projects": "projekty",
+  "projectsTags": "Projekty / Štítky",
   "FABPrizePool": "CENOVÝ FOND",
   "FABPrizeValue": "$30,000",
   "FABStartDate": "STARTOVACÍ DATUM",

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1067,6 +1067,7 @@
   "choicesSeparatedBy": "Choices (separated by ,)",
   "choicesLockedHelp": "Options can only be changed through the admin panel once forecasting has started.",
   "projects": "projects",
+  "projectsTags": "Projects / Tags",
   "FABPrizePool": "PRIZE POOL",
   "FABPrizeValue": "$30,000",
   "FABStartDate": "START DATE",

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -702,6 +702,7 @@
   "resolutionCriteriaExplanation": "Una buena pregunta casi siempre se resolverá de manera inequívoca. ¿Cuál es el evento específico que podría ocurrir? ¿Antes de qué fecha tendría que ocurrir para que la pregunta se resuelva como Sí? Si tienes una fuente de datos con la que se resolverá la pregunta, enlázala aquí.",
   "choicesSeparatedBy": "Opciones (separadas por ,)",
   "projects": "proyectos",
+  "projectsTags": "Proyectos / Etiquetas",
   "FABPrizePool": "FONDO DE PREMIOS",
   "FABPrizeValue": "$30,000",
   "FABStartDate": "FECHA DE INICIO",

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -791,6 +791,7 @@
   "choices": "Escolhas",
   "choicesSeparatedBy": "Escolhas (separadas por ,)",
   "projects": "projetos",
+  "projectsTags": "Projetos / Tags",
   "FABPrizePool": "PRÊMIO TOTAL",
   "FABPrizeValue": "$30,000",
   "FABStartDate": "DATA DE INÍCIO",

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -853,6 +853,7 @@
   "choices": "選擇",
   "choicesSeparatedBy": "選擇（以,分隔）",
   "projects": "專案",
+  "projectsTags": "專案 / 標籤",
   "FABPrizePool": "獎金池",
   "FABPrizeValue": "$30,000",
   "FABStartDate": "開始日期",

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -691,6 +691,7 @@
   "resolutionCriteriaExplanation": "一個好的問題幾乎總是能夠明確解決。可能發生的具體事件是什麼？在什麼日期之前需要發生才能使問題解決為「是」？如果你有用於解決問題的數據源，請在此處連結。",
   "choicesSeparatedBy": "選項（以逗號分隔）",
   "projects": "專案",
+  "projectsTags": "项目 / 标签",
   "FABPrizePool": "獎金池",
   "FABPrizeValue": "30,000美元",
   "FABStartDate": "開始日期",

--- a/front_end/src/app/(main)/questions/[id]/components/question_layout/consumer_question_layout/responsive_comment_feed.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_layout/consumer_question_layout/responsive_comment_feed.tsx
@@ -9,6 +9,7 @@ import { PostWithForecasts } from "@/types/post";
 type Props = {
   postData: PostWithForecasts;
   compactVersion?: boolean;
+  showTitle?: boolean;
 };
 
 /**
@@ -22,6 +23,7 @@ type Props = {
 const ResponsiveCommentFeed: FC<Props> = ({
   postData,
   compactVersion = false,
+  showTitle,
 }) => {
   const isLargeScreen = useBreakpoint("lg");
 
@@ -33,7 +35,13 @@ const ResponsiveCommentFeed: FC<Props> = ({
     return null;
   }
 
-  return <CommentFeed postData={postData} compactVersion={compactVersion} />;
+  return (
+    <CommentFeed
+      postData={postData}
+      compactVersion={compactVersion}
+      showTitle={showTitle}
+    />
+  );
 };
 
 export default ResponsiveCommentFeed;

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { FC } from "react";
+
+import { PostWithForecasts } from "@/types/post";
+
+import QuestionPageShellTabBar from "./tab_bar";
+import CommentsTab from "./tabs/comments";
+import KeyFactorsTab from "./tabs/key_factors";
+import PrivateNotesTab from "./tabs/private_notes";
+import QuestionInfoTab from "./tabs/question_info";
+import QuestionLinksTab from "./tabs/question_links";
+import { useQuestionLayout } from "../question_layout/question_layout_context";
+
+type Variant = "consumer" | "forecaster";
+
+type Props = {
+  post: PostWithForecasts;
+  variant: Variant;
+  className?: string;
+};
+
+const renderActivePanel = (
+  activeTab: string | undefined,
+  post: PostWithForecasts,
+  variant: Variant
+) => {
+  switch (activeTab) {
+    case "key-factors":
+      return <KeyFactorsTab post={post} />;
+    case "info":
+      return <QuestionInfoTab post={post} />;
+    case "question-links":
+      return variant === "forecaster" ? <QuestionLinksTab post={post} /> : null;
+    case "private-notes":
+      return variant === "forecaster" ? <PrivateNotesTab post={post} /> : null;
+    case "comments":
+    default:
+      return <CommentsTab post={post} />;
+  }
+};
+
+const QuestionPageShellTabs: FC<Props> = ({ post, variant, className }) => {
+  const { activeTab } = useQuestionLayout();
+
+  return (
+    <div className={className}>
+      <QuestionPageShellTabBar post={post} variant={variant} />
+      <div className="mt-8">{renderActivePanel(activeTab, post, variant)}</div>
+    </div>
+  );
+};
+
+export default QuestionPageShellTabs;

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/comments.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/comments.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { FC } from "react";
+
+import { PostWithForecasts } from "@/types/post";
+
+import ResponsiveCommentFeed from "../../question_layout/consumer_question_layout/responsive_comment_feed";
+
+type Props = {
+  post: PostWithForecasts;
+};
+
+const CommentsTab: FC<Props> = ({ post }) => (
+  <div className="[&>section]:!w-full [&>section]:!max-w-none [&>section]:!px-0">
+    <ResponsiveCommentFeed postData={post} showTitle={false} />
+  </div>
+);
+
+export default CommentsTab;

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/key_factors.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/key_factors.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { FC } from "react";
+
+import { PostWithForecasts } from "@/types/post";
+
+import KeyFactorsFeed from "../../key_factors/key_factors_feed";
+
+type Props = {
+  post: PostWithForecasts;
+};
+
+const KeyFactorsTab: FC<Props> = ({ post }) => <KeyFactorsFeed post={post} />;
+
+export default KeyFactorsTab;

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/private_notes.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/private_notes.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { FC } from "react";
+
+import PrivateNote from "@/components/question/private_note";
+import { PostWithForecasts } from "@/types/post";
+
+type Props = {
+  post: PostWithForecasts;
+};
+
+const PrivateNotesTab: FC<Props> = ({ post }) => (
+  <PrivateNote post={post} hideToggle />
+);
+
+export default PrivateNotesTab;

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/question_info.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/question_info.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { FC } from "react";
+
+import MarkdownEditor from "@/components/markdown_editor";
+import Chip from "@/components/ui/chip";
+import { PostWithForecasts } from "@/types/post";
+import { TaxonomyProjectType } from "@/types/projects";
+import { sendAnalyticsEvent } from "@/utils/analytics";
+import { getProjectLink } from "@/utils/navigation";
+
+import SidebarQuestionInfo from "../../sidebar/sidebar_question_info";
+
+type Props = {
+  post: PostWithForecasts;
+};
+
+type MarkdownSection = { title: string; markdown: string };
+
+const getChipText = (name: string, type?: string) =>
+  type === "leaderboard_tag" ? `🏆 ${name}` : name;
+
+const useTextSections = (post: PostWithForecasts): MarkdownSection[] => {
+  const t = useTranslations();
+
+  if (post.conditional) {
+    const { condition, condition_child } = post.conditional;
+    const sections: MarkdownSection[] = [];
+    if (condition.resolution_criteria) {
+      sections.push({
+        title: t("parentResolutionCriteria"),
+        markdown: condition.resolution_criteria,
+      });
+    }
+    if (condition.fine_print) {
+      sections.push({ title: t("finePrint"), markdown: condition.fine_print });
+    }
+    if (condition.description) {
+      sections.push({
+        title: t("parentBackgroundInfo"),
+        markdown: condition.description,
+      });
+    }
+    if (condition_child.resolution_criteria) {
+      sections.push({
+        title: t("childResolutionCriteria"),
+        markdown: condition_child.resolution_criteria,
+      });
+    }
+    if (condition_child.fine_print) {
+      sections.push({
+        title: t("finePrint"),
+        markdown: condition_child.fine_print,
+      });
+    }
+    if (condition_child.description) {
+      sections.push({
+        title: t("childBackgroundInfo"),
+        markdown: condition_child.description,
+      });
+    }
+    return sections;
+  }
+
+  const resolution =
+    post.group_of_questions?.resolution_criteria ??
+    post.question?.resolution_criteria ??
+    "";
+  const finePrint =
+    post.group_of_questions?.fine_print ?? post.question?.fine_print ?? "";
+  const description =
+    post.group_of_questions?.description ?? post.question?.description ?? "";
+
+  const sections: MarkdownSection[] = [];
+  if (resolution)
+    sections.push({ title: t("resolutionCriteria"), markdown: resolution });
+  if (finePrint) sections.push({ title: t("finePrint"), markdown: finePrint });
+  if (description)
+    sections.push({ title: t("backgroundInfo"), markdown: description });
+  return sections;
+};
+
+const QuestionInfoTab: FC<Props> = ({ post }) => {
+  const t = useTranslations();
+  const sections = useTextSections(post);
+
+  const projectsData = post.projects;
+  const allProjects = projectsData
+    ? [
+        ...(projectsData.index ?? []),
+        ...(projectsData.tournament ?? []),
+        ...(projectsData.question_series ?? []),
+        ...(projectsData.community ?? []),
+        ...(projectsData.category ?? []),
+        ...(projectsData.leaderboard_tag ?? []),
+      ]
+    : [];
+
+  return (
+    <div className="flex flex-col items-start gap-10 lg:flex-row">
+      <aside className="flex w-full flex-col gap-8 lg:w-[284px] lg:shrink-0">
+        <SidebarQuestionInfo postData={post} />
+        {allProjects.length > 0 && (
+          <section className="flex w-full flex-col gap-3">
+            <h3 className="m-0 text-base font-medium leading-6 text-blue-900 dark:text-blue-900-dark">
+              {t("projectsTags")}
+            </h3>
+            <div className="flex flex-wrap gap-3">
+              {allProjects.map((element) => (
+                <Chip
+                  color={
+                    Object.values(TaxonomyProjectType).includes(
+                      element.type as TaxonomyProjectType
+                    )
+                      ? "olive"
+                      : "orange"
+                  }
+                  key={element.id}
+                  href={getProjectLink(element)}
+                  onClick={() =>
+                    sendAnalyticsEvent("questionTagClicked", {
+                      event_category: element.name,
+                    })
+                  }
+                >
+                  {getChipText(element.name, element.type)}
+                </Chip>
+              ))}
+            </div>
+          </section>
+        )}
+      </aside>
+
+      <div className="flex min-w-0 flex-1 flex-col gap-8 text-blue-900 dark:text-blue-900-dark">
+        {sections.map((section, idx) => (
+          <section
+            key={`${section.title}-${idx}`}
+            className="flex w-full flex-col gap-2"
+          >
+            <h3 className="m-0 text-base font-medium leading-6">
+              {section.title}
+            </h3>
+            <div className="text-base font-normal leading-6 text-blue-900 dark:text-blue-900-dark">
+              <MarkdownEditor withCodeBlocks markdown={section.markdown} />
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default QuestionInfoTab;

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/question_links.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/question_links.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { FC } from "react";
+
+import { CoherenceLinks } from "@/app/(main)/questions/components/coherence_links/coherence_links";
+import { PostWithForecasts } from "@/types/post";
+
+type Props = {
+  post: PostWithForecasts;
+};
+
+const QuestionLinksTab: FC<Props> = ({ post }) => (
+  <CoherenceLinks post={post} hideToggle />
+);
+
+export default QuestionLinksTab;

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/sidebar_question_info.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/sidebar_question_info.tsx
@@ -23,7 +23,7 @@ const SidebarQuestionInfo: FC<Props> = ({ postData }) => {
     <div className="flex flex-col items-start gap-4 self-stretch @container">
       <div className="flex flex-col justify-between gap-3 self-stretch @lg:grid @lg:grid-cols-4 @lg:gap-1 @lg:gap-y-5">
         <div className="flex justify-between gap-4 @lg:flex-col @lg:justify-start @lg:gap-1">
-          <span className="text-xs font-medium uppercase text-gray-700 dark:text-gray-700-dark">
+          <span className="text-xs font-normal uppercase leading-4 text-blue-900 opacity-50 dark:text-blue-900-dark">
             {t("authorWithCount", {
               count: postData.coauthors.length + 1,
             })}
@@ -31,7 +31,7 @@ const SidebarQuestionInfo: FC<Props> = ({ postData }) => {
           </span>
           <div className="text-metac-blue-700 dark:text-metac-blue-700-dark flex min-w-0 shrink flex-col items-end gap-1 font-medium @lg:items-start">
             <Link
-              className="flex min-w-0 shrink flex-col items-end gap-1 text-sm font-medium leading-4 text-blue-700 @lg:items-start dark:text-blue-700-dark"
+              className="flex min-w-0 shrink flex-col items-end gap-1 text-sm font-medium leading-5 text-blue-700 underline @lg:items-start dark:text-blue-700-dark"
               href={`/accounts/profile/${postData.author_id}`}
             >
               {postData.author_username}
@@ -39,7 +39,7 @@ const SidebarQuestionInfo: FC<Props> = ({ postData }) => {
 
             {postData.coauthors.map((coauthor) => (
               <Link
-                className="flex min-w-0 shrink flex-col items-end gap-1 text-sm font-medium leading-4 text-blue-700 @lg:items-start dark:text-blue-700-dark"
+                className="flex min-w-0 shrink flex-col items-end gap-1 text-sm font-medium leading-5 text-blue-700 underline @lg:items-start dark:text-blue-700-dark"
                 href={`/accounts/profile/${coauthor.id}`}
                 key={`coauthor-${coauthor.id}`}
               >
@@ -51,10 +51,10 @@ const SidebarQuestionInfo: FC<Props> = ({ postData }) => {
 
         {postData.status === PostStatus.PENDING && (
           <div className="flex justify-between gap-4 @lg:flex-col @lg:justify-start @lg:gap-1">
-            <span className="text-xs font-medium uppercase text-gray-700 dark:text-gray-700-dark">
+            <span className="text-xs font-normal uppercase leading-4 text-blue-900 opacity-50 dark:text-blue-900-dark">
               {t("inReview")}:
             </span>
-            <span className="text-sm font-medium leading-4 text-gray-900 dark:text-gray-900-dark">
+            <span className="text-sm font-medium leading-5 text-blue-900 dark:text-blue-900-dark">
               {postData.curation_status_updated_at ? (
                 <LocalDaytime date={postData.curation_status_updated_at} />
               ) : (
@@ -66,20 +66,20 @@ const SidebarQuestionInfo: FC<Props> = ({ postData }) => {
 
         {(postData.open_time || postData.published_at) && (
           <div className="flex justify-between gap-4 @lg:flex-col @lg:justify-start @lg:gap-1">
-            <span className="text-xs font-medium uppercase text-gray-700 dark:text-gray-700-dark">
+            <span className="text-xs font-normal uppercase leading-4 text-blue-900 opacity-50 dark:text-blue-900-dark">
               {t(isUpcoming ? "opens" : "opened")}:
             </span>
-            <span className="text-sm font-medium leading-4 text-gray-900 dark:text-gray-900-dark">
+            <span className="text-sm font-medium leading-5 text-blue-900 dark:text-blue-900-dark">
               <LocalDaytime date={postData.open_time} />
             </span>
           </div>
         )}
 
         <div className="flex justify-between gap-4 @lg:flex-col @lg:justify-start @lg:gap-1">
-          <span className="text-xs font-medium uppercase text-gray-700 dark:text-gray-700-dark">
+          <span className="text-xs font-normal uppercase leading-4 text-blue-900 opacity-50 dark:text-blue-900-dark">
             {postData.status === PostStatus.CLOSED ? t("closed") : t("closes")}:
           </span>
-          <span className="text-sm font-medium leading-4 text-gray-900 dark:text-gray-900-dark">
+          <span className="text-sm font-medium leading-5 text-blue-900 dark:text-blue-900-dark">
             {postData.scheduled_close_time && (
               <LocalDaytime date={postData.scheduled_close_time} />
             )}
@@ -87,13 +87,13 @@ const SidebarQuestionInfo: FC<Props> = ({ postData }) => {
         </div>
 
         <div className="flex justify-between gap-4 @lg:flex-col @lg:justify-start @lg:gap-1">
-          <span className="text-xs font-medium uppercase text-gray-700 dark:text-gray-700-dark">
+          <span className="text-xs font-normal uppercase leading-4 text-blue-900 opacity-50 dark:text-blue-900-dark">
             {postData.status === PostStatus.RESOLVED
               ? t("resolved")
               : t("scheduledResolution")}
             :
           </span>
-          <span className="text-sm font-medium leading-4 text-gray-900 dark:text-gray-900-dark">
+          <span className="text-sm font-medium leading-5 text-blue-900 dark:text-blue-900-dark">
             <LocalDaytime
               date={
                 (postData.status === PostStatus.RESOLVED &&
@@ -106,10 +106,10 @@ const SidebarQuestionInfo: FC<Props> = ({ postData }) => {
 
         {!!postData.question?.spot_scoring_time && (
           <div className="flex justify-between gap-4 @lg:flex-col @lg:justify-start @lg:gap-1">
-            <span className="text-xs font-medium uppercase text-gray-700 dark:text-gray-700-dark">
+            <span className="text-xs font-normal uppercase leading-4 text-blue-900 opacity-50 dark:text-blue-900-dark">
               {t("spotScoingTime")}:
             </span>
-            <span className="text-sm font-medium leading-4 text-gray-900 dark:text-gray-900-dark">
+            <span className="text-sm font-medium leading-5 text-blue-900 dark:text-blue-900-dark">
               {<LocalDaytime date={postData.question?.spot_scoring_time} />}
             </span>
           </div>
@@ -119,10 +119,10 @@ const SidebarQuestionInfo: FC<Props> = ({ postData }) => {
           postData.question?.default_aggregation_method !==
             AggregationMethod.recency_weighted && (
             <div className="flex justify-between gap-4 @lg:flex-col @lg:justify-start @lg:gap-1">
-              <span className="text-xs font-medium uppercase text-gray-700 dark:text-gray-700-dark">
+              <span className="text-xs font-normal uppercase leading-4 text-blue-900 opacity-50 dark:text-blue-900-dark">
                 {t("cpAggregationMethod")}:
               </span>
-              <span className="text-sm font-medium leading-4 text-gray-900 dark:text-gray-900-dark">
+              <span className="text-sm font-medium leading-5 text-blue-900 dark:text-blue-900-dark">
                 {t(postData.question.default_aggregation_method)}
               </span>
             </div>

--- a/front_end/src/app/(main)/questions/components/coherence_links/coherence_links.tsx
+++ b/front_end/src/app/(main)/questions/components/coherence_links/coherence_links.tsx
@@ -16,11 +16,12 @@ import { Post } from "@/types/post";
 
 type Props = {
   post: Post;
+  hideToggle?: boolean;
 };
 
 const MAX_COLLAPSED_HEIGHT = 9999;
 
-export const CoherenceLinks: FC<Props> = ({ post }) => {
+export const CoherenceLinks: FC<Props> = ({ post, hideToggle }) => {
   const t = useTranslations();
   const expandLabel = t("showMore");
   const collapseLabel = t("showLess");
@@ -51,57 +52,65 @@ export const CoherenceLinks: FC<Props> = ({ post }) => {
   )
     return null;
 
+  const inner = (
+    <ExpandableContent
+      maxCollapsedHeight={MAX_COLLAPSED_HEIGHT}
+      expandLabel={expandLabel}
+      collapseLabel={collapseLabel}
+      className="-mt-4"
+    >
+      <div ref={toggleOpenRef} className="mt-3 flex flex-col gap-3">
+        {Array.from(coherenceLinks?.data ?? [], (link) => (
+          <DisplayCoherenceLink
+            key={link.id}
+            link={link}
+            post={post}
+            compact={false}
+          ></DisplayCoherenceLink>
+        ))}
+
+        {Array.from(newLinks, (id) => (
+          <CreateCoherenceLink
+            post={post}
+            key={id}
+            linkKey={id}
+            deleteLink={deleteLink}
+          ></CreateCoherenceLink>
+        ))}
+
+        <div className="flex flex-col items-center justify-between gap-3 px-0 md:px-20">
+          {(!coherenceLinks || coherenceLinks.data.length === 0) &&
+            newLinks?.length === 0 && (
+              <div className="flex flex-col items-center justify-between gap-2 pt-3">
+                <span className="text-balance text-center text-sm">
+                  {t("noQuestionsLinkedP2")}
+                </span>
+                <span className="text-balance text-center text-sm">
+                  {t("noQuestionsLinkedP3")}
+                </span>
+                <span className="mt-1 text-center text-sm text-blue-600 dark:text-blue-600-dark">
+                  {t("noQuestionsLinkedP1")}
+                </span>
+              </div>
+            )}
+
+          {!user?.is_bot && (
+            <AddButton onClick={addLink} className="mx-auto self-start">
+              {t("linkQuestion")}
+            </AddButton>
+          )}
+        </div>
+      </div>
+    </ExpandableContent>
+  );
+
+  if (hideToggle) {
+    return inner;
+  }
+
   return (
     <SectionToggle title={t("questionLinksPrivate")} defaultOpen={true}>
-      <ExpandableContent
-        maxCollapsedHeight={MAX_COLLAPSED_HEIGHT}
-        expandLabel={expandLabel}
-        collapseLabel={collapseLabel}
-        className="-mt-4"
-      >
-        <div ref={toggleOpenRef} className="mt-3 flex flex-col gap-3">
-          {Array.from(coherenceLinks?.data ?? [], (link) => (
-            <DisplayCoherenceLink
-              key={link.id}
-              link={link}
-              post={post}
-              compact={false}
-            ></DisplayCoherenceLink>
-          ))}
-
-          {Array.from(newLinks, (id) => (
-            <CreateCoherenceLink
-              post={post}
-              key={id}
-              linkKey={id}
-              deleteLink={deleteLink}
-            ></CreateCoherenceLink>
-          ))}
-
-          <div className="flex flex-col items-center justify-between gap-3 px-0 md:px-20">
-            {(!coherenceLinks || coherenceLinks.data.length === 0) &&
-              newLinks?.length === 0 && (
-                <div className="flex flex-col items-center justify-between gap-2 pt-3">
-                  <span className="text-balance text-center text-sm">
-                    {t("noQuestionsLinkedP2")}
-                  </span>
-                  <span className="text-balance text-center text-sm">
-                    {t("noQuestionsLinkedP3")}
-                  </span>
-                  <span className="mt-1 text-center text-sm text-blue-600 dark:text-blue-600-dark">
-                    {t("noQuestionsLinkedP1")}
-                  </span>
-                </div>
-              )}
-
-            {!user?.is_bot && (
-              <AddButton onClick={addLink} className="mx-auto self-start">
-                {t("linkQuestion")}
-              </AddButton>
-            )}
-          </div>
-        </div>
-      </ExpandableContent>
+      {inner}
     </SectionToggle>
   );
 };

--- a/front_end/src/components/question/private_note.tsx
+++ b/front_end/src/components/question/private_note.tsx
@@ -17,6 +17,7 @@ import { formatDate } from "@/utils/formatters/date";
 
 type Props = {
   post: Post;
+  hideToggle?: boolean;
 };
 
 const SavedAgo: FC<{ savedAt: Date }> = ({ savedAt }) => {
@@ -54,7 +55,7 @@ const SavedAgo: FC<{ savedAt: Date }> = ({ savedAt }) => {
   });
 };
 
-const PrivateNote: FC<Props> = ({ post: { private_note, id } }) => {
+const PrivateNote: FC<Props> = ({ post: { private_note, id }, hideToggle }) => {
   const t = useTranslations();
   const locale = useLocale();
   const { text, updated_at } = private_note || {};
@@ -94,6 +95,52 @@ const PrivateNote: FC<Props> = ({ post: { private_note, id } }) => {
     return null;
   }
 
+  const editorBody = (
+    <MarkdownEditor
+      ref={editorRef}
+      markdown={noteText}
+      mode="write"
+      onChange={(val) => {
+        saveNoteDebounced(val);
+      }}
+      onBlur={() => {
+        const val = editorRef.current?.getMarkdown();
+        if (!isNil(val)) {
+          saveNote(val);
+        }
+      }}
+      withUgcLinks
+      withCodeBlocks
+    />
+  );
+
+  const editor = (
+    <div className="bg-gray-0 dark:bg-gray-0-dark">{editorBody}</div>
+  );
+
+  if (hideToggle) {
+    return (
+      <div className="flex flex-col gap-2">
+        <div className="scroll-mt-24 border border-gray-500 bg-gray-0 dark:border-gray-500-dark dark:bg-gray-0-dark">
+          {editorBody}
+        </div>
+        {(noteStatusDetails || updated_at) && (
+          <div className="text-right text-xs">
+            {noteStatusDetails ??
+              (updated_at &&
+                t.rich("privateNoteUpdatedFrom", {
+                  date: () => (
+                    <RelativeTime datetime={updated_at} format="relative">
+                      {formatDate(locale, new Date(updated_at))}
+                    </RelativeTime>
+                  ),
+                }))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <SectionToggle
       title={t("privateNote")}
@@ -116,24 +163,7 @@ const PrivateNote: FC<Props> = ({ post: { private_note, id } }) => {
         }
       }}
     >
-      <div className="bg-gray-0 dark:bg-gray-0-dark">
-        <MarkdownEditor
-          ref={editorRef}
-          markdown={noteText}
-          mode="write"
-          onChange={(val) => {
-            saveNoteDebounced(val);
-          }}
-          onBlur={() => {
-            const val = editorRef.current?.getMarkdown();
-            if (!isNil(val)) {
-              saveNote(val);
-            }
-          }}
-          withUgcLinks
-          withCodeBlocks
-        />
-      </div>
+      {editor}
     </SectionToggle>
   );
 };


### PR DESCRIPTION
Related to #4638

This PR adds tab content adapters for the new question page shell, so the desktop tab bar can render the right panel for the active tab.

<img width="1558" height="1482" alt="image" src="https://github.com/user-attachments/assets/eb104081-8208-42e4-b537-70916a8f69f4" />
