### PR TITLE
FutureEval: remove trend line blurb and link tournament cards

### DIFF
--- a/front_end/src/app/(futureeval)/futureeval/components/benchmark/performance-over-time/futureeval-benchmark-forecasting-performance.tsx
+++ b/front_end/src/app/(futureeval)/futureeval/components/benchmark/performance-over-time/futureeval-benchmark-forecasting-performance.tsx
@@ -9,7 +9,6 @@ import useAppTheme from "@/hooks/use_app_theme";
 import { BenchmarkChart } from "./benchmark-chart";
 import { BenchmarkChartLegend } from "./benchmark-chart-legend";
 import { safeIndex } from "./helpers";
-import { FE_COLORS, FE_TYPOGRAPHY } from "../../../theme";
 import { FAMILY_METADATA, type Family } from "../../leaderboard/bot_meta";
 import { useFutureEvalLeaderboard } from "../../leaderboard/futureeval-leaderboard-provider";
 
@@ -108,16 +107,6 @@ const FutureEvalBenchmarkForecastingPerformance: React.FC = () => {
         onHoveredPointKeyChange={setHoveredPointKey}
         showProjection={showProjection}
       />
-
-      {communityDate && proDate && (
-        <p
-          className={`mt-4 w-full rounded ${FE_COLORS.bgSecondary} text-balance px-4 py-2.5 text-center ${FE_TYPOGRAPHY.bodySmall} ${FE_COLORS.textSecondary}`}
-        >
-          The trend line indicates that bots will start beating the Metaculus
-          community performance in <strong>{communityDate}</strong> and Pro
-          Forecaster performance in <strong>{proDate}</strong>.
-        </p>
-      )}
     </div>
   );
 };

--- a/front_end/src/app/(futureeval)/futureeval/components/futureeval-methodology-sections.tsx
+++ b/front_end/src/app/(futureeval)/futureeval/components/futureeval-methodology-sections.tsx
@@ -16,7 +16,6 @@ import Button from "@/components/ui/button";
 import cn from "@/utils/core/cn";
 
 import { FE_COLORS, FE_TYPOGRAPHY } from "../theme";
-import { useFutureEvalLeaderboard } from "./leaderboard/futureeval-leaderboard-provider";
 
 const PROMPTS = {
   binary: `You are a professional forecaster interviewing for a job.
@@ -305,9 +304,6 @@ const BulletList: React.FC<{ items: ReactNode[] }> = ({ items }) => {
  * All additional methodology sections
  */
 const FutureEvalMethodologySections: React.FC = () => {
-  const { sotaCrossingDates } = useFutureEvalLeaderboard();
-  const { communityDate, proDate } = sotaCrossingDates;
-
   return (
     <div className="space-y-[60px] sm:space-y-[80px] lg:space-y-[120px]">
       {/* Section 1: What Makes FutureEval Unique */}
@@ -538,14 +534,6 @@ const FutureEvalMethodologySections: React.FC = () => {
             forecast of our first AI model to today. These lines may move as new
             data is added to this running average.
           </p>
-          {communityDate && proDate && (
-            <p className="m-0">
-              The trend line indicates that bots will start beating the
-              Metaculus community performance in{" "}
-              <strong>{communityDate}</strong> and Pro Forecaster performance in{" "}
-              <strong>{proDate}</strong>.
-            </p>
-          )}
         </SectionBody>
       </section>
 

--- a/front_end/src/app/(futureeval)/futureeval/components/futureeval-participate-tab.tsx
+++ b/front_end/src/app/(futureeval)/futureeval/components/futureeval-participate-tab.tsx
@@ -254,6 +254,8 @@ const FutureEvalTournamentOverview: React.FC = () => {
           <Link
             key={t.title}
             href={t.href}
+            target="_blank"
+            rel="noopener noreferrer"
             className={cn(
               "group flex flex-col rounded-[10px] border p-5 no-underline transition hover:-translate-y-0.5 hover:shadow-md",
               t.primary

--- a/front_end/src/app/(futureeval)/futureeval/components/futureeval-participate-tab.tsx
+++ b/front_end/src/app/(futureeval)/futureeval/components/futureeval-participate-tab.tsx
@@ -206,6 +206,7 @@ const FutureEvalTournamentOverview: React.FC = () => {
       description:
         "Our primary tournament with ~4-month seasons starting every January, May, and September, each with 300–500 questions across all formats.",
       primary: true,
+      href: "/tournament/summer-futureeval-2026/",
     },
     {
       icon: faBolt,
@@ -214,6 +215,7 @@ const FutureEvalTournamentOverview: React.FC = () => {
       description:
         "Back-to-back 2-week rounds of ~60 auto-generated questions, designed for fast feedback loops and lowering the barrier to entry.",
       primary: true,
+      href: "/tournament/minibench/",
     },
     {
       icon: faChartLine,
@@ -222,6 +224,7 @@ const FutureEvalTournamentOverview: React.FC = () => {
       description:
         "Bots compete for prizes by continuously updating forecasts on numeric group questions throughout each question's lifetime.",
       primary: false,
+      href: "/tournament/market-pulse-26q2/",
     },
     {
       icon: faUsers,
@@ -230,6 +233,7 @@ const FutureEvalTournamentOverview: React.FC = () => {
       description:
         "Test your bot against human forecasters on diverse questions — bots aren't prize-eligible but it's a great strength benchmark.",
       primary: false,
+      href: "/tournament/metaculus-cup-summer-2026/",
     },
   ] as const;
 
@@ -247,10 +251,11 @@ const FutureEvalTournamentOverview: React.FC = () => {
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {tournaments.map((t) => (
-          <div
+          <Link
             key={t.title}
+            href={t.href}
             className={cn(
-              "flex flex-col rounded-[10px] border p-5",
+              "group flex flex-col rounded-[10px] border p-5 no-underline transition hover:-translate-y-0.5 hover:shadow-md",
               t.primary
                 ? cn(
                     FE_COLORS.borderPrimary,
@@ -291,7 +296,7 @@ const FutureEvalTournamentOverview: React.FC = () => {
             >
               {t.description}
             </p>
-          </div>
+          </Link>
         ))}
       </div>
 


### PR DESCRIPTION
Closes #4685

## Summary
- Remove the "The trend line indicates" blurb from the FutureEval page (Performance Over Time chart and Methodology section).
- Make the four tournament cards under the Participate tab link to the actual tournaments (Seasonal Bot Tournament, MiniBench, Market Pulse, Metaculus Cup).

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tournament cards are now clickable and open their respective tournament pages in a new tab.

* **Bug Fixes**
  * Removed date-specific predictive statements and an explanatory paragraph from performance analysis sections for clearer, simplified wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->