### PR TITLE
improve max coverage calculation at leaderboard serialization

### DIFF
--- a/scoring/serializers.py
+++ b/scoring/serializers.py
@@ -92,7 +92,7 @@ class LeaderboardSerializer(serializers.Serializer):
 
     def get_max_coverage(self, obj: Leaderboard):
         if self.context.get("include_max_coverage", False):
-            return (
+            return sum(
                 obj.get_questions()
                 .filter(resolution__isnull=False)
                 .exclude(
@@ -101,7 +101,7 @@ class LeaderboardSerializer(serializers.Serializer):
                         UnsuccessfulResolutionType.AMBIGUOUS,
                     ]
                 )
-                .count()
+                .values_list("question_weight", flat=True)
             )
 
     def get_is_primary_leaderboard(self, obj: Leaderboard):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved max coverage calculation to account for question weights rather than simple counts, ensuring more accurate coverage metrics when valid resolutions are present and excluding annulled or ambiguous outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->