### PR TITLE
fix: labor hub commentary misalignments (chart data vs text)

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -34,9 +34,10 @@ export const JOBS_INSIGHTS = {
   "2035": {
     positive: (
       <>
-        By 2035, <strong>nurses</strong> and <strong>restaurant workers</strong>{" "}
-        are expected to see the highest growth, driven by hands-on needs, while{" "}
-        <strong>law enforcement</strong> and{" "}
+        By 2035, <strong>nurses</strong> and{" "}
+        <strong>law enforcement</strong> are expected to see the highest growth,
+        driven by hands-on needs, while{" "}
+        <strong>restaurant servers</strong> and{" "}
         <strong>construction workers</strong> see muted growth counteracted by
         potential robotics advancements.
       </>

--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -179,7 +179,7 @@ export default function LaborAutomationHubPage() {
               </span>
               , <strong>median wages are expected to grow.</strong> The workweek
               is also expected to become{" "}
-              <strong>four hours shorter by 2035</strong> among all workers,
+              <strong>approximately three hours shorter by 2035</strong> among all workers,
               while productivity grows.
             </ContentParagraph>
             <ContentParagraph>
@@ -323,7 +323,7 @@ export default function LaborAutomationHubPage() {
               }}
             />
             <ContentParagraph small>
-              With only 12% of workers using AI daily as of late 2025, the
+              With only 10% of workers using AI daily as of late 2025, the
               workplace is still in the early stages of an adoption curve that
               could fundamentally change how most Americans do their jobs within
               a decade. But forecasters note that some people may only think

--- a/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
@@ -149,7 +149,7 @@ export async function KeyInsightsSection({
         <KeyInsightItem title="Young workers">
           The youngest workers are expected to be hit hardest, with unemployment
           for 4-year college graduates in the 22-27 age range expected to grow
-          from the current 6%
+          from the current 5%
           {youthDisplay != null ? ` to ${youthDisplay}%` : ""} in 2035.
           Meanwhile, trade school and community college certificates are
           expected to{" "}


### PR DESCRIPTION
## Summary

Four misalignments were found by cross-referencing the live RSC chart payload against the commentary text on `/labor-hub`. All fixes are commentary-only — no chart data, component structure, or logic was changed.

---

### Fix 1 — Jobs Monitor, 2035 positive insight (`jobs_insights.tsx`)

| | Text |
|---|---|
| **Before** | "By 2035, **nurses** and **restaurant workers** are expected to see the highest growth, driven by hands-on needs, while **law enforcement** and **construction workers** see muted growth…" |
| **After** | "By 2035, **nurses** and **law enforcement** are expected to see the highest growth, driven by hands-on needs, while **restaurant servers** and **construction workers** see muted growth…" |

**Why:** Raw chart data for 2035: Law Enforcement = **+8.7%** (2nd highest), Restaurant Servers = **+7.8%** (3rd). The commentary had them transposed — law enforcement was incorrectly called "muted growth" when it has the second-highest growth rate of all 15 occupations.

---

### Fix 2 — Wages section, workweek hours (`page.tsx`)

| | Text |
|---|---|
| **Before** | "The workweek is also expected to become **four hours shorter by 2035**…" |
| **After** | "The workweek is also expected to become **approximately three hours shorter by 2035**…" |

**Why:** Hours chart data: 2025 historical = 38.3 hrs, 2035 forecast = 35.1 hrs → difference of **3.2 hours**, not 4. The Key Insights box on the same page correctly says "down from 38 now" to "35 hours" (3 hours), making "four hours" internally inconsistent as well.

---

### Fix 3 — Wages section, AI adoption paragraph (`page.tsx`)

| | Text |
|---|---|
| **Before** | "With only **12%** of workers using AI daily as of late 2025…" |
| **After** | "With only **10%** of workers using AI daily as of late 2025…" |

**Why:** The "Percent of workers that use AI daily" chart has a historical data point of **10%** at x=2025 (before the forecast divider at 2026). The commentary cited 12%, which does not match any data point in the chart.

---

### Fix 4 — Key Insights, "Young workers" bullet (`sections/key_insights.tsx`)

| | Text |
|---|---|
| **Before** | "…expected to grow from the **current 6%** to 12% in 2035." |
| **After** | "…expected to grow from the **current 5%** to 12% in 2035." |

**Why:** The graduate unemployment chart has a historical data point of **5.4%** at x=2025 (the most recent data before the forecast horizon). `Math.round(5.4) = 5`, so the correct rounded figure is 5%, not 6%.

---

## Files changed

- `front_end/src/app/(main)/labor-hub/jobs_insights.tsx` — Fix 1
- `front_end/src/app/(main)/labor-hub/page.tsx` — Fixes 2 & 3
- `front_end/src/app/(main)/labor-hub/sections/key_insights.tsx` — Fix 4

https://claude.ai/code/session_01MQ5pMZ8bK1PEDy9JLMCSyw

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQ5pMZ8bK1PEDy9JLMCSyw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Job growth roles reordered in 2035 projections (nurses and law enforcement highlighted)
  * Workweek expected to shorten by 3 hours by 2035 (revised from 4 hours)
  * AI adoption updated to 10% of workers daily (revised from 12%)
  * Young college graduate unemployment updated to 5% (revised from 6%)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4709)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->