### PR TITLE
Live cursor updates the side-by-side left card

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -235,7 +235,7 @@ export const ConsumerShell: FC<{
               <QuestionTimeline
                 postData={postData}
                 keyFactors={postData.key_factors}
-                isConsumerView={!isContinuousSingleQuestion}
+                isConsumerView={true}
                 preselectedGroupQuestionId={preselectedGroupQuestionId}
                 className={cn(
                   "hidden sm:block",

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -9,6 +9,7 @@ import DetailedGroupCard from "@/components/detailed_question_card/detailed_grou
 import DetailedQuestionCard from "@/components/detailed_question_card/detailed_question_card";
 import ForecastMaker from "@/components/forecast_maker";
 import CommunityDisclaimer from "@/components/post_card/community_disclaimer";
+import { ContinuousChartCursorProvider } from "@/contexts/continuous_chart_cursor_context";
 import { useContentTranslatedBannerContext } from "@/contexts/translations_banner_context";
 import {
   GroupOfQuestionsGraphType,
@@ -280,11 +281,14 @@ const QuestionPageShell: FC<Props> = ({
     <QuestionLayoutProvider>
       <QuestionVariantComposer
         consumer={
-          <ConsumerShell
-            postData={postData}
-            preselectedGroupQuestionId={preselectedGroupQuestionId}
-            mobileSidebar={mobileSidebar}
-          />
+          <ContinuousChartCursorProvider>
+            {/* Bridges timeline cursor to the mobile mini chart in consumer view */}
+            <ConsumerShell
+              postData={postData}
+              preselectedGroupQuestionId={preselectedGroupQuestionId}
+              mobileSidebar={mobileSidebar}
+            />
+          </ContinuousChartCursorProvider>
         }
         forecaster={
           <ForecasterShell

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import { getContinuousAreaChartData } from "@/components/charts/continuous_area_chart";
+import {
+  ContinuousAreaGraphInput,
+  getContinuousAreaChartData,
+} from "@/components/charts/continuous_area_chart";
 import MinifiedContinuousAreaChart from "@/components/charts/minified_continuous_area_chart";
 import ConsumerContinuousTile from "@/components/consumer_post_card/consumer_question_tile/consumer_continuous_tile";
+import { useContinuousChartCursor } from "@/contexts/continuous_chart_cursor_context";
+import { ContinuousAreaType } from "@/types/charts";
 import { QuestionStatus } from "@/types/post";
 import { QuestionWithNumericForecasts } from "@/types/question";
+import { cdfToPmf } from "@/utils/math";
 import { getQuestionForecastAvailability } from "@/utils/questions/forecastAvailability";
 
 type Props = {
@@ -17,6 +23,8 @@ const ContinuousQuestionPrediction: React.FC<Props> = ({
   chartHeight,
 }) => {
   const forecastAvailability = getQuestionForecastAvailability(question);
+  const cursorCtx = useContinuousChartCursor();
+  const cursorForecast = cursorCtx?.activeForecast ?? null;
 
   // Hide chart if no forecasts or CP not yet revealed
   const shouldHideChart =
@@ -27,12 +35,27 @@ const ContinuousQuestionPrediction: React.FC<Props> = ({
     isClosed: question.status === QuestionStatus.CLOSED,
   });
 
+  // Null when cursor is inactive — chart falls back to the latest aggregate.
+  const cursorChartData: ContinuousAreaGraphInput | null =
+    cursorForecast?.forecast_values
+      ? [
+          {
+            pmf: cdfToPmf(cursorForecast.forecast_values),
+            cdf: cursorForecast.forecast_values,
+            type: (question.status === QuestionStatus.CLOSED
+              ? "community_closed"
+              : "community") as ContinuousAreaType,
+          },
+        ]
+      : null;
+
   return (
     <div className="mx-auto mb-7 flex max-w-[340px] flex-col items-center gap-2.5">
       <ConsumerContinuousTile
         question={question}
         forecastAvailability={forecastAvailability}
         variant="question"
+        overrideCenter={cursorForecast?.centers?.[0] ?? null}
       />
       {!shouldHideChart && (
         <>
@@ -40,7 +63,7 @@ const ContinuousQuestionPrediction: React.FC<Props> = ({
             <div className="origin-center transform-gpu md:scale-150">
               <MinifiedContinuousAreaChart
                 question={question}
-                data={continuousAreaChartData}
+                data={cursorChartData ?? continuousAreaChartData}
                 height={chartHeight ?? 50}
                 forceTickCount={2}
                 variant="question"

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useMemo } from "react";
+
 import {
   ContinuousAreaGraphInput,
   getContinuousAreaChartData,
@@ -35,19 +37,21 @@ const ContinuousQuestionPrediction: React.FC<Props> = ({
     isClosed: question.status === QuestionStatus.CLOSED,
   });
 
+  const cursorForecastValues = cursorForecast?.forecast_values ?? null;
+
   // Null when cursor is inactive — chart falls back to the latest aggregate.
-  const cursorChartData: ContinuousAreaGraphInput | null =
-    cursorForecast?.forecast_values
-      ? [
-          {
-            pmf: cdfToPmf(cursorForecast.forecast_values),
-            cdf: cursorForecast.forecast_values,
-            type: (question.status === QuestionStatus.CLOSED
-              ? "community_closed"
-              : "community") as ContinuousAreaType,
-          },
-        ]
-      : null;
+  const cursorChartData = useMemo<ContinuousAreaGraphInput | null>(() => {
+    if (!cursorForecastValues) return null;
+    return [
+      {
+        pmf: cdfToPmf(cursorForecastValues),
+        cdf: cursorForecastValues,
+        type: (question.status === QuestionStatus.CLOSED
+          ? "community_closed"
+          : "community") as ContinuousAreaType,
+      },
+    ];
+  }, [cursorForecastValues, question.status]);
 
   return (
     <div className="mx-auto mb-7 flex max-w-[340px] flex-col items-center gap-2.5">

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useLocale, useTranslations } from "next-intl";
-import React, { FC } from "react";
+import React, { FC, useMemo } from "react";
 import { VictoryThemeDefinition } from "victory";
 
 import {
@@ -69,6 +69,22 @@ const QuestionHeaderCPStatus: FC<Props> = ({
   const isEmbedBelow376 = isEmbed && (w ?? 0) > 0 && (w ?? 0) < 376;
   const isEmbedWide = isEmbed && (w ?? 0) >= 500;
 
+  const cursorForecastValues = cursorForecast?.forecast_values ?? null;
+  const cursorAreaChartData = useMemo<ContinuousAreaGraphInput | null>(() => {
+    if (!cursorForecastValues) return null;
+    return [
+      {
+        pmf: cdfToPmf(cursorForecastValues),
+        cdf: cursorForecastValues,
+        type: (question.status === QuestionStatus.RESOLVED
+          ? "community_resolved"
+          : question.status === QuestionStatus.CLOSED
+            ? "community_closed"
+            : "community") as ContinuousAreaType,
+      },
+    ];
+  }, [cursorForecastValues, question.status]);
+
   if (question.status === QuestionStatus.RESOLVED && question.resolution) {
     // Resolved/Annulled/Ambiguous
     const formatedResolution = formatResolution({
@@ -118,20 +134,6 @@ const QuestionHeaderCPStatus: FC<Props> = ({
   const cursorCenter = cursorForecast?.centers?.[0] ?? null;
   const cursorLower = cursorForecast?.interval_lower_bounds?.[0] ?? null;
   const cursorUpper = cursorForecast?.interval_upper_bounds?.[0] ?? null;
-  const cursorAreaChartData: ContinuousAreaGraphInput | null =
-    cursorForecast?.forecast_values
-      ? [
-          {
-            pmf: cdfToPmf(cursorForecast.forecast_values),
-            cdf: cursorForecast.forecast_values,
-            type: (question.status === QuestionStatus.RESOLVED
-              ? "community_resolved"
-              : question.status === QuestionStatus.CLOSED
-                ? "community_closed"
-                : "community") as ContinuousAreaType,
-          },
-        ]
-      : null;
 
   if (isContinuous) {
     return (

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
@@ -8,17 +8,26 @@ import {
   useIsEmbedMode,
 } from "@/app/(embed)/questions/components/question_view_mode_context";
 import QuestionHeaderContinuousResolutionChip from "@/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_continuous_resolution_chip";
-import { getContinuousAreaChartData } from "@/components/charts/continuous_area_chart";
+import {
+  ContinuousAreaGraphInput,
+  getContinuousAreaChartData,
+} from "@/components/charts/continuous_area_chart";
 import MinifiedContinuousAreaChart from "@/components/charts/minified_continuous_area_chart";
 import BinaryCPBar from "@/components/consumer_post_card/binary_cp_bar";
 import QuestionResolutionChip from "@/components/consumer_post_card/question_resolution_chip";
 import QuestionCPMovement from "@/components/cp_movement";
 import ContinuousCPBar from "@/components/post_card/question_tile/continuous_cp_bar";
 import { useHideCP } from "@/contexts/cp_context";
+import { ContinuousAreaType } from "@/types/charts";
 import { QuestionStatus } from "@/types/post";
-import { QuestionType, QuestionWithForecasts } from "@/types/question";
+import {
+  NumericAggregateForecast,
+  QuestionType,
+  QuestionWithForecasts,
+} from "@/types/question";
 import cn from "@/utils/core/cn";
 import { formatResolution } from "@/utils/formatters/resolution";
+import { cdfToPmf } from "@/utils/math";
 import { getQuestionForecastAvailability } from "@/utils/questions/forecastAvailability";
 import { isSuccessfullyResolved } from "@/utils/questions/resolution";
 
@@ -28,6 +37,7 @@ type Props = {
   hideLabel?: boolean;
   colorOverride?: string;
   chartTheme?: VictoryThemeDefinition;
+  cursorForecast?: NumericAggregateForecast | null;
 };
 
 const QuestionHeaderCPStatus: FC<Props> = ({
@@ -36,6 +46,7 @@ const QuestionHeaderCPStatus: FC<Props> = ({
   hideLabel = false,
   colorOverride,
   chartTheme,
+  cursorForecast,
 }) => {
   const locale = useLocale();
   const t = useTranslations();
@@ -104,6 +115,24 @@ const QuestionHeaderCPStatus: FC<Props> = ({
         ? "border-[0.5px] border-gray-500 p-3 dark:border-gray-500-dark md:p-3"
         : "border-[0.5px] border-olive-500 p-3 dark:border-olive-500-dark md:p-3";
 
+  const cursorCenter = cursorForecast?.centers?.[0] ?? null;
+  const cursorLower = cursorForecast?.interval_lower_bounds?.[0] ?? null;
+  const cursorUpper = cursorForecast?.interval_upper_bounds?.[0] ?? null;
+  const cursorAreaChartData: ContinuousAreaGraphInput | null =
+    cursorForecast?.forecast_values
+      ? [
+          {
+            pmf: cdfToPmf(cursorForecast.forecast_values),
+            cdf: cursorForecast.forecast_values,
+            type: (question.status === QuestionStatus.RESOLVED
+              ? "community_resolved"
+              : question.status === QuestionStatus.CLOSED
+                ? "community_closed"
+                : "community") as ContinuousAreaType,
+          },
+        ]
+      : null;
+
   if (isContinuous) {
     return (
       !forecastAvailability.isEmpty && (
@@ -148,6 +177,12 @@ const QuestionHeaderCPStatus: FC<Props> = ({
                 size={size}
                 variant="question"
                 colorOverride={colorOverride}
+                overrideCenter={cursorCenter}
+                overrideBounds={
+                  cursorLower !== null && cursorUpper !== null
+                    ? [cursorLower, cursorUpper]
+                    : null
+                }
               />
             )}
           </div>
@@ -161,7 +196,7 @@ const QuestionHeaderCPStatus: FC<Props> = ({
             >
               <MinifiedContinuousAreaChart
                 question={question}
-                data={continuousAreaChartData}
+                data={cursorAreaChartData ?? continuousAreaChartData}
                 height={
                   hideLabel && size === "lg"
                     ? 120

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -76,6 +76,7 @@ type Props = {
   chartTitle?: ReactNode;
   height?: number;
   hideCP?: boolean;
+  hideCursorValueLabel?: boolean;
   defaultZoom?: TimelineChartZoomOption;
   withZoomPicker?: boolean;
   resolutionPoint?: LinePoint[];
@@ -127,10 +128,12 @@ const NumericChart: FC<Props> = ({
   nonInteractive = false,
   isEmbedded = false,
   simplifiedCursor = false,
+  hideCursorValueLabel = false,
   forecastAvailability,
   questionStatus,
   resolution,
   cursorTooltip,
+  isConsumerView,
   questionType,
   newsAnnotations,
   showNewsAnnotations,
@@ -142,6 +145,11 @@ const NumericChart: FC<Props> = ({
   const [zoom, setZoom] = useState(defaultZoom);
 
   const [isCursorActive, setIsCursorActive] = useState(false);
+  const isContinuousConsumerView =
+    isConsumerView &&
+    (questionType === QuestionType.Numeric ||
+      questionType === QuestionType.Date ||
+      questionType === QuestionType.Discrete);
   const { ref: chartContainerRef, width: chartWidth } =
     useContainerSize<HTMLDivElement>();
   const { line, area, points, yDomain, xDomain, yScale, xScale } = useMemo(
@@ -252,13 +260,17 @@ const NumericChart: FC<Props> = ({
           }
         }}
         cursorComponent={
-          <LineSegment
-            style={{
-              stroke: getThemeColor(METAC_COLORS.blue["700"]),
-              opacity: 0.5,
-              strokeDasharray: "5,2",
-            }}
-          />
+          isContinuousConsumerView ? (
+            <LineSegment style={{ stroke: "none" }} />
+          ) : (
+            <LineSegment
+              style={{
+                stroke: getThemeColor(METAC_COLORS.blue["700"]),
+                opacity: 0.5,
+                strokeDasharray: "5,2",
+              }}
+            />
+          )
         }
         cursorLabelComponent={
           <VictoryPortal>
@@ -779,7 +791,28 @@ const NumericChart: FC<Props> = ({
                   </VictoryPortal>
                 ) : null}
 
-                {!isDiamondActive && !isNil(highlightedPoint) && !hideCP ? (
+                {isCursorActive &&
+                !isNil(highlightedPoint) &&
+                !hideCP &&
+                isContinuousConsumerView ? (
+                  <VictoryScatter
+                    data={[highlightedPoint]}
+                    size={4}
+                    style={{
+                      data: {
+                        fill: colorOverride
+                          ? String(colorOverride)
+                          : getThemeColor(colorPalette.chip),
+                        stroke: "none",
+                      },
+                    }}
+                  />
+                ) : null}
+
+                {!isDiamondActive &&
+                !isNil(highlightedPoint) &&
+                !hideCP &&
+                !(hideCursorValueLabel && isCursorActive) ? (
                   <VictoryScatter
                     data={[highlightedPoint]}
                     dataComponent={
@@ -825,7 +858,7 @@ const NumericChart: FC<Props> = ({
       </div>
 
       {/* Forecaster view tooltip */}
-      {isCursorActive && !!cursorTooltip ? (
+      {isCursorActive && !!cursorTooltip && !isContinuousConsumerView ? (
         <FloatingPortal>
           <div
             className="pointer-events-none z-100 rounded bg-gray-0 leading-4 shadow-lg dark:bg-gray-0-dark"

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -496,6 +496,13 @@ const NumericChart: FC<Props> = ({
     return typeof fromTheme === "number" ? fromTheme : 0.3;
   }, [hasExternalTheme, themeAreaData?.opacity]);
 
+  const cursorDotFill = useMemo(
+    () =>
+      resolveToCssColor(getThemeColor, colorOverride) ??
+      getThemeColor(colorPalette.chip),
+    [getThemeColor, colorOverride, colorPalette.chip]
+  );
+
   const rightPad = Math.max(rightPadding, MIN_RIGHT_PADDING);
   const yAxisLabel = !isNil(yLabel) ? `(${yLabel})` : undefined;
   const leftPad = 10;
@@ -824,9 +831,7 @@ const NumericChart: FC<Props> = ({
                     size={4}
                     style={{
                       data: {
-                        fill: colorOverride
-                          ? String(colorOverride)
-                          : getThemeColor(colorPalette.chip),
+                        fill: cursorDotFill,
                         stroke: "none",
                       },
                     }}

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -316,6 +316,10 @@ const NumericChart: FC<Props> = ({
           onTouchStart: () => {
             setIsCursorActive(true);
           },
+          onTouchEnd: () => {
+            setIsCursorActive(false);
+            handleCursorChange(null);
+          },
           onMouseEnter: () => {
             setIsCursorActive(true);
           },
@@ -397,8 +401,26 @@ const NumericChart: FC<Props> = ({
     return xDomain;
   }, [xDomain, isEmbedded]);
 
+  const [touchPoint, setTouchPoint] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
   const { getReferenceProps, getFloatingProps, refs, floatingStyles } =
-    useChartTooltip({ placement: "top", tooltipOffset: 15 });
+    useChartTooltip({
+      placement: "top",
+      tooltipOffset: touchPoint ? 50 : 15,
+      x: touchPoint?.x ?? null,
+      y: touchPoint?.y ?? null,
+    });
+
+  const handleTouchMove = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    setTouchPoint({ x: touch.clientX, y: touch.clientY });
+  }, []);
+  const handleTouchEnd = useCallback(() => {
+    setTouchPoint(null);
+  }, []);
   const {
     isActive: isDiamondActive,
     getReferenceProps: getDiamondRefProps,
@@ -561,6 +583,8 @@ const NumericChart: FC<Props> = ({
         )}
         ref={refs.setReference}
         {...getReferenceProps()}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
       >
         <ForecastAvailabilityChartOverflow
           forecastAvailability={forecastAvailability}

--- a/front_end/src/components/charts/numeric_timeline.tsx
+++ b/front_end/src/components/charts/numeric_timeline.tsx
@@ -61,6 +61,7 @@ type Props = {
   keyFactors?: KeyFactor[];
   showNewsAnnotations?: boolean;
   onToggleNewsAnnotations?: () => void;
+  hideCursorValueLabel?: boolean;
 };
 
 const NumericTimeline: FC<Props> = ({
@@ -98,6 +99,7 @@ const NumericTimeline: FC<Props> = ({
   keyFactors,
   showNewsAnnotations,
   onToggleNewsAnnotations,
+  hideCursorValueLabel,
 }) => {
   const locale = useLocale();
   const resolutionPoint = useMemo(() => {
@@ -235,6 +237,7 @@ const NumericTimeline: FC<Props> = ({
       newsAnnotations={newsAnnotations}
       showNewsAnnotations={showNewsAnnotations}
       onToggleNewsAnnotations={onToggleNewsAnnotations}
+      hideCursorValueLabel={hideCursorValueLabel}
     />
   );
 };

--- a/front_end/src/components/charts/primitives/line_cursor_points.tsx
+++ b/front_end/src/components/charts/primitives/line_cursor_points.tsx
@@ -10,8 +10,6 @@ import {
 } from "@/utils/charts/helpers";
 
 const SIZE = 4;
-// https://commerce.nearform.com/open-source/victory/docs/api/victory-cursor-container#cursorlabeloffset
-const DEFAULT_X_OFFSET = 5;
 
 type Props<T> = {
   chartData: Array<{
@@ -87,13 +85,13 @@ const LineCursorPoints = <T extends string>({
         ) : (
           <Point
             key={index}
-            x={x - DEFAULT_X_OFFSET}
+            x={x}
             y={finalScaledY}
             size={SIZE}
             style={{
-              fill: "transparent",
-              stroke: color,
-              strokeWidth: 1,
+              fill: color,
+              stroke: "white",
+              strokeWidth: 1.5,
             }}
           />
         );

--- a/front_end/src/components/consumer_post_card/consumer_question_tile/consumer_continuous_tile.tsx
+++ b/front_end/src/components/consumer_post_card/consumer_question_tile/consumer_continuous_tile.tsx
@@ -12,25 +12,33 @@ type Props = {
   question: QuestionWithForecasts;
   forecastAvailability: ForecastAvailability;
   variant?: "feed" | "question";
+  overrideCenter?: number | null;
 };
 
 const ConsumerContinuousTile: FC<Props> = ({
   question,
   forecastAvailability,
   variant = "feed",
+  overrideCenter,
 }) => {
   const locale = useLocale();
 
   const latest =
     question.aggregations[question.default_aggregation_method]?.latest;
-  const communityPredictionDisplayValue = latest
-    ? getPredictionDisplayValue(latest.centers?.[0], {
-        questionType: question.type,
-        scaling: question.scaling,
-        actual_resolve_time: question.actual_resolve_time ?? null,
-        unit: question.unit,
-      })
-    : null;
+  // Cursor position overrides the latest CP center when hovering the timeline.
+  const effectiveCenter =
+    overrideCenter !== null && overrideCenter !== undefined
+      ? overrideCenter
+      : latest?.centers?.[0];
+  const communityPredictionDisplayValue =
+    effectiveCenter !== undefined
+      ? getPredictionDisplayValue(effectiveCenter, {
+          questionType: question.type,
+          scaling: question.scaling,
+          actual_resolve_time: question.actual_resolve_time ?? null,
+          unit: question.unit,
+        })
+      : null;
 
   // Resolved/Annulled/Ambiguous
   if (question.resolution) {

--- a/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
@@ -44,6 +44,8 @@ import {
   isContinuousQuestion,
 } from "@/utils/questions/helpers";
 
+import { useFullAggregation } from "./hooks/use_full_aggregation";
+
 const Histogram = dynamic(() => import("@/components/charts/histogram"), {
   ssr: false,
 });
@@ -93,8 +95,21 @@ const DetailedContinuousChartCard: FC<Props> = ({
   const [isChartReady, setIsChartReady] = useState(false);
   const [activeView, setActiveView] = useState<ChartView>("timeline");
 
+  const [shouldFetchFull, setShouldFetchFull] = useState(false);
+  const { data: enrichedAggregation = null } = useFullAggregation(
+    question.id,
+    question.default_aggregation_method,
+    isContinuousConsumer && shouldFetchFull
+  );
+
+  const handlePointerEnter = useCallback(() => {
+    if (isContinuousConsumer) setShouldFetchFull(true);
+  }, [isContinuousConsumer]);
+
   const aggregation =
     question.aggregations[question.default_aggregation_method];
+  const effectiveAggregation = (enrichedAggregation ??
+    aggregation) as typeof aggregation;
   const isCpHidden = !!forecastAvailability?.cpRevealsOn;
 
   const [cursorTimestamp, setCursorTimestamp] = useState<number | null>(null);
@@ -113,7 +128,7 @@ const DetailedContinuousChartCard: FC<Props> = ({
       };
     }
 
-    const forecast = getCursorForecast(cursorTimestamp, aggregation);
+    const forecast = getCursorForecast(cursorTimestamp, effectiveAggregation);
     let timestamp = cursorTimestamp;
     if (
       timestamp === null &&
@@ -137,7 +152,7 @@ const DetailedContinuousChartCard: FC<Props> = ({
   }, [
     isCpHidden,
     cursorTimestamp,
-    aggregation,
+    effectiveAggregation,
     question.my_forecasts,
     nrForecasters,
   ]);
@@ -209,9 +224,9 @@ const DetailedContinuousChartCard: FC<Props> = ({
       return null;
     return getCursorForecast(
       cursorTimestamp,
-      aggregation
+      effectiveAggregation
     ) as NumericAggregateForecast | null;
-  }, [isCpHidden, cursorTimestamp, aggregation, question]);
+  }, [isCpHidden, cursorTimestamp, effectiveAggregation, question]);
 
   const cursorCtx = useContinuousChartCursor();
   useEffect(() => {
@@ -435,6 +450,7 @@ const DetailedContinuousChartCard: FC<Props> = ({
         "flex w-full flex-col",
         isChartReady ? "opacity-100" : "opacity-0"
       )}
+      onPointerEnter={isContinuousConsumer ? handlePointerEnter : undefined}
     >
       {isContinuousQuestion(question) && !isEmbed ? (
         <>

--- a/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
@@ -99,6 +99,7 @@ const DetailedContinuousChartCard: FC<Props> = ({
   const { data: enrichedAggregation = null } = useFullAggregation(
     question.id,
     question.default_aggregation_method,
+    question.include_bots_in_aggregates,
     isContinuousConsumer && shouldFetchFull
   );
 

--- a/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
@@ -230,11 +230,12 @@ const DetailedContinuousChartCard: FC<Props> = ({
   }, [isCpHidden, cursorTimestamp, effectiveAggregation, question]);
 
   const cursorCtx = useContinuousChartCursor();
+  const setCursorForecast = cursorCtx?.setActiveForecast;
   useEffect(() => {
-    if (!isContinuousQuestion(question) || !cursorCtx) return;
-    cursorCtx.setActiveForecast(activeForecast);
-    return () => cursorCtx.setActiveForecast(null);
-  }, [activeForecast, cursorCtx, question]);
+    if (!isContinuousQuestion(question) || !setCursorForecast) return;
+    setCursorForecast(activeForecast);
+    return () => setCursorForecast(null);
+  }, [activeForecast, setCursorForecast, question]);
 
   const handleCursorChange = useCallback((value: number | null) => {
     setCursorTimestamp(value);

--- a/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
@@ -2,7 +2,14 @@
 import { isNil } from "lodash";
 import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
-import { FC, ReactNode, useCallback, useMemo, useState } from "react";
+import {
+  FC,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { VictoryThemeDefinition } from "victory";
 
 import { useIsEmbedMode } from "@/app/(embed)/questions/components/question_view_mode_context";
@@ -14,6 +21,7 @@ import ContinuousPredictionChart from "@/components/forecast_maker/continuous_in
 import Button from "@/components/ui/button";
 import { GroupButton } from "@/components/ui/button_group";
 import { useAuth } from "@/contexts/auth_context";
+import { useContinuousChartCursor } from "@/contexts/continuous_chart_cursor_context";
 import { EmbedChartType, TimelineChartZoomOption } from "@/types/charts";
 import { KeyFactor } from "@/types/comment";
 import {
@@ -204,6 +212,13 @@ const DetailedContinuousChartCard: FC<Props> = ({
       aggregation
     ) as NumericAggregateForecast | null;
   }, [isCpHidden, cursorTimestamp, aggregation, question]);
+
+  const cursorCtx = useContinuousChartCursor();
+  useEffect(() => {
+    if (!isContinuousQuestion(question) || !cursorCtx) return;
+    cursorCtx.setActiveForecast(activeForecast);
+    return () => cursorCtx.setActiveForecast(null);
+  }, [activeForecast, cursorCtx, question]);
 
   const handleCursorChange = useCallback((value: number | null) => {
     setCursorTimestamp(value);
@@ -430,7 +445,9 @@ const DetailedContinuousChartCard: FC<Props> = ({
                 question={question}
                 size="lg"
                 hideLabel={true}
-                cursorForecast={activeForecast}
+                cursorForecast={
+                  isContinuousConsumer ? activeForecast : undefined
+                }
               />
             )}
 

--- a/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
@@ -18,6 +18,7 @@ import { EmbedChartType, TimelineChartZoomOption } from "@/types/charts";
 import { KeyFactor } from "@/types/comment";
 import {
   ForecastAvailability,
+  NumericAggregateForecast,
   QuestionType,
   QuestionWithNumericForecasts,
 } from "@/types/question";
@@ -80,6 +81,7 @@ const DetailedContinuousChartCard: FC<Props> = ({
 
   const effectiveWithZoomPicker = withZoomPicker ?? true;
   const isConsumerView = isConsumerViewProp ?? !user;
+  const isContinuousConsumer = isConsumerView && isContinuousQuestion(question);
   const [isChartReady, setIsChartReady] = useState(false);
   const [activeView, setActiveView] = useState<ChartView>("timeline");
 
@@ -188,6 +190,21 @@ const DetailedContinuousChartCard: FC<Props> = ({
     discreteValueOptions,
   ]);
 
+  const isBinary = question.type === QuestionType.Binary;
+
+  const activeForecast = useMemo<NumericAggregateForecast | null>(() => {
+    if (
+      isCpHidden ||
+      cursorTimestamp === null ||
+      !isContinuousQuestion(question)
+    )
+      return null;
+    return getCursorForecast(
+      cursorTimestamp,
+      aggregation
+    ) as NumericAggregateForecast | null;
+  }, [isCpHidden, cursorTimestamp, aggregation, question]);
+
   const handleCursorChange = useCallback((value: number | null) => {
     setCursorTimestamp(value);
   }, []);
@@ -220,8 +237,6 @@ const DetailedContinuousChartCard: FC<Props> = ({
     !forecastAvailability?.isEmpty &&
     !forecastAvailability?.cpRevealsOn &&
     (question.type === QuestionType.Binary || isContinuousQuestion(question));
-
-  const isBinary = question.type === QuestionType.Binary;
 
   const chartViewButtons: GroupButton<ChartView>[] = [
     { value: "timeline", label: t("timeline") },
@@ -278,10 +293,11 @@ const DetailedContinuousChartCard: FC<Props> = ({
       unit={question.unit}
       inboundOutcomeCount={question.inbound_outcome_count}
       simplifiedCursor={false}
+      hideCursorValueLabel={isContinuousConsumer && !isEmbed}
       title={timelineTitle}
       forecastAvailability={forecastAvailability}
       cursorTooltip={cursorTooltip}
-      isConsumerView={isConsumerView}
+      isConsumerView={isContinuousConsumer}
       isEmbedded={isEmbed}
       height={chartHeight}
       extraTheme={extraTheme}
@@ -306,6 +322,7 @@ const DetailedContinuousChartCard: FC<Props> = ({
       hideLabel={isContinuousQuestion(question)}
       colorOverride={cpColorOverride}
       chartTheme={extraTheme}
+      cursorForecast={activeForecast}
     />
   );
 
@@ -404,7 +421,7 @@ const DetailedContinuousChartCard: FC<Props> = ({
         isChartReady ? "opacity-100" : "opacity-0"
       )}
     >
-      {!isConsumerView ? (
+      {isContinuousQuestion(question) && !isEmbed ? (
         <>
           {/* Desktop */}
           <div className="hidden items-stretch gap-4 md:flex">
@@ -413,6 +430,7 @@ const DetailedContinuousChartCard: FC<Props> = ({
                 question={question}
                 size="lg"
                 hideLabel={true}
+                cursorForecast={activeForecast}
               />
             )}
 

--- a/front_end/src/components/detailed_question_card/detailed_question_card/hooks/use_full_aggregation.ts
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/hooks/use_full_aggregation.ts
@@ -8,16 +8,22 @@ import { NumericAggregateForecastHistory } from "@/types/question";
 export function useFullAggregation(
   questionId: number,
   defaultAggregationMethod: string,
+  includeBots: boolean,
   enabled: boolean
 ) {
   return useQuery({
-    queryKey: ["full-aggregation", questionId, defaultAggregationMethod],
+    queryKey: [
+      "full-aggregation",
+      questionId,
+      defaultAggregationMethod,
+      includeBots,
+    ],
     enabled,
     queryFn: async () => {
       const result = await ClientAggregationExplorerApi.getAggregations({
         questionId,
         aggregationMethods: defaultAggregationMethod,
-        includeBots: false,
+        includeBots,
       });
       return (
         (

--- a/front_end/src/components/detailed_question_card/detailed_question_card/hooks/use_full_aggregation.ts
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/hooks/use_full_aggregation.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import ClientAggregationExplorerApi from "@/services/api/aggregation_explorer/aggregation_explorer.client";
+import { NumericAggregateForecastHistory } from "@/types/question";
+
+export function useFullAggregation(
+  questionId: number,
+  defaultAggregationMethod: string,
+  enabled: boolean
+) {
+  return useQuery({
+    queryKey: ["full-aggregation", questionId, defaultAggregationMethod],
+    enabled,
+    queryFn: async () => {
+      const result = await ClientAggregationExplorerApi.getAggregations({
+        questionId,
+        aggregationMethods: defaultAggregationMethod,
+        includeBots: false,
+      });
+      return (
+        (
+          result.aggregations as Record<
+            string,
+            NumericAggregateForecastHistory | undefined
+          >
+        )[defaultAggregationMethod] ?? null
+      );
+    },
+  });
+}

--- a/front_end/src/components/post_card/question_tile/continuous_cp_bar.tsx
+++ b/front_end/src/components/post_card/question_tile/continuous_cp_bar.tsx
@@ -19,6 +19,8 @@ type Props = {
   size?: "md" | "lg";
   variant?: "feed" | "question";
   colorOverride?: string;
+  overrideCenter?: number | null;
+  overrideBounds?: [number, number] | null;
 };
 
 const ContinuousCPBar: FC<Props> = ({
@@ -26,6 +28,8 @@ const ContinuousCPBar: FC<Props> = ({
   size = "md",
   variant = "feed",
   colorOverride,
+  overrideCenter,
+  overrideBounds,
 }) => {
   const latest =
     question.aggregations[question.default_aggregation_method]?.latest;
@@ -41,18 +45,20 @@ const ContinuousCPBar: FC<Props> = ({
   }
   const discreteValueOptions = getDiscreteValueOptions(question);
 
+  const effectiveCenter = overrideCenter ?? latest.centers?.[0];
+  const effectiveLower =
+    overrideBounds?.[0] ?? latest.interval_lower_bounds?.[0];
+  const effectiveUpper =
+    overrideBounds?.[1] ?? latest.interval_upper_bounds?.[0];
+
   const displayValue = getPredictionDisplayValue(
-    latest.centers?.[0],
+    effectiveCenter,
     {
       questionType: question.type,
       scaling: question.scaling,
       range:
-        !isNil(latest?.interval_lower_bounds?.[0]) &&
-        !isNil(latest?.interval_upper_bounds?.[0])
-          ? [
-              latest?.interval_lower_bounds?.[0] as number,
-              latest?.interval_upper_bounds?.[0] as number,
-            ]
+        !isNil(effectiveLower) && !isNil(effectiveUpper)
+          ? [effectiveLower as number, effectiveUpper as number]
           : [],
       unit: question.unit,
       actual_resolve_time: question.actual_resolve_time ?? null,

--- a/front_end/src/contexts/continuous_chart_cursor_context.tsx
+++ b/front_end/src/contexts/continuous_chart_cursor_context.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import {
+  createContext,
+  FC,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+import { NumericAggregateForecast } from "@/types/question";
+
+type CursorContextValue = {
+  activeForecast: NumericAggregateForecast | null;
+  setActiveForecast: (f: NumericAggregateForecast | null) => void;
+};
+
+const ContinuousChartCursorContext = createContext<CursorContextValue | null>(
+  null
+);
+
+export const ContinuousChartCursorProvider: FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [activeForecast, setActiveForecast] =
+    useState<NumericAggregateForecast | null>(null);
+  const stableSet = useCallback(
+    (f: NumericAggregateForecast | null) => setActiveForecast(f),
+    []
+  );
+  const value = useMemo(
+    () => ({ activeForecast, setActiveForecast: stableSet }),
+    [activeForecast, stableSet]
+  );
+  return (
+    <ContinuousChartCursorContext.Provider value={value}>
+      {children}
+    </ContinuousChartCursorContext.Provider>
+  );
+};
+
+export const useContinuousChartCursor = () =>
+  useContext(ContinuousChartCursorContext);

--- a/front_end/src/hooks/use_chart_tooltip.ts
+++ b/front_end/src/hooks/use_chart_tooltip.ts
@@ -15,11 +15,15 @@ import { useState } from "react";
 type Props = {
   placement?: Placement;
   tooltipOffset?: number;
+  x?: number | null;
+  y?: number | null;
 };
 
 const useChartTooltip = ({
   placement = "left",
   tooltipOffset = 24,
+  x,
+  y,
 }: Props = {}) => {
   const [isActive, setIsActive] = useState(false);
   const { refs, floatingStyles, context } = useFloating({
@@ -34,7 +38,7 @@ const useChartTooltip = ({
     placement,
     whileElementsMounted: autoUpdate,
   });
-  const clientPoint = useClientPoint(context);
+  const clientPoint = useClientPoint(context, { x, y });
   const dismiss = useDismiss(context);
   const hover = useHover(context);
   const { getReferenceProps, getFloatingProps } = useInteractions([

--- a/questions/serializers/aggregate_forecasts.py
+++ b/questions/serializers/aggregate_forecasts.py
@@ -128,7 +128,7 @@ def serialize_question_aggregations(
 
         for method, forecasts in aggregate_forecasts_by_method.items():
             serialized_data[method]["history"] = [
-                serialize_aggregate_forecast(forecast, question.type, full=True)
+                serialize_aggregate_forecast(forecast, question.type, full=full_forecast_values)
                 for forecast in forecasts
             ]
             serialized_data[method]["latest"] = (

--- a/questions/serializers/aggregate_forecasts.py
+++ b/questions/serializers/aggregate_forecasts.py
@@ -128,9 +128,7 @@ def serialize_question_aggregations(
 
         for method, forecasts in aggregate_forecasts_by_method.items():
             serialized_data[method]["history"] = [
-                serialize_aggregate_forecast(
-                    forecast, question.type, full=full_forecast_values
-                )
+                serialize_aggregate_forecast(forecast, question.type, full=True)
                 for forecast in forecasts
             ]
             serialized_data[method]["latest"] = (

--- a/questions/serializers/aggregate_forecasts.py
+++ b/questions/serializers/aggregate_forecasts.py
@@ -128,7 +128,9 @@ def serialize_question_aggregations(
 
         for method, forecasts in aggregate_forecasts_by_method.items():
             serialized_data[method]["history"] = [
-                serialize_aggregate_forecast(forecast, question.type, full=full_forecast_values)
+                serialize_aggregate_forecast(
+                    forecast, question.type, full=full_forecast_values
+                )
                 for forecast in forecasts
             ]
             serialized_data[method]["latest"] = (


### PR DESCRIPTION
Related to https://github.com/Metaculus/metaculus/issues/4642

This PR implements live cursor updates for the consumer view: hovering the timeline updates the left-panel value, range, and mini distribution chart in real-time. Applies to all consumer continuous charts. Binary timeline/radial is explicitly excluded. Live updates are scoped to consumer view only - forecaster left panel and mobile header remain static.

## Implemented features & fixes

- `Consumer continuous left panel` - `QuestionHeaderCPStatus` now accepts a `cursorForecast` prop; on hover, the center value, confidence interval, and minified area chart all animate to the cursor position; reverts to latest aggregate when cursor leaves
- `Consumer continuous timeline` - removed dashed cursor line and floating tooltip (replaced by left-panel live update); added a filled 8px dot on the CP line at cursor position
- `Consumer mobile mini chart` - `ContinuousQuestionPrediction` now reads cursor forecast from `ContinuousChartCursorContext` and updates both the center value display and the minified distribution chart in real-time on mobile
- `ContinuousChartCursorContext` - new context scoped to `ConsumerShell` that bridges the timeline cursor forecast to the mobile mini chart without prop drilling; `DetailedContinuousChartCard` writes, `ContinuousQuestionPrediction` reads
- `Mobile tooltip position` - floating tooltip now follows touch position in real-time via `useClientPoint` x/y override in `useChartTooltip`; touch offset increased to 50px to clear the finger; `onTouchEnd` added to Victory chart events so cursor resets on touch lift
- `Forecaster continuous timeline` - unchanged; dashed line, floating tooltip, and value label chip are preserved
- `hideCursorValueLabel` - added to `NumericChart`/`NumericTimeline` to suppress the on-chart value chip when the left panel is already showing the value (consumer continuous only)
- `ContinuousCPBar` - added `overrideCenter`/`overrideBounds` props so the value/range display can be driven by cursor data without mutating the underlying question object

https://github.com/user-attachments/assets/a4488e7b-87b4-4dcf-ac74-1821d9afe87e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced cursor state management for synchronized chart interactions across multiple views.
  * Improved touch handling on mobile devices for better tooltip positioning and cursor tracking.

* **Bug Fixes**
  * Refined cursor rendering behavior in consumer views for clearer forecast visualization.
  * Improved forecast data display alignment when interacting with charts via cursor or touch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->