### PR TITLE
deactivate daily coherence leaderboard updating

### DIFF
--- a/scoring/jobs.py
+++ b/scoring/jobs.py
@@ -8,7 +8,6 @@ from scoring.constants import LeaderboardScoreTypes
 from scoring.models import Leaderboard
 from scoring.utils import update_project_leaderboard
 from scoring.tasks import update_custom_leaderboard
-from scoring.tasks import update_coherence_spring_2026_cup
 
 from scoring.management.commands.update_global_bot_leaderboard import (
     run_update_global_bot_leaderboard,
@@ -92,12 +91,14 @@ def update_custom_leaderboards():
         # in all environments
         logger.info("Index 'us-democracy-threat' not found.")
 
-    # Coherence Links Tournament Metaculus Cup Spring 2026
-    project = Project.objects.filter(slug="metaculus-cup-spring-2026").first()
-    if project:
-        try:
-            update_coherence_spring_2026_cup.send()
-        except Exception as e:
-            logger.error(
-                f"Error updating Coherence Links Tournament Metaculus Cup Spring 2026: {e}"
-            )
+    # TODO: remove this and relevant code after finalization is done
+    # from scoring.tasks import update_coherence_spring_2026_cup
+    # # Coherence Links Tournament Metaculus Cup Spring 2026
+    # project = Project.objects.filter(slug="metaculus-cup-spring-2026").first()
+    # if project:
+    #     try:
+    #         update_coherence_spring_2026_cup.send()
+    #     except Exception as e:
+    #         logger.error(
+    #             f"Error updating Coherence Links Tournament Metaculus Cup Spring 2026: {e}"
+    #         )


### PR DESCRIPTION
coherence leaderboard is done so deactivating the daily task
keeping code until prizes have been actually disbursed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Disabled Coherence Links Tournament Metaculus Cup Spring 2026 custom leaderboard updates pending finalization. Global leaderboard and other custom leaderboards remain functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->