### PR TITLE
Clicking a leaderboard's "Advanced" toggle opens/closes the leaderboard drawer

### DIFF
--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/project_leaderboard_client.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/project_leaderboard_client.tsx
@@ -54,7 +54,10 @@ const ProjectLeaderboardClient = ({
   const hasMultipleLeaderboards = leaderboards.length > 1;
 
   const advancedToggleElement = (
-    <div className="ml-auto flex items-center gap-2">
+    <div
+      className="ml-auto flex items-center gap-2"
+      onClick={(e) => e.stopPropagation()}
+    >
       <span className="text-sm">{t("advanced")}</span>
       <Switch
         as="div"


### PR DESCRIPTION
Closes #4651

Fixed issues:

- Clicking the "Advanced" toggle switch on tournament leaderboard sections was also triggering the SectionToggle collapse/expand, because the switch is rendered inside Collapsible.Trigger via the detailElement prop and click events bubbled up to it


https://github.com/user-attachments/assets/a5e6feec-c866-410a-91d5-8e7715fa764e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where clicking the advanced toggle on leaderboards would unexpectedly trigger other interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->