### PR TITLE
Question page flickering

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/item_view/news/key_factor_news_item.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/item_view/news/key_factor_news_item.tsx
@@ -144,15 +144,7 @@ const SourceDateLabel: React.FC<{
   useLayoutEffect(() => {
     const el = measureRef.current;
     if (!el || !date) return;
-
-    const check = () => {
-      setHideSource(el.scrollWidth > el.clientWidth);
-    };
-    check();
-
-    const observer = new ResizeObserver(check);
-    observer.observe(el);
-    return () => observer.disconnect();
+    setHideSource(el.scrollWidth > el.clientWidth);
   }, [source, date]);
 
   if (!date) {

--- a/front_end/src/components/ui/expandable_content.tsx
+++ b/front_end/src/components/ui/expandable_content.tsx
@@ -38,6 +38,7 @@ const ExpandableContent: FC<PropsWithChildren<Props>> = ({
   const [isExpanded, setIsExpanded] = useState(false);
   const [isExpandable, setIsExpandable] = useState(false);
   const userInteractedRef = useRef(false);
+  const hasSetInitialStateRef = useRef(false);
 
   useEffect(() => {
     const element = ref.current;
@@ -46,12 +47,17 @@ const ExpandableContent: FC<PropsWithChildren<Props>> = ({
     const contentHeight = element.scrollHeight;
     if (contentHeight <= maxCollapsedHeight) {
       setIsExpandable(false);
-      setIsExpanded(true);
+      if (!userInteractedRef.current) {
+        setIsExpanded(true);
+      }
     } else {
       setIsExpandable(true);
-      if (!userInteractedRef.current) {
+      if (!hasSetInitialStateRef.current && !userInteractedRef.current) {
         setIsExpanded(false);
       }
+    }
+    if (contentHeight > 0) {
+      hasSetInitialStateRef.current = true;
     }
   }, [maxCollapsedHeight, height, width, ref]);
 

--- a/front_end/src/components/ui/expandable_content.tsx
+++ b/front_end/src/components/ui/expandable_content.tsx
@@ -47,7 +47,7 @@ const ExpandableContent: FC<PropsWithChildren<Props>> = ({
     const contentHeight = element.scrollHeight;
     if (contentHeight <= maxCollapsedHeight) {
       setIsExpandable(false);
-      if (!userInteractedRef.current) {
+      if (!hasSetInitialStateRef.current && !userInteractedRef.current) {
         setIsExpanded(true);
       }
     } else {


### PR DESCRIPTION
Fixes #4671

This PR fixes a page flickering bug that occurred when scrolling in the forecaster view with news key factors disclosed. Implemented fixes:

- Removed the persistent `ResizeObserver` from `SourceDateLabel` in news key factor items. The overflow check now runs once on mount instead of on every layout change, eliminating cascading re-renders that were triggered
- Added `hasSetInitialStateRef` to `ExpandableContent` so the collapsed/expanded state is locked after the first measurement and cannot be toggled again by subsequent `ResizeObserver` events during scroll
- Guarded the auto-expand branch in `ExpandableContent` with `userInteractedRef` so clicking "Show Less" is no longer immediately overridden when the button leaving document flow causes `scrollHeight` to drop below the collapsed height threshold

### Before 

https://github.com/user-attachments/assets/7cbd97ca-a8c1-4c5e-8f43-8a72bffb0437


### After

https://github.com/user-attachments/assets/ccae658d-267a-452c-b174-05da209b32af



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable display of source date labels in news items to prevent incorrect hiding/showing.
  * Expandable content now respects its initial expanded/collapsed state and user interaction, avoiding unintended state changes during size measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->