### PR TITLE
fix: start Community Prediction at question open_time

### DIFF
--- a/tests/unit/test_utils/test_the_math/test_aggregations.py
+++ b/tests/unit/test_utils/test_the_math/test_aggregations.py
@@ -1007,3 +1007,112 @@ class TestGetAggregationHistoryCutoff:
         assert len(aggregations) == 1
         assert aggregations[0].end_time is None
         assert aggregations[0].forecaster_count == 2
+
+
+class TestGetAggregationHistoryPreOpen:
+    @pytest.mark.django_db
+    def test_cp_starts_at_open_time_with_pre_predictions(
+        self, question_binary: Question
+    ):
+        from datetime import timedelta
+        from unittest.mock import patch
+        from questions.models import Forecast
+        from utils.the_math.aggregations import get_aggregation_history
+
+        open_time = datetime(2025, 1, 1, tzinfo=dt_timezone.utc)
+        scheduled_close = datetime(2025, 6, 1, tzinfo=dt_timezone.utc)
+        actual_close = datetime(2025, 6, 1, tzinfo=dt_timezone.utc)
+        fake_now = datetime(2025, 7, 1, tzinfo=dt_timezone.utc)
+
+        question_binary.open_time = open_time
+        question_binary.scheduled_close_time = scheduled_close
+        question_binary.actual_close_time = actual_close
+        question_binary.save()
+
+        user_a = User.objects.create(username="preopen_user_a")
+        user_b = User.objects.create(username="preopen_user_b")
+
+        # User A pre-predicts before the question opens
+        Forecast.objects.create(
+            question=question_binary,
+            author=user_a,
+            probability_yes=0.7,
+            start_time=open_time - timedelta(days=30),
+            end_time=None,
+        )
+        # User B predicts a month after open
+        Forecast.objects.create(
+            question=question_binary,
+            author=user_b,
+            probability_yes=0.3,
+            start_time=open_time + timedelta(days=30),
+            end_time=None,
+        )
+
+        with patch("utils.the_math.aggregations.timezone.now", return_value=fake_now):
+            result = get_aggregation_history(
+                question=question_binary,
+                aggregation_methods=["recency_weighted"],
+                minimize=False,
+            )
+
+        aggregations = result["recency_weighted"]
+        # The CP timeline should start at open_time, not before
+        assert len(aggregations) == 2
+        assert aggregations[0].start_time == open_time
+        assert aggregations[0].forecaster_count == 1
+        assert aggregations[1].start_time == open_time + timedelta(days=30)
+        assert aggregations[1].forecaster_count == 2
+
+    @pytest.mark.django_db
+    def test_pre_prediction_ending_before_open_time_excluded(
+        self, question_binary: Question
+    ):
+        from datetime import timedelta
+        from unittest.mock import patch
+        from questions.models import Forecast
+        from utils.the_math.aggregations import get_aggregation_history
+
+        open_time = datetime(2025, 1, 1, tzinfo=dt_timezone.utc)
+        scheduled_close = datetime(2025, 6, 1, tzinfo=dt_timezone.utc)
+        actual_close = datetime(2025, 6, 1, tzinfo=dt_timezone.utc)
+        fake_now = datetime(2025, 7, 1, tzinfo=dt_timezone.utc)
+
+        question_binary.open_time = open_time
+        question_binary.scheduled_close_time = scheduled_close
+        question_binary.actual_close_time = actual_close
+        question_binary.save()
+
+        user_a = User.objects.create(username="preopen_user_a")
+        user_b = User.objects.create(username="preopen_user_b")
+
+        # User A pre-predicts and the prediction ends before the question opens
+        Forecast.objects.create(
+            question=question_binary,
+            author=user_a,
+            probability_yes=0.7,
+            start_time=open_time - timedelta(days=30),
+            end_time=open_time - timedelta(days=10),
+        )
+        # User B predicts after open
+        Forecast.objects.create(
+            question=question_binary,
+            author=user_b,
+            probability_yes=0.3,
+            start_time=open_time + timedelta(days=30),
+            end_time=None,
+        )
+
+        with patch("utils.the_math.aggregations.timezone.now", return_value=fake_now):
+            result = get_aggregation_history(
+                question=question_binary,
+                aggregation_methods=["recency_weighted"],
+                minimize=False,
+            )
+
+        aggregations = result["recency_weighted"]
+        # User A's pre-prediction ended before open_time, so the CP should
+        # only have one entry starting when user B predicts
+        assert len(aggregations) == 1
+        assert aggregations[0].start_time == open_time + timedelta(days=30)
+        assert aggregations[0].forecaster_count == 1

--- a/utils/the_math/aggregations.py
+++ b/utils/the_math/aggregations.py
@@ -935,11 +935,7 @@ def get_user_forecast_history(
 
     timestep_set: set[datetime] = set()
     for forecast in forecasts:
-        if (
-            earliest_time
-            and forecast.end_time
-            and forecast.end_time <= earliest_time
-        ):
+        if earliest_time and forecast.end_time and forecast.end_time <= earliest_time:
             continue
         timestep_set.add(get_effective_start(forecast))
         if forecast.end_time:
@@ -961,11 +957,7 @@ def get_user_forecast_history(
         for timestep in timesteps
     }
     for forecast in forecasts:
-        if (
-            earliest_time
-            and forecast.end_time
-            and forecast.end_time <= earliest_time
-        ):
+        if earliest_time and forecast.end_time and forecast.end_time <= earliest_time:
             continue
         # Find active timesteps using bisect to find the start & end indexes
         start_index = bisect_left(timesteps, get_effective_start(forecast))

--- a/utils/the_math/aggregations.py
+++ b/utils/the_math/aggregations.py
@@ -923,10 +923,25 @@ def get_user_forecast_history(
     forecasts: Sequence[Forecast],
     minimize: bool | int = False,
     cutoff: datetime | None = None,
+    earliest_time: datetime | None = None,
 ) -> list[ForecastSet]:
+    # When earliest_time is set, forecasts that started earlier are treated as
+    # if they started at earliest_time (clipping pre-open predictions to the
+    # question's open_time so the CP timeline begins at open_time).
+    def get_effective_start(forecast: Forecast) -> datetime:
+        if earliest_time and forecast.start_time < earliest_time:
+            return earliest_time
+        return forecast.start_time
+
     timestep_set: set[datetime] = set()
     for forecast in forecasts:
-        timestep_set.add(forecast.start_time)
+        if (
+            earliest_time
+            and forecast.end_time
+            and forecast.end_time <= earliest_time
+        ):
+            continue
+        timestep_set.add(get_effective_start(forecast))
         if forecast.end_time:
             if cutoff and forecast.end_time > cutoff:
                 continue
@@ -946,8 +961,14 @@ def get_user_forecast_history(
         for timestep in timesteps
     }
     for forecast in forecasts:
+        if (
+            earliest_time
+            and forecast.end_time
+            and forecast.end_time <= earliest_time
+        ):
+            continue
         # Find active timesteps using bisect to find the start & end indexes
-        start_index = bisect_left(timesteps, forecast.start_time)
+        start_index = bisect_left(timesteps, get_effective_start(forecast))
         end_index = (
             bisect_left(timesteps, forecast.end_time)
             if forecast.end_time
@@ -1005,16 +1026,48 @@ def get_aggregation_history(
         )
 
     with sentry_sdk.start_span(op="compute", name="get_user_forecast_history"):
-        forecast_history = get_user_forecast_history(forecasts, minimize, cutoff=cutoff)
+        forecast_history = get_user_forecast_history(
+            forecasts,
+            minimize,
+            cutoff=cutoff,
+            earliest_time=question.open_time,
+        )
 
     forecaster_ids = set(forecast.author_id for forecast in forecasts)
     for method in aggregation_methods:
         if method == "geometric_mean":
             if minimize:
                 continue  # gomean is useless minimized
-            from scoring.score_math import get_geometric_means
+            from scoring.score_math import AggregationEntry, get_geometric_means
 
             geometric_means = get_geometric_means(forecasts)
+            open_timestamp = (
+                question.open_time.timestamp() if question.open_time else None
+            )
+            if open_timestamp is not None:
+                # Clip pre-open entries: keep only post-open entries, but
+                # carry the most recent pre-open state forward as a synthetic
+                # entry at open_time so the CP timeline begins at open_time.
+                last_pre_open: AggregationEntry | None = None
+                post_open: list[AggregationEntry] = []
+                for gm in geometric_means:
+                    if gm.timestamp < open_timestamp:
+                        last_pre_open = gm
+                    else:
+                        post_open.append(gm)
+                if last_pre_open is not None and (
+                    not post_open or post_open[0].timestamp > open_timestamp
+                ):
+                    geometric_means = [
+                        AggregationEntry(
+                            pmf=last_pre_open.pmf,
+                            num_forecasters=last_pre_open.num_forecasters,
+                            timestamp=open_timestamp,
+                        ),
+                        *post_open,
+                    ]
+                else:
+                    geometric_means = post_open
             full_summary[method] = []
             previous_forecast = None
             for gm in geometric_means:


### PR DESCRIPTION
Pre-predictions made before the question opens were being included in the CP timeline, causing it to start before open_time. Now clip pre-open forecasts so the CP timeline begins at the question's open_time, while still incorporating the most recent pre-open forecast state from each user that is still active at open_time.