### PR TITLE
Add new team member to about page

### DIFF
--- a/front_end/src/app/(main)/about/components/TeamBlock.tsx
+++ b/front_end/src/app/(main)/about/components/TeamBlock.tsx
@@ -351,6 +351,13 @@ const people: Person[] = [
     introduction:
       "Jesse Damiani is a writer, curator, and foresight strategist who founded the Reality Studies newsletter and Urgent Futures podcast. He has taught at NYU, USC, SCI-Arc, and elsewhere, and served as Research Affiliate at Institute for the Future and Director of Emerging Technology & Insight at Southern New Hampshire University. His writing appears in Architectural Design, Flash Art, NBC News, WIRED, and The Yale Review.",
   },
+  {
+    name: "Carolin Ullrich",
+    position: "Principal Product Manager",
+    imgSrc: "https://cdn.metaculus.com/carolin.webp",
+    introduction:
+      "Carolin is a Principal Product Manager at Metaculus, focused on bridging the gap between generating accurate forecasts and enabling organizations to translate them into better decisions. She brings a background in B2B SaaS, having worked at a Data and AI company serving multinational clients across industries. She holds degrees in Psychology and Human-Computer Interaction. Outside of work, Carolin tends to her garden (a hobby she'll tell you has a lot in common with foresight).",
+  },
 ];
 
 const groups: Groups = {
@@ -375,6 +382,7 @@ const groups: Groups = {
     "Kelley Edelmann",
     "Grace McLain",
     "Jesse Damiani",
+    "Carolin Ullrich",
   ],
   board: [
     "Anthony Aguirre",

--- a/front_end/src/app/(main)/about/components/TeamBlock.tsx
+++ b/front_end/src/app/(main)/about/components/TeamBlock.tsx
@@ -354,7 +354,7 @@ const people: Person[] = [
   {
     name: "Carolin Ullrich",
     position: "Principal Product Manager",
-    imgSrc: "https://cdn.metaculus.com/carolin.webp",
+    imgSrc: "https://cdn.metaculus.com/caro-grayscale.webp",
     introduction:
       "Carolin is a Principal Product Manager at Metaculus, focused on bridging the gap between generating accurate forecasts and enabling organizations to translate them into better decisions. She brings a background in B2B SaaS, having worked at a Data and AI company serving multinational clients across industries. She holds degrees in Psychology and Human-Computer Interaction. Outside of work, Carolin tends to her garden (a hobby she'll tell you has a lot in common with foresight).",
   },


### PR DESCRIPTION
## Summary
- Adds new team member to the team section of the about page
- Bio and title sourced from employee submission

## Test plan
- [x] Verify headshot is accessible at CDN path
- [x] Check about page renders card correctly in the team section
- [x] Verify modal opens with full bio on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new team member profile (Carolin Ullrich) to the public team roster. She now appears in the team section, is included in the team rotation, and can be opened to view her profile details via the team member modal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->