### PR TITLE
fix: link Metaculus logo to /home/ for logged-in users

### DIFF
--- a/front_end/src/app/(main)/components/headers/components/navbar_logo.tsx
+++ b/front_end/src/app/(main)/components/headers/components/navbar_logo.tsx
@@ -13,7 +13,7 @@ const NavbarLogo: FC<{ className?: string }> = ({ className }) => {
 
   return (
     <Link
-      href="/"
+      href="/home/"
       className={cn(
         "inline-flex max-w-60 flex-shrink-0 flex-grow-0 basis-auto flex-col justify-center bg-blue-800 text-center no-underline",
         className


### PR DESCRIPTION
## Summary

Changes the Metaculus "M" logo in the header to link to `/home/` instead of `/`, so logged-in users can always reach the home page regardless of any `PUBLIC_LANDING_PAGE_URL` redirect configured for `/`.

Fixes #4669

## Test plan

- [ ] Click the M logo while logged in — it should open `/home/` (storefront home page).
- [ ] Click the M logo while logged out — it should still open `/home/`.
- [ ] Verify `PUBLIC_MINIMAL_UI` still hides the logo when enabled.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated navbar logo navigation to route to the home page instead of the root path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->