### PR TITLE
Changed devEngines packageManager onFail to warn

### DIFF
--- a/front_end/package.json
+++ b/front_end/package.json
@@ -6,7 +6,7 @@
   "devEngines": {
     "packageManager": {
       "name": "bun",
-      "onFail": "error"
+      "onFail": "warn"
     }
   },
   "scripts": {


### PR DESCRIPTION
Skip hard errors for nvm
<img width="833" height="170" alt="image" src="https://github.com/user-attachments/assets/3fdd1ed8-8163-4bed-952a-0225842bc06a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager validation to emit warnings instead of errors when expected conditions are not met, allowing more flexible development environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->