### PR TITLE
Mobile: introduce forecaster tab bar + styling-parity pass

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_question_consumer_section.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_question_consumer_section.tsx
@@ -8,14 +8,14 @@ import { openKeyFactorsSectionAndScrollTo } from "@/app/(main)/questions/[id]/co
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import { sendAnalyticsEvent } from "@/utils/analytics";
 
-import KeyFactorDetailOverlay from "./key_factor_detail_overlay";
-import KeyFactorsConsumerCarousel from "./key_factors_consumer_carousel";
-import { useShouldHideKeyFactors } from "./use_should_hide_key_factors";
-import { useQuestionLayout } from "../question_layout/question_layout_context";
 import {
   MAX_TOP_KEY_FACTORS,
   useTopKeyFactorsCarouselItems,
 } from "./hooks/use_top_key_factors_carousel_items";
+import KeyFactorDetailOverlay from "./key_factor_detail_overlay";
+import KeyFactorsConsumerCarousel from "./key_factors_consumer_carousel";
+import { useShouldHideKeyFactors } from "./use_should_hide_key_factors";
+import { useQuestionLayout } from "../question_layout/question_layout_context";
 
 type Props = {
   post: PostWithForecasts;
@@ -51,7 +51,7 @@ const KeyFactorsQuestionConsumerSection: FC<Props> = ({ post }) => {
 
   return (
     <div
-      className="-ml-4 mt-8 flex w-[calc(100%+32px)] flex-col pb-4 sm:ml-0 sm:w-full"
+      className="-ml-4 flex w-[calc(100%+32px)] flex-col pb-4 sm:ml-0 sm:mt-8 sm:w-full"
       id="top-key-factors"
     >
       <div className="mb-4 flex items-center justify-between px-4 sm:px-0">

--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_question_consumer_section.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_question_consumer_section.tsx
@@ -63,7 +63,7 @@ const KeyFactorsQuestionConsumerSection: FC<Props> = ({ post }) => {
             openKeyFactorsElement("[id='key-factors']");
             sendAnalyticsEvent("KeyFactorViewAllClick");
           }}
-          className="text-sm text-blue-700 hover:text-blue-800 dark:text-blue-700-dark dark:hover:text-blue-600-dark"
+          className="text-center text-sm font-normal leading-5 text-blue-600 hover:text-blue-700 dark:text-blue-600-dark dark:hover:text-blue-700-dark"
         >
           {t("viewAll", { count: totalCount })}
         </button>

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -185,10 +185,10 @@ export const ConsumerShell: FC<{
           />
           <TitleRow post={postData} variant="consumer" />
         </div>
-        <div className="order-2 md:order-none">
+        <div className="order-2 sm:order-none">
           <ActionRow post={postData} variant="consumer" />
         </div>
-        <div className="order-1 mt-6 sm:mt-8 md:order-none md:-mt-2 lg:-mt-3">
+        <div className="order-1 mt-3 sm:order-none sm:mt-8 md:-mt-2 lg:-mt-3">
           {showClosedMessageMultipleChoice && (
             <p className="m-0 mb-8 text-center text-sm leading-[20px] text-gray-700 dark:text-gray-700-dark">
               {t("predictionClosedMessage")}
@@ -249,7 +249,7 @@ export const ConsumerShell: FC<{
           </div>
         </div>
         {shouldShowKeyFactorsSection && (
-          <div className="order-3 md:order-none">
+          <div className="order-3 sm:order-none">
             <KeyFactorsQuestionConsumerSection post={postData} />
           </div>
         )}

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -39,7 +39,7 @@ import ConsumerQuestionPrediction from "../question_view/consumer_question_view/
 import QuestionTimeline from "../question_view/consumer_question_view/timeline";
 
 const baseSectionClassName =
-  "relative z-10 flex w-[59rem] max-w-full flex-col gap-5 overflow-x-clip rounded border border-blue-400 p-4 text-gray-900 dark:border-blue-200-dark dark:text-gray-900-dark lg:gap-6 lg:p-8";
+  "relative z-10 flex w-[59rem] max-w-full flex-col gap-6 overflow-x-clip rounded border border-blue-400 p-4 text-gray-900 dark:border-blue-200-dark dark:text-gray-900-dark lg:p-8";
 
 const mainSectionClassName = `${baseSectionClassName} bg-gray-0 dark:bg-gray-0-dark`;
 const commentSectionClassName = `${baseSectionClassName} bg-blue-100 dark:bg-gray-0-dark`;
@@ -70,7 +70,7 @@ export const ForecasterShell: FC<
 
   return (
     <Fragment>
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1.5 md:gap-4">
         <section className={mainSectionClassName}>
           <PostStatusBox post={postData} className="mb-5 rounded lg:mb-6" />
           {postData.projects?.default_project && (
@@ -168,7 +168,7 @@ export const ConsumerShell: FC<{
   const shouldShowKeyFactorsSection = hasKeyFactors || hasQuestionLinks;
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-1.5 md:gap-4">
       <section className={mainSectionClassName}>
         <PostStatusBox post={postData} className="mb-5 rounded lg:mb-6" />
         {postData.projects?.default_project && (
@@ -224,13 +224,13 @@ export const ConsumerShell: FC<{
                 hideTitle
                 isConsumerView={!isContinuousSingleQuestion}
                 preselectedGroupQuestionId={preselectedGroupQuestionId}
-                className={
-                  showSideBySide
-                    ? isDateGroup
+                className={cn(
+                  "hidden sm:block",
+                  showSideBySide &&
+                    (isDateGroup
                       ? "order-1 mt-0 flex-1"
-                      : "order-2 mt-0 flex-1"
-                    : undefined
-                }
+                      : "order-2 mt-0 flex-1")
+                )}
               />
             )}
             {isFanGraph && isGroupOfQuestionsPost(postData) && (
@@ -249,10 +249,12 @@ export const ConsumerShell: FC<{
               </p>
             )}
           </div>
-          {shouldShowKeyFactorsSection && (
-            <KeyFactorsQuestionConsumerSection post={postData} />
-          )}
         </div>
+        {shouldShowKeyFactorsSection && (
+          <div className="order-3 md:order-none">
+            <KeyFactorsQuestionConsumerSection post={postData} />
+          </div>
+        )}
       </section>
       <section className={commentSectionClassName}>
         <QuestionPageShellTabs post={postData} variant="consumer" />

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -16,6 +16,7 @@ import {
   PostWithForecasts,
   QuestionStatus,
 } from "@/types/post";
+import { TournamentType } from "@/types/projects";
 import { QuestionType } from "@/types/question";
 import cn from "@/utils/core/cn";
 import {
@@ -73,7 +74,8 @@ export const ForecasterShell: FC<
       <div className="flex flex-col gap-1.5 md:gap-4">
         <section className={mainSectionClassName}>
           <PostStatusBox post={postData} className="mb-5 rounded lg:mb-6" />
-          {postData.projects?.default_project && (
+          {postData.projects?.default_project?.type ===
+            TournamentType.Community && (
             <CommunityDisclaimer
               project={postData.projects.default_project}
               variant="standalone"
@@ -170,7 +172,8 @@ export const ConsumerShell: FC<{
     <div className="flex flex-col gap-1.5 md:gap-4">
       <section className={mainSectionClassName}>
         <PostStatusBox post={postData} className="mb-5 rounded lg:mb-6" />
-        {postData.projects?.default_project && (
+        {postData.projects?.default_project?.type ===
+          TournamentType.Community && (
           <CommunityDisclaimer
             project={postData.projects.default_project}
             variant="standalone"
@@ -206,17 +209,13 @@ export const ConsumerShell: FC<{
           >
             <div
               className={cn(
-                showSideBySide
-                  ? isDateGroup
-                    ? "order-2"
-                    : "order-1"
-                  : undefined,
+                showSideBySide && !isDateGroup ? "order-1" : undefined,
                 isContinuousSingleQuestion && "md:hidden"
               )}
             >
               <ConsumerQuestionPrediction postData={postData} />
             </div>
-            {!isFanGraph && (
+            {!isFanGraph && !isDateGroup && (
               <QuestionTimeline
                 postData={postData}
                 keyFactors={postData.key_factors}
@@ -224,21 +223,8 @@ export const ConsumerShell: FC<{
                 preselectedGroupQuestionId={preselectedGroupQuestionId}
                 className={cn(
                   "hidden sm:block",
-                  showSideBySide &&
-                    (isDateGroup
-                      ? "order-1 mt-0 flex-1"
-                      : "order-2 mt-0 flex-1")
+                  showSideBySide && "order-2 mt-0 flex-1"
                 )}
-              />
-            )}
-            {isFanGraph && isGroupOfQuestionsPost(postData) && (
-              <DetailedGroupCard
-                post={postData}
-                preselectedQuestionId={preselectedGroupQuestionId}
-                groupPresentationOverride={
-                  GroupOfQuestionsGraphType.MultipleChoiceGraph
-                }
-                prioritizeOpenSubquestions
               />
             )}
             {showClosedMessageFanGraph && (

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -205,19 +205,18 @@ export const ConsumerShell: FC<{
               showSideBySide && "sm:flex-row sm:items-center sm:gap-8"
             )}
           >
-            {!isContinuousSingleQuestion && (
-              <div
-                className={
-                  showSideBySide
-                    ? isDateGroup
-                      ? "order-2"
-                      : "order-1"
-                    : undefined
-                }
-              >
-                <ConsumerQuestionPrediction postData={postData} />
-              </div>
-            )}
+            <div
+              className={cn(
+                showSideBySide
+                  ? isDateGroup
+                    ? "order-2"
+                    : "order-1"
+                  : undefined,
+                isContinuousSingleQuestion && "md:hidden"
+              )}
+            >
+              <ConsumerQuestionPrediction postData={postData} />
+            </div>
             {!isFanGraph && (
               <QuestionTimeline
                 postData={postData}

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -98,7 +98,6 @@ export const ForecasterShell: FC<
               <DetailedQuestionCard
                 post={postData}
                 keyFactors={postData.key_factors}
-                hideTitle
               />
             )}
             {isGroup && (
@@ -221,7 +220,6 @@ export const ConsumerShell: FC<{
               <QuestionTimeline
                 postData={postData}
                 keyFactors={postData.key_factors}
-                hideTitle
                 isConsumerView={!isContinuousSingleQuestion}
                 preselectedGroupQuestionId={preselectedGroupQuestionId}
                 className={cn(

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
@@ -63,7 +63,7 @@ const MetaRow: FC<Props> = ({ post, className, variant }) => {
         )}
       >
         <div className="flex items-center gap-1.5">
-          {variant === "forecaster" && <PostVoter post={post} />}
+          {variant === "forecaster" && <PostVoter post={post} compact />}
           <CommentStatus
             totalCount={post.comment_count ?? 0}
             unreadCount={post.unread_comment_count ?? 0}

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
@@ -7,7 +7,6 @@ import { useTranslations } from "next-intl";
 import { FC } from "react";
 
 import ForecastersCounter from "@/app/(main)/questions/components/forecaster_counter";
-import TrophyIcon from "@/components/icons/trophy";
 import { PostDropdownMenu } from "@/components/post_actions";
 import CommentStatus from "@/components/post_card/basic_post_card/comment_status";
 import PostVoter from "@/components/post_card/basic_post_card/post_voter";
@@ -16,11 +15,13 @@ import Button from "@/components/ui/button";
 import Chip from "@/components/ui/chip";
 import useContainerSize from "@/hooks/use_container_size";
 import { PostWithForecasts } from "@/types/post";
-import { Project, TaxonomyProjectType, TournamentType } from "@/types/projects";
+import { Project } from "@/types/projects";
 import { sendAnalyticsEvent } from "@/utils/analytics";
 import cn from "@/utils/core/cn";
 import { getPostLink, getProjectLink } from "@/utils/navigation";
 import { extractPostResolution } from "@/utils/questions/resolution";
+
+import { getChipColor, getChipContent } from "./project_chip_helpers";
 
 type Props = {
   post: PostWithForecasts;
@@ -51,28 +52,6 @@ const MetaRow: FC<Props> = ({ post, className, variant }) => {
 
   const visibleChips = allProjects.slice(0, maxVisibleChips);
   const hiddenChips = allProjects.slice(maxVisibleChips);
-
-  const getChipContent = (element: Project) => {
-    if (
-      element.type === TournamentType.Tournament ||
-      element.type === TaxonomyProjectType.LeaderboardTag
-    ) {
-      return (
-        <span className="flex min-w-0 items-center gap-1">
-          <TrophyIcon className="h-4 w-4 shrink-0" />
-          <span className="min-w-0 truncate">{element.name}</span>
-        </span>
-      );
-    }
-    return <span className="min-w-0 truncate">{element.name}</span>;
-  };
-
-  const chipColor = (element: Project) =>
-    Object.values(TaxonomyProjectType).includes(
-      element.type as TaxonomyProjectType
-    )
-      ? "olive"
-      : "orange";
 
   return (
     <div className={cn("px-4 lg:px-8", className)}>
@@ -146,7 +125,7 @@ const MetaRow: FC<Props> = ({ post, className, variant }) => {
         <div className="flex min-w-0 items-center gap-2">
           {visibleChips.map((element) => (
             <Chip
-              color={chipColor(element)}
+              color={getChipColor(element)}
               key={element.id}
               href={getProjectLink(element)}
               className="min-w-0 overflow-hidden text-sm font-medium leading-4 [&>*]:min-w-0"
@@ -168,7 +147,7 @@ const MetaRow: FC<Props> = ({ post, className, variant }) => {
               <PopoverPanel className="absolute right-0 top-full z-10 mt-1 flex max-w-[250px] flex-wrap gap-2 rounded border border-gray-300 bg-gray-0 p-3 shadow-lg dark:border-gray-300-dark dark:bg-gray-0-dark">
                 {hiddenChips.map((element) => (
                   <Chip
-                    color={chipColor(element)}
+                    color={getChipColor(element)}
                     key={element.id}
                     href={getProjectLink(element)}
                     className="overflow-hidden text-sm font-medium leading-4"

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
@@ -89,7 +89,10 @@ const MetaRow: FC<Props> = ({ post, className, variant }) => {
             totalCount={post.comment_count ?? 0}
             unreadCount={post.unread_comment_count ?? 0}
             url={getPostLink(post)}
-            className="bg-gray-200 text-xs leading-4 dark:bg-gray-200-dark"
+            className={cn(
+              "bg-gray-200 text-xs leading-4 dark:bg-gray-200-dark",
+              variant === "consumer" && "font-bold"
+            )}
             compact={true}
           />
           {variant === "forecaster" && (

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/project_chip_helpers.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/project_chip_helpers.tsx
@@ -1,0 +1,24 @@
+import TrophyIcon from "@/components/icons/trophy";
+import { Project, TaxonomyProjectType, TournamentType } from "@/types/projects";
+
+export const getChipContent = (element: Project) => {
+  if (
+    element.type === TournamentType.Tournament ||
+    element.type === TaxonomyProjectType.LeaderboardTag
+  ) {
+    return (
+      <span className="flex min-w-0 items-center gap-1">
+        <TrophyIcon className="h-4 w-4 shrink-0" />
+        <span className="min-w-0 truncate">{element.name}</span>
+      </span>
+    );
+  }
+  return <span className="min-w-0 truncate">{element.name}</span>;
+};
+
+export const getChipColor = (element: Project) =>
+  Object.values(TaxonomyProjectType).includes(
+    element.type as TaxonomyProjectType
+  )
+    ? "olive"
+    : "orange";

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tab_bar.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tab_bar.tsx
@@ -4,11 +4,13 @@ import { useTranslations } from "next-intl";
 import { FC } from "react";
 
 import { Tabs, TabsList, TabsTab } from "@/components/ui/tabs";
+import { useBreakpoint } from "@/hooks/tailwind";
 import { PostWithForecasts } from "@/types/post";
 import cn from "@/utils/core/cn";
 
 import { shouldPostShowUserScores } from "../post_score_data/utils";
 import { useQuestionLayout } from "../question_layout/question_layout_context";
+import { hasTimeline } from "../question_view/consumer_question_view/timeline";
 
 type TabKey =
   | "comments"
@@ -16,7 +18,8 @@ type TabKey =
   | "info"
   | "my-scores"
   | "question-links"
-  | "private-notes";
+  | "private-notes"
+  | "timeline";
 
 type TabDef = {
   key: TabKey;
@@ -33,7 +36,7 @@ type Props = {
 const tabClassName = (isActive: boolean) =>
   cn(
     "border-[1.25px] border-solid rounded-full font-medium transition-colors",
-    "text-base leading-6 px-[15px] py-[5px] sm:text-base sm:leading-6 sm:px-[15px] sm:py-[5px]",
+    "text-sm leading-4 px-2 py-1 sm:text-base sm:leading-6 sm:px-[15px] sm:py-[5px]",
     isActive
       ? "bg-blue-500/60 border-transparent text-blue-900 dark:bg-blue-500-dark/60 dark:text-blue-900-dark"
       : "bg-gray-0 border-blue-500/20 text-blue-900 dark:bg-gray-0-dark dark:border-blue-500-dark/20 dark:text-blue-900-dark"
@@ -43,10 +46,10 @@ const QuestionPageShellTabBar: FC<Props> = ({ post, variant, className }) => {
   const t = useTranslations();
   const { activeTab, setActiveTab } = useQuestionLayout();
 
+  const isSm = useBreakpoint("sm");
   const commentCount = post.comment_count ?? 0;
   const keyFactorsCount = post.key_factors?.length ?? 0;
   const hasScores = shouldPostShowUserScores(post);
-
   const forecasterTabs: TabDef[] = [
     { key: "comments", label: t("comments"), count: commentCount },
     { key: "key-factors", label: t("keyFactors"), count: keyFactorsCount },
@@ -55,21 +58,19 @@ const QuestionPageShellTabBar: FC<Props> = ({ post, variant, className }) => {
     { key: "private-notes", label: t("privateNotes") },
   ];
 
-  const tabs: TabDef[] =
-    variant === "forecaster"
-      ? forecasterTabs
-      : [
-          { key: "comments", label: t("comments"), count: commentCount },
-          {
-            key: "key-factors",
-            label: t("keyFactors"),
-            count: keyFactorsCount,
-          },
-          { key: "info", label: t("info") },
-          ...(hasScores
-            ? [{ key: "my-scores" as TabKey, label: t("myScores") }]
-            : []),
-        ];
+  const consumerTabs: TabDef[] = [
+    { key: "comments", label: t("comments"), count: commentCount },
+    { key: "key-factors", label: t("keyFactors"), count: keyFactorsCount },
+    { key: "info", label: t("info") },
+    ...(!isSm && hasTimeline(post)
+      ? [{ key: "timeline" as TabKey, label: t("timeline") }]
+      : []),
+    ...(hasScores
+      ? [{ key: "my-scores" as TabKey, label: t("myScores") }]
+      : []),
+  ];
+
+  const tabs = variant === "forecaster" ? forecasterTabs : consumerTabs;
 
   const defaultValue: TabKey = "comments";
   const active =
@@ -84,7 +85,7 @@ const QuestionPageShellTabBar: FC<Props> = ({ post, variant, className }) => {
       onChange={setActiveTab}
       className={cn("bg-transparent dark:bg-transparent", className)}
     >
-      <TabsList contained className="gap-[10px]">
+      <TabsList contained className="gap-[10px] overflow-x-auto">
         {tabs.map((tab) => (
           <TabsTab
             key={tab.key}

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tab_bar.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tab_bar.tsx
@@ -5,7 +5,7 @@ import { FC } from "react";
 
 import { Tabs, TabsList, TabsTab } from "@/components/ui/tabs";
 import { useBreakpoint } from "@/hooks/tailwind";
-import { PostWithForecasts } from "@/types/post";
+import { PostStatus, PostWithForecasts } from "@/types/post";
 import cn from "@/utils/core/cn";
 
 import { shouldPostShowUserScores } from "../post_score_data/utils";
@@ -19,7 +19,8 @@ type TabKey =
   | "my-scores"
   | "question-links"
   | "private-notes"
-  | "timeline";
+  | "timeline"
+  | "similar-questions";
 
 type TabDef = {
   key: TabKey;
@@ -50,23 +51,42 @@ const QuestionPageShellTabBar: FC<Props> = ({ post, variant, className }) => {
   const commentCount = post.comment_count ?? 0;
   const keyFactorsCount = post.key_factors?.length ?? 0;
   const hasScores = shouldPostShowUserScores(post);
+  const hasSimilarQuestionsTab =
+    !isSm && post.curation_status === PostStatus.APPROVED;
+
   const forecasterTabs: TabDef[] = [
     { key: "comments", label: t("comments"), count: commentCount },
     { key: "key-factors", label: t("keyFactors"), count: keyFactorsCount },
     { key: "info", label: t("info") },
     { key: "question-links", label: t("questionLinks") },
     { key: "private-notes", label: t("privateNotes") },
+    ...(hasSimilarQuestionsTab
+      ? [
+          {
+            key: "similar-questions" as TabKey,
+            label: t("similarQuestions"),
+          },
+        ]
+      : []),
   ];
 
   const consumerTabs: TabDef[] = [
     { key: "comments", label: t("comments"), count: commentCount },
-    { key: "key-factors", label: t("keyFactors"), count: keyFactorsCount },
-    { key: "info", label: t("info") },
     ...(!isSm && hasTimeline(post)
       ? [{ key: "timeline" as TabKey, label: t("timeline") }]
       : []),
+    { key: "key-factors", label: t("keyFactors"), count: keyFactorsCount },
+    { key: "info", label: t("info") },
     ...(hasScores
       ? [{ key: "my-scores" as TabKey, label: t("myScores") }]
+      : []),
+    ...(hasSimilarQuestionsTab
+      ? [
+          {
+            key: "similar-questions" as TabKey,
+            label: t("similarQuestions"),
+          },
+        ]
       : []),
   ];
 

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { FC } from "react";
+import { FC, useEffect, useState } from "react";
 
-import { PostWithForecasts } from "@/types/post";
+import ClientPostsApi from "@/services/api/posts/posts.client";
+import { PostStatus, PostWithForecasts } from "@/types/post";
 
 import QuestionPageShellTabBar from "./tab_bar";
 import CommentsTab from "./tabs/comments";
@@ -11,6 +12,7 @@ import MyScoresTab from "./tabs/my_scores";
 import PrivateNotesTab from "./tabs/private_notes";
 import QuestionInfoTab from "./tabs/question_info";
 import QuestionLinksTab from "./tabs/question_links";
+import SimilarQuestionsTab from "./tabs/similar_questions";
 import TimelineTab from "./tabs/timeline";
 import KeyFactorsFeed from "../key_factors/key_factors_feed";
 import { useQuestionLayout } from "../question_layout/question_layout_context";
@@ -26,9 +28,12 @@ type Props = {
 const renderActivePanel = (
   activeTab: string | undefined,
   post: PostWithForecasts,
-  variant: Variant
+  variant: Variant,
+  similarQuestions: PostWithForecasts[]
 ) => {
   switch (activeTab) {
+    case "similar-questions":
+      return <SimilarQuestionsTab questions={similarQuestions} variant={variant} />;
     case "timeline":
       return variant === "consumer" ? <TimelineTab post={post} /> : null;
     case "key-factors":
@@ -51,6 +56,13 @@ const QuestionPageShellTabs: FC<Props> = ({ post, variant, className }) => {
   const { activeTab } = useQuestionLayout();
   const isKeyFactors = activeTab === "key-factors";
 
+  const [similarQuestions, setSimilarQuestions] = useState<PostWithForecasts[]>([]);
+  useEffect(() => {
+    if (post.curation_status === PostStatus.APPROVED) {
+      ClientPostsApi.getSimilarPosts(post.id).then(setSimilarQuestions);
+    }
+  }, [post.id, post.curation_status]);
+
   return (
     <div className={className}>
       <QuestionPageShellTabBar post={post} variant={variant} />
@@ -61,7 +73,7 @@ const QuestionPageShellTabs: FC<Props> = ({ post, variant, className }) => {
         </div>
       )}
       <div className="mt-4 md:mt-5">
-        {renderActivePanel(activeTab, post, variant)}
+        {renderActivePanel(activeTab, post, variant, similarQuestions)}
       </div>
     </div>
   );

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs.tsx
@@ -11,6 +11,7 @@ import MyScoresTab from "./tabs/my_scores";
 import PrivateNotesTab from "./tabs/private_notes";
 import QuestionInfoTab from "./tabs/question_info";
 import QuestionLinksTab from "./tabs/question_links";
+import TimelineTab from "./tabs/timeline";
 import KeyFactorsFeed from "../key_factors/key_factors_feed";
 import { useQuestionLayout } from "../question_layout/question_layout_context";
 
@@ -28,6 +29,8 @@ const renderActivePanel = (
   variant: Variant
 ) => {
   switch (activeTab) {
+    case "timeline":
+      return variant === "consumer" ? <TimelineTab post={post} /> : null;
     case "key-factors":
       return <KeyFactorsTab post={post} />;
     case "info":
@@ -57,7 +60,9 @@ const QuestionPageShellTabs: FC<Props> = ({ post, variant, className }) => {
           <KeyFactorsFeed post={post} />
         </div>
       )}
-      <div className="mt-5">{renderActivePanel(activeTab, post, variant)}</div>
+      <div className="mt-4 md:mt-5">
+        {renderActivePanel(activeTab, post, variant)}
+      </div>
     </div>
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { FC, useEffect, useState } from "react";
+import { FC } from "react";
 
-import ClientPostsApi from "@/services/api/posts/posts.client";
-import { PostStatus, PostWithForecasts } from "@/types/post";
+import { PostWithForecasts } from "@/types/post";
 
 import QuestionPageShellTabBar from "./tab_bar";
 import CommentsTab from "./tabs/comments";
@@ -28,12 +27,11 @@ type Props = {
 const renderActivePanel = (
   activeTab: string | undefined,
   post: PostWithForecasts,
-  variant: Variant,
-  similarQuestions: PostWithForecasts[]
+  variant: Variant
 ) => {
   switch (activeTab) {
     case "similar-questions":
-      return <SimilarQuestionsTab questions={similarQuestions} variant={variant} />;
+      return <SimilarQuestionsTab post={post} variant={variant} />;
     case "timeline":
       return variant === "consumer" ? <TimelineTab post={post} /> : null;
     case "key-factors":
@@ -56,13 +54,6 @@ const QuestionPageShellTabs: FC<Props> = ({ post, variant, className }) => {
   const { activeTab } = useQuestionLayout();
   const isKeyFactors = activeTab === "key-factors";
 
-  const [similarQuestions, setSimilarQuestions] = useState<PostWithForecasts[]>([]);
-  useEffect(() => {
-    if (post.curation_status === PostStatus.APPROVED) {
-      ClientPostsApi.getSimilarPosts(post.id).then(setSimilarQuestions);
-    }
-  }, [post.id, post.curation_status]);
-
   return (
     <div className={className}>
       <QuestionPageShellTabBar post={post} variant={variant} />
@@ -73,7 +64,7 @@ const QuestionPageShellTabs: FC<Props> = ({ post, variant, className }) => {
         </div>
       )}
       <div className="mt-4 md:mt-5">
-        {renderActivePanel(activeTab, post, variant, similarQuestions)}
+        {renderActivePanel(activeTab, post, variant)}
       </div>
     </div>
   );

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/comments.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/comments.tsx
@@ -2,9 +2,8 @@
 
 import { FC } from "react";
 
+import CommentFeed from "@/components/comment_feed";
 import { PostWithForecasts } from "@/types/post";
-
-import ResponsiveCommentFeed from "../../question_layout/consumer_question_layout/responsive_comment_feed";
 
 type Props = {
   post: PostWithForecasts;
@@ -12,7 +11,7 @@ type Props = {
 
 const CommentsTab: FC<Props> = ({ post }) => (
   <div className="[&>section]:!w-full [&>section]:!max-w-none [&>section]:!border-0 [&>section]:!bg-transparent [&>section]:!px-0 [&>section]:!py-0 [&>section]:after:!hidden">
-    <ResponsiveCommentFeed postData={post} showTitle={false} />
+    <CommentFeed postData={post} showTitle={false} />
   </div>
 );
 

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/question_info.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/question_info.tsx
@@ -6,20 +6,17 @@ import { FC } from "react";
 import MarkdownEditor from "@/components/markdown_editor";
 import Chip from "@/components/ui/chip";
 import { PostWithForecasts } from "@/types/post";
-import { TaxonomyProjectType } from "@/types/projects";
 import { sendAnalyticsEvent } from "@/utils/analytics";
 import { getProjectLink } from "@/utils/navigation";
 
 import SidebarQuestionInfo from "../../sidebar/sidebar_question_info";
+import { getChipColor, getChipContent } from "../project_chip_helpers";
 
 type Props = {
   post: PostWithForecasts;
 };
 
 type MarkdownSection = { title: string; markdown: string };
-
-const getChipText = (name: string, type?: string) =>
-  type === "leaderboard_tag" ? `🏆 ${name}` : name;
 
 const useTextSections = (post: PostWithForecasts): MarkdownSection[] => {
   const t = useTranslations();
@@ -109,22 +106,17 @@ const QuestionInfoTab: FC<Props> = ({ post }) => {
             <div className="flex flex-wrap gap-3">
               {allProjects.map((element) => (
                 <Chip
-                  color={
-                    Object.values(TaxonomyProjectType).includes(
-                      element.type as TaxonomyProjectType
-                    )
-                      ? "olive"
-                      : "orange"
-                  }
+                  color={getChipColor(element)}
                   key={element.id}
                   href={getProjectLink(element)}
+                  className="min-w-0 overflow-hidden [&>*]:min-w-0"
                   onClick={() =>
                     sendAnalyticsEvent("questionTagClicked", {
                       event_category: element.name,
                     })
                   }
                 >
-                  {getChipText(element.name, element.type)}
+                  {getChipContent(element)}
                 </Chip>
               ))}
             </div>

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/similar_questions.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/similar_questions.tsx
@@ -14,15 +14,33 @@ type Props = {
 };
 
 const SimilarQuestionsTab: FC<Props> = ({ post, variant }) => {
-  const { data: questions = [], isFetching } = useQuery({
+  const { data: similarQuestions = [] } = useQuery({
     queryKey: ["similar-posts", post.id],
     queryFn: () => ClientPostsApi.getSimilarPosts(post.id),
     enabled: post.curation_status === PostStatus.APPROVED,
   });
 
-  if (isFetching || !questions.length) return null;
+  const { data: topQuestions = [] } = useQuery({
+    queryKey: ["top-posts-fallback"],
+    queryFn: () =>
+      ClientPostsApi.getPostsWithCP({
+        topic: "top-50",
+        for_main_feed: "false",
+        order_by: "-hotness",
+        limit: 8,
+      }),
+    select: (data) => data.results.filter((q) => q.id !== post.id),
+  });
 
-  return <SimilarQuestionsList questions={questions} variant={variant} />;
+  const displayQuestions = similarQuestions.length
+    ? similarQuestions
+    : topQuestions;
+
+  if (!displayQuestions.length) return null;
+
+  return (
+    <SimilarQuestionsList questions={displayQuestions} variant={variant} />
+  );
 };
 
 export default SimilarQuestionsTab;

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/similar_questions.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/similar_questions.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { FC } from "react";
 
+import LoadingSpinner from "@/components/ui/loading_spiner";
 import ClientPostsApi from "@/services/api/posts/posts.client";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 
@@ -16,33 +17,52 @@ type Props = {
 const SimilarQuestionsTab: FC<Props> = ({ post, variant }) => {
   const isApproved = post.curation_status === PostStatus.APPROVED;
 
-  const { data: similarQuestions = [], isSuccess: hasSimilarQuestionsResult } =
-    useQuery({
-      queryKey: ["similar-posts", post.id],
-      queryFn: () => ClientPostsApi.getSimilarPosts(post.id),
-      enabled: isApproved,
-    });
+  const {
+    data: similarQuestions = [],
+    isSuccess: hasSimilarQuestionsResult,
+    isError: isSimilarError,
+    isLoading: isSimilarLoading,
+  } = useQuery({
+    queryKey: ["similar-posts", post.id],
+    queryFn: () => ClientPostsApi.getSimilarPosts(post.id),
+    enabled: isApproved,
+  });
 
-  const { data: topQuestions = [] } = useQuery({
-    queryKey: ["top-posts-fallback"],
+  const { data: topQuestions = [], isLoading: isTopLoading } = useQuery({
+    queryKey: ["top-posts-fallback", variant],
     queryFn: () =>
       ClientPostsApi.getPostsWithCP({
         topic: "top-50",
         for_main_feed: "false",
+        for_consumer_view: variant === "consumer" ? "true" : "false",
         order_by: "-hotness",
+        statuses: [
+          PostStatus.OPEN,
+          PostStatus.CLOSED,
+          PostStatus.RESOLVED,
+          PostStatus.UPCOMING,
+        ],
         limit: 8,
       }),
-    // only fetch when similar posts query settled with no results
+    // only fetch when similar posts query settled with no results or errored
     enabled:
-      !isApproved || (hasSimilarQuestionsResult && !similarQuestions.length),
+      !isApproved ||
+      isSimilarError ||
+      (hasSimilarQuestionsResult && !similarQuestions.length),
     select: (data) => data.results.filter((q) => q.id !== post.id),
+    staleTime: 5 * 60 * 1000,
   });
 
   const displayQuestions = similarQuestions.length
     ? similarQuestions
     : topQuestions;
 
-  if (!displayQuestions.length) return null;
+  if (!displayQuestions.length) {
+    if (isSimilarLoading || isTopLoading) {
+      return <LoadingSpinner className="my-4" />;
+    }
+    return null;
+  }
 
   return (
     <SimilarQuestionsList questions={displayQuestions} variant={variant} />

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/similar_questions.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/similar_questions.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { FC } from "react";
+
+import { PostWithForecasts } from "@/types/post";
+
+import SimilarQuestionsList from "../../sidebar/similar_questions/similar_questions_list";
+
+type Props = {
+  questions: PostWithForecasts[];
+  variant?: "forecaster" | "consumer";
+};
+
+const SimilarQuestionsTab: FC<Props> = ({ questions, variant }) => {
+  if (!questions.length) return null;
+
+  return <SimilarQuestionsList questions={questions} variant={variant} />;
+};
+
+export default SimilarQuestionsTab;

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/similar_questions.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/similar_questions.tsx
@@ -1,18 +1,26 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import { FC } from "react";
 
-import { PostWithForecasts } from "@/types/post";
+import ClientPostsApi from "@/services/api/posts/posts.client";
+import { PostStatus, PostWithForecasts } from "@/types/post";
 
 import SimilarQuestionsList from "../../sidebar/similar_questions/similar_questions_list";
 
 type Props = {
-  questions: PostWithForecasts[];
+  post: PostWithForecasts;
   variant?: "forecaster" | "consumer";
 };
 
-const SimilarQuestionsTab: FC<Props> = ({ questions, variant }) => {
-  if (!questions.length) return null;
+const SimilarQuestionsTab: FC<Props> = ({ post, variant }) => {
+  const { data: questions = [], isFetching } = useQuery({
+    queryKey: ["similar-posts", post.id],
+    queryFn: () => ClientPostsApi.getSimilarPosts(post.id),
+    enabled: post.curation_status === PostStatus.APPROVED,
+  });
+
+  if (isFetching || !questions.length) return null;
 
   return <SimilarQuestionsList questions={questions} variant={variant} />;
 };

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/similar_questions.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/similar_questions.tsx
@@ -14,11 +14,14 @@ type Props = {
 };
 
 const SimilarQuestionsTab: FC<Props> = ({ post, variant }) => {
-  const { data: similarQuestions = [] } = useQuery({
-    queryKey: ["similar-posts", post.id],
-    queryFn: () => ClientPostsApi.getSimilarPosts(post.id),
-    enabled: post.curation_status === PostStatus.APPROVED,
-  });
+  const isApproved = post.curation_status === PostStatus.APPROVED;
+
+  const { data: similarQuestions = [], isSuccess: hasSimilarQuestionsResult } =
+    useQuery({
+      queryKey: ["similar-posts", post.id],
+      queryFn: () => ClientPostsApi.getSimilarPosts(post.id),
+      enabled: isApproved,
+    });
 
   const { data: topQuestions = [] } = useQuery({
     queryKey: ["top-posts-fallback"],
@@ -29,6 +32,9 @@ const SimilarQuestionsTab: FC<Props> = ({ post, variant }) => {
         order_by: "-hotness",
         limit: 8,
       }),
+    // only fetch when similar posts query settled with no results
+    enabled:
+      !isApproved || (hasSimilarQuestionsResult && !similarQuestions.length),
     select: (data) => data.results.filter((q) => q.id !== post.id),
   });
 

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/timeline.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/timeline.tsx
@@ -12,7 +12,6 @@ const TimelineTab: FC<Props> = ({ post }) => (
   <QuestionTimeline
     postData={post}
     keyFactors={post.key_factors}
-    hideTitle
     isConsumerView
   />
 );

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/timeline.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/timeline.tsx
@@ -1,0 +1,20 @@
+import { FC } from "react";
+
+import { PostWithForecasts } from "@/types/post";
+
+import QuestionTimeline from "../../question_view/consumer_question_view/timeline";
+
+type Props = {
+  post: PostWithForecasts;
+};
+
+const TimelineTab: FC<Props> = ({ post }) => (
+  <QuestionTimeline
+    postData={post}
+    keyFactors={post.key_factors}
+    hideTitle
+    isConsumerView
+  />
+);
+
+export default TimelineTab;

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
@@ -41,7 +41,7 @@ const TitleRow: FC<Props> = ({ post, variant, className }) => {
       >
         <div className="flex flex-1 flex-col">
           <div className="lg:order-0 order-1 flex items-center">
-            <QuestionTitle className="text-2xl font-bold tracking-tight sm:text-3xl lg:text-4xl">
+            <QuestionTitle className="text-xl font-bold leading-tight tracking-[-0.4px] text-blue-800 sm:text-3xl sm:tracking-tight lg:text-4xl dark:text-blue-800-dark">
               {post.title}
             </QuestionTitle>
             <div className="md:hidden">

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
@@ -41,7 +41,7 @@ const TitleRow: FC<Props> = ({ post, variant, className }) => {
       >
         <div className="flex flex-1 flex-col">
           <div className="lg:order-0 order-1 flex items-center">
-            <QuestionTitle className="text-xl font-bold leading-tight tracking-[-0.4px] text-blue-800 sm:text-3xl sm:tracking-tight lg:text-4xl dark:text-blue-800-dark">
+            <QuestionTitle className="text-xl font-bold leading-tight tracking-[-0.4px] text-blue-800 dark:text-blue-800-dark sm:text-3xl sm:tracking-tight lg:text-4xl">
               {post.title}
             </QuestionTitle>
             <div className="md:hidden">
@@ -69,7 +69,7 @@ const TitleRow: FC<Props> = ({ post, variant, className }) => {
     <QuestionTitle
       className={cn(
         "text-2xl font-bold tracking-tight sm:text-3xl lg:text-4xl",
-        variant === "consumer" && "text-center md:text-left",
+        variant === "consumer" && "pr-0 text-center md:text-left",
         className
       )}
     >

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
@@ -69,6 +69,7 @@ const TitleRow: FC<Props> = ({ post, variant, className }) => {
     <QuestionTitle
       className={cn(
         "text-2xl font-bold tracking-tight sm:text-3xl lg:text-4xl",
+        variant === "consumer" && "text-center md:text-left",
         className
       )}
     >

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/action_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/action_row.tsx
@@ -70,7 +70,7 @@ const ActionRow: FC<Props> = ({ post, variant }) => {
   return (
     <div
       className={cn(
-        "relative w-full flex-wrap items-center gap-2 py-3",
+        "relative w-full flex-wrap items-center gap-2 pb-3 pt-1 md:py-3",
         variant === "forecaster"
           ? "hidden md:flex"
           : "flex justify-center md:justify-start"

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/group_of_questions_prediction/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/group_of_questions_prediction/index.tsx
@@ -56,10 +56,17 @@ const GroupOfQuestionsPrediction: React.FC<Props> = ({ postData }) => {
     }
   } else if (checkGroupOfQuestionsPostType(postData, QuestionType.Date)) {
     content = (
-      <DateForecastCard
-        post={postData}
-        questionsGroup={postData.group_of_questions}
-      />
+      <>
+        <div className="sm:hidden">
+          <NumericForecastCard post={postData} />
+        </div>
+        <div className="hidden sm:block">
+          <DateForecastCard
+            post={postData}
+            questionsGroup={postData.group_of_questions}
+          />
+        </div>
+      </>
     );
   }
 
@@ -70,7 +77,7 @@ const GroupOfQuestionsPrediction: React.FC<Props> = ({ postData }) => {
     postData.group_of_questions?.graph_type ===
       GroupOfQuestionsGraphType.FanGraph
       ? "mb-7"
-      : "mt-7";
+      : "md:mt-7";
 
   return <div className={wrapperClass}>{content}</div>;
 };

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/group_of_questions_prediction/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/group_of_questions_prediction/index.tsx
@@ -76,7 +76,7 @@ const GroupOfQuestionsPrediction: React.FC<Props> = ({ postData }) => {
     checkGroupOfQuestionsPostType(postData, QuestionType.Date) ||
     postData.group_of_questions?.graph_type ===
       GroupOfQuestionsGraphType.FanGraph
-      ? "mb-7"
+      ? "md:mb-7"
       : "md:mt-7";
 
   return <div className={wrapperClass}>{content}</div>;

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/group_of_questions_prediction/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/group_of_questions_prediction/index.tsx
@@ -56,17 +56,10 @@ const GroupOfQuestionsPrediction: React.FC<Props> = ({ postData }) => {
     }
   } else if (checkGroupOfQuestionsPostType(postData, QuestionType.Date)) {
     content = (
-      <>
-        <div className="sm:hidden">
-          <NumericForecastCard post={postData} />
-        </div>
-        <div className="hidden sm:block">
-          <DateForecastCard
-            post={postData}
-            questionsGroup={postData.group_of_questions}
-          />
-        </div>
-      </>
+      <DateForecastCard
+        post={postData}
+        questionsGroup={postData.group_of_questions}
+      />
     );
   }
 

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/binary_question_prediction.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/binary_question_prediction.tsx
@@ -56,7 +56,7 @@ const BinaryQuestionPrediction: React.FC<Props> = ({
   );
 
   return (
-    <div className="mx-auto mb-0 space-y-7 pt-5 lg:mb-7 lg:px-10">
+    <div className="mx-auto mb-0 space-y-7 md:pt-5 lg:mb-7 lg:px-10">
       <PredictionBinaryInfo
         showMyPrediction
         question={question}

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
@@ -36,7 +36,7 @@ const ContinuousQuestionPrediction: React.FC<Props> = ({
       />
       {!shouldHideChart && (
         <>
-          <div className="w-full overflow-visible pb-1 md:pt-4 md:pb-4">
+          <div className="w-full overflow-visible pb-1 md:pb-4 md:pt-4">
             <div className="origin-center transform-gpu md:scale-150">
               <MinifiedContinuousAreaChart
                 question={question}

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
@@ -36,7 +36,7 @@ const ContinuousQuestionPrediction: React.FC<Props> = ({
       />
       {!shouldHideChart && (
         <>
-          <div className="w-full overflow-visible pb-1 pt-4 md:pb-4">
+          <div className="w-full overflow-visible pb-1 md:pt-4 md:pb-4">
             <div className="origin-center scale-125 transform-gpu md:scale-150">
               <MinifiedContinuousAreaChart
                 question={question}

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
@@ -37,7 +37,7 @@ const ContinuousQuestionPrediction: React.FC<Props> = ({
       {!shouldHideChart && (
         <>
           <div className="w-full overflow-visible pb-1 md:pt-4 md:pb-4">
-            <div className="origin-center scale-125 transform-gpu md:scale-150">
+            <div className="origin-center transform-gpu md:scale-150">
               <MinifiedContinuousAreaChart
                 question={question}
                 data={continuousAreaChartData}

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/timeline/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/timeline/index.tsx
@@ -35,11 +35,7 @@ const QuestionTimeline: React.FC<Props> = ({
   const isFanGraph =
     postData.group_of_questions?.graph_type ===
     GroupOfQuestionsGraphType.FanGraph;
-  const wrapperClass = cn(
-    " hidden sm:block",
-    isFanGraph ? "mb-8" : "mt-8",
-    className
-  );
+  const wrapperClass = cn(isFanGraph ? "mb-8" : "mt-8", className);
 
   if (isQuestionPost(postData)) {
     if (postData.question.status !== QuestionStatus.UPCOMING) {

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/timeline/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/timeline/index.tsx
@@ -62,7 +62,27 @@ const QuestionTimeline: React.FC<Props> = ({
     return (
       <div className={wrapperClass}>
         {isDateType ? (
-          <NumericForecastCard post={postData} forceColorful />
+          <div className="flex flex-col gap-6">
+            <DetailedGroupCard
+              post={postData}
+              preselectedQuestionId={preselectedGroupQuestionId}
+            />
+            <NumericForecastCard post={postData} forceColorful />
+          </div>
+        ) : isFanGraph ? (
+          <div className="flex flex-col gap-6">
+            <DetailedGroupCard
+              post={postData}
+              preselectedQuestionId={preselectedGroupQuestionId}
+              groupPresentationOverride={
+                GroupOfQuestionsGraphType.MultipleChoiceGraph
+              }
+            />
+            <DetailedGroupCard
+              post={postData}
+              preselectedQuestionId={preselectedGroupQuestionId}
+            />
+          </div>
         ) : (
           <DetailedGroupCard
             post={postData}

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/index.tsx
@@ -1,6 +1,7 @@
 import dynamic from "next/dynamic";
 import { FC, Suspense } from "react";
 
+import LoadingSpinner from "@/components/ui/loading_spiner";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 
 import SidebarContainer from "./sidebar_container";
@@ -34,7 +35,7 @@ const Sidebar: FC<Props> = ({
       )}
 
       {postData.curation_status === PostStatus.APPROVED && (
-        <Suspense fallback={null}>
+        <Suspense fallback={<LoadingSpinner className="my-4" />}>
           <SimilarQuestions post_id={postData.id} variant={variant} />
         </Suspense>
       )}

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/index.tsx
@@ -20,21 +20,7 @@ const Sidebar: FC<Props> = ({
   variant = "forecaster",
 }) => {
   if (layout === "mobile") {
-    return (
-      <section className="flex flex-col gap-4 lg:hidden">
-        {variant === "forecaster" && (
-          <SidebarContainer>
-            <SidebarQuestionInfo postData={postData} />
-          </SidebarContainer>
-        )}
-
-        {postData.curation_status === PostStatus.APPROVED && (
-          <Suspense fallback={null}>
-            <SimilarQuestions post_id={postData.id} variant={variant} />
-          </Suspense>
-        )}
-      </section>
-    );
+    return null;
   }
 
   return (

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/index.tsx
@@ -2,6 +2,7 @@ import { FC } from "react";
 
 import WithServerComponentErrorBoundary from "@/components/server_component_error_boundary";
 import ServerPostsApi from "@/services/api/posts/posts.server";
+import { PostStatus } from "@/types/post";
 
 import SimilarQuestionsList from "./similar_questions_list";
 
@@ -17,7 +18,14 @@ const SimilarQuestions: FC<Props> = async ({ post_id, variant }) => {
     const { results } = await ServerPostsApi.getPostsWithCP({
       topic: "top-50",
       for_main_feed: "false",
+      for_consumer_view: variant === "consumer" ? "true" : "false",
       order_by: "-hotness",
+      statuses: [
+        PostStatus.OPEN,
+        PostStatus.CLOSED,
+        PostStatus.RESOLVED,
+        PostStatus.UPCOMING,
+      ],
       limit: 8,
     });
     questions = results.filter((q) => q.id !== post_id);

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/index.tsx
@@ -11,7 +11,17 @@ type Props = {
 };
 
 const SimilarQuestions: FC<Props> = async ({ post_id, variant }) => {
-  const questions = await ServerPostsApi.getSimilarPosts(post_id);
+  let questions = await ServerPostsApi.getSimilarPosts(post_id);
+
+  if (!questions.length) {
+    const { results } = await ServerPostsApi.getPostsWithCP({
+      topic: "top-50",
+      for_main_feed: "false",
+      order_by: "-hotness",
+      limit: 8,
+    });
+    questions = results.filter((q) => q.id !== post_id);
+  }
 
   if (!questions.length) return null;
 

--- a/front_end/src/components/charts/group_chart.tsx
+++ b/front_end/src/components/charts/group_chart.tsx
@@ -376,7 +376,7 @@ const GroupChart: FC<Props> = ({
                         setLocalCursorTimestamp(null);
                       }
                     },
-                    onMouseLeaveCapture: () => {
+                    onMouseLeave: () => {
                       if (!onCursorChange) return;
                       inPlotRef.current = false;
                       setIsCursorActive(false);

--- a/front_end/src/components/charts/primitives/x_tick_label.tsx
+++ b/front_end/src/components/charts/primitives/x_tick_label.tsx
@@ -20,18 +20,20 @@ const XTickLabel: FC<Props> = ({
 
   const x = (props.x ?? 0) + dx;
 
-  const overlapsRightEdge = withCursor
-    ? x > chartWidth - estimatedTextWidth
-    : x > chartWidth - 12;
-
-  if (overlapsRightEdge) {
-    return null;
+  let textAnchor: "start" | "middle" | "end" = "middle";
+  if (x - estimatedTextWidth < 0) {
+    textAnchor = "start";
+  } else if (
+    withCursor ? x > chartWidth - estimatedTextWidth : x > chartWidth - 12
+  ) {
+    textAnchor = "end";
   }
 
   return (
     <VictoryLabel
       {...props}
       dx={dx}
+      textAnchor={textAnchor}
       style={{
         ...(props.style ?? {}),
         fontSize,

--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -965,6 +965,7 @@ const Comment: FC<CommentProps> = ({
                     withUgcLinks
                     withTwitterPreview
                     withCodeBlocks
+                    contentEditableClassName="text-base font-normal leading-6 [&_p]:!text-gray-700 dark:[&_p]:!text-gray-700-dark [&_ul]:!text-gray-700 dark:[&_ul]:!text-gray-700-dark [&_ol]:!text-gray-700 dark:[&_ol]:!text-gray-700-dark"
                   />
                 )}
                 {commentKeyFactors.length > 0 &&

--- a/front_end/src/components/comment_feed/index.tsx
+++ b/front_end/src/components/comment_feed/index.tsx
@@ -427,7 +427,7 @@ const CommentFeed: FC<Props> = ({
           <DropdownMenu items={menuItems} itemClassName={"capitalize"}>
             <Button
               variant="text"
-              className="text-sm font-medium capitalize leading-5 text-blue-800 dark:text-blue-800-dark"
+              className="py-0 text-sm font-medium capitalize leading-5 text-blue-800 dark:text-blue-800-dark"
             >
               {menuItems.find((item) => item.id === feedFilters.sort)?.name ??
                 "sort"}

--- a/front_end/src/components/comment_feed/index.tsx
+++ b/front_end/src/components/comment_feed/index.tsx
@@ -410,7 +410,7 @@ const CommentFeed: FC<Props> = ({
             )}
           </div>
         )}
-        <div className="mb-5 flex flex-row items-center justify-start gap-1">
+        <div className="mb-4 flex flex-row items-center justify-start gap-1 md:mb-5">
           <span className="text-sm font-medium leading-5 text-gray-600 dark:text-gray-600-dark">
             {totalCount ? `${totalCount} ` : ""}
             {t("commentsWithCount", { count: totalCount })}
@@ -453,7 +453,7 @@ const CommentFeed: FC<Props> = ({
             )}
           </>
         )}
-        <div className="mt-5 flex flex-col gap-5">
+        <div className="mt-4 flex flex-col gap-4 md:mt-5 md:gap-5">
           {comments.map((comment: CommentType) => (
             <CommentWrapper
               key={comment.id}

--- a/front_end/src/components/post_card/basic_post_card/post_voter.tsx
+++ b/front_end/src/components/post_card/basic_post_card/post_voter.tsx
@@ -80,7 +80,7 @@ const PostVoter: FC<Props> = ({ className, post, questionPage, compact }) => {
       {vote.score != null && vote.score !== 0 && (
         <span
           className={cn(
-            "font-normal leading-4 text-gray-700 dark:text-gray-700-dark",
+            "font-normal leading-4 text-gray-700 dark:text-gray-700-dark md:text-sm",
             compact ? "text-xs" : "text-sm"
           )}
         >

--- a/front_end/src/components/ui/section_toggle.tsx
+++ b/front_end/src/components/ui/section_toggle.tsx
@@ -120,8 +120,8 @@ const iconVariants = cva("h-4 duration-75 ease-linear print:hidden", {
       dark: "text-blue-900 dark:text-blue-900-dark",
     },
     open: {
-      true: "rotate-180",
-      false: null,
+      true: null,
+      false: "-rotate-90",
     },
   },
   defaultVariants: {

--- a/posts/views.py
+++ b/posts/views.py
@@ -242,7 +242,7 @@ def post_detail(request: Request, pk):
         include_cp_history=True,
         include_movements=True,
         include_average_scores=True,
-        include_user_forecasts=True
+        include_user_forecasts=True,
     )
 
     if not posts:


### PR DESCRIPTION
Related to #4638

This PR introduces a full mobile styling and layout parity pass for both the consumer and forecaster question page views.

Implemented features & fixes:

- `Consumer mobile typography`: question title centered/bold/gray-700 on mobile, scales to blue-800 at md+; comment count badge gets `font-bold` on mobile
- `Forecaster mobile typography`: question title adjusted size/weight/tracking/color on mobile, scales up at sm+; vote count badge adjusted size on mobile only
- `Forecast Timeline label` restored across all views and screen sizes (removed `hideTitle` from `ForecasterShell`, `ConsumerShell`, and `TimelineTab`)
- `Timeline tab` added to consumer tab bar on mobile only (`< sm`); inline timeline chart remains visible at sm+ next to the prediction block
- `Similar Questions tab` added to both consumer and forecaster tab bars on mobile only (`< sm`, approved posts only); data fetched once on mount in `QuestionPageShellTabs` to avoid re-fetching on tab switch; sidebar author/dates section and Similar Questions removed from mobile layout
- `project_chip_helpers` extracted (`getChipContent`, `getChipColor`) so both `MetaRow` and `QuestionInfoTab` use `TrophyIcon` consistently instead of an emoji string
- `Tab bar mobile sizing`: adjusted pill size and padding with horizontal scroll enabled
- `Section gaps` adjusted between main and comments sections on mobile
- `Prediction block`: top padding removed on mobile for both binary and continuous question types
- `Continuous graph clipping fix`: removed mobile scale to prevent overflow clipping against `overflow-x-clip` on the parent section; desktop scale preserved
- `Consumer title right padding` removed on mobile
- `Key factors section` ordering fixed on mobile; top margin disabled on mobile
- `Action row` ordering on mobile: prediction shown above buttons below sm, full action row in document order at sm+
- `Comment feed`: adjusted header margin and list gap on mobile

### Demo videos

- Consumer view charts 

https://github.com/user-attachments/assets/ae0fb259-1926-4634-bfc1-86cf99fea096

- Consumer responsive view

https://github.com/user-attachments/assets/fcc76cbe-3143-45c3-9941-356e2c2c1aee

- Forecaster view charts

https://github.com/user-attachments/assets/45876d3a-30ee-4bf8-bb45-68ee060583ac

- Forecaster responsive view

https://github.com/user-attachments/assets/2dd32b24-3dcd-4e2e-8a1c-92fa4e770269

- Consumer and forecaster timeline, my scores and similar questions tabs

https://github.com/user-attachments/assets/c75df949-6ece-4b22-9bd1-94c83b891b5c

















<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Similar Questions" and "Timeline" tabs to question pages for better content organization.

* **Bug Fixes**
  * Fixed chart axis labels from being hidden at chart edges; labels now reposition intelligently.

* **Style**
  * Refined responsive spacing and layouts across question pages and comments.
  * Updated section toggle chevron rotation to more clearly indicate open/closed states.
  * Improved comment formatting and styling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->