### PR TITLE
fix: labor hub commentary misalignments vs chart data

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -34,9 +34,9 @@ export const JOBS_INSIGHTS = {
   "2035": {
     positive: (
       <>
-        By 2035, <strong>nurses</strong> and <strong>restaurant workers</strong>{" "}
-        are expected to see the highest growth, driven by hands-on needs, while{" "}
-        <strong>law enforcement</strong> and{" "}
+        By 2035, <strong>nurses</strong>, <strong>law enforcement</strong>, and{" "}
+        <strong>restaurant workers</strong> are expected to see the highest
+        growth, driven by hands-on needs, while{" "}
         <strong>construction workers</strong> see muted growth counteracted by
         potential robotics advancements.
       </>

--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -179,7 +179,7 @@ export default function LaborAutomationHubPage() {
               </span>
               , <strong>median wages are expected to grow.</strong> The workweek
               is also expected to become{" "}
-              <strong>four hours shorter by 2035</strong> among all workers,
+              <strong>three hours shorter by 2035</strong> among all workers,
               while productivity grows.
             </ContentParagraph>
             <ContentParagraph>

--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -323,7 +323,7 @@ export default function LaborAutomationHubPage() {
               }}
             />
             <ContentParagraph small>
-              With only 12% of workers using AI daily as of late 2025, the
+              With only 10% of workers using AI daily as of late 2025, the
               workplace is still in the early stages of an adoption curve that
               could fundamentally change how most Americans do their jobs within
               a decade. But forecasters note that some people may only think

--- a/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
@@ -149,7 +149,7 @@ export async function KeyInsightsSection({
         <KeyInsightItem title="Young workers">
           The youngest workers are expected to be hit hardest, with unemployment
           for 4-year college graduates in the 22-27 age range expected to grow
-          from the current 6%
+          from the current 5%
           {youthDisplay != null ? ` to ${youthDisplay}%` : ""} in 2035.
           Meanwhile, trade school and community college certificates are
           expected to{" "}


### PR DESCRIPTION
## Summary

Four places where hardcoded commentary text contradicted the actual chart values shown on `/labor-hub`. All changes are commentary-only — no chart data, component logic, or structure was touched.

---

### Fix 1 — Jobs Monitor, 2035 positive insight (`jobs_insights.tsx`)

| | Text |
|---|---|
| **Before** | "By 2035, **nurses** and **restaurant workers** are expected to see the highest growth … while **law enforcement** and **construction workers** see muted growth …" |
| **After** | "By 2035, **nurses**, **law enforcement**, and **restaurant workers** are expected to see the highest growth … while **construction workers** see muted growth …" |

**Why:** 2035 chart data — Law Enforcement **+8.7%** (2nd highest of all 15 occupations), Restaurant Servers **+7.8%** (3rd). Law enforcement was incorrectly placed in the "muted growth" bucket alongside Construction Workers (+3.1%).

---

### Fix 2 — Wages section, workweek hours (`page.tsx`)

| | Text |
|---|---|
| **Before** | "The workweek is also expected to become **four hours shorter by 2035** …" |
| **After** | "The workweek is also expected to become **three hours shorter by 2035** …" |

**Why:** Hours chart: 2025 historical = 38.3 hrs, 2035 forecast = 35.1 hrs → **3.2 hours** shorter, not 4. The Key Insights box on the same page correctly reads "35 hours … down from 38 now" (3 hours), making "four hours" internally inconsistent.

---

### Fix 3 — Wages section, AI adoption paragraph (`page.tsx`)

| | Text |
|---|---|
| **Before** | "With only **12%** of workers using AI daily as of late 2025 …" |
| **After** | "With only **10%** of workers using AI daily as of late 2025 …" |

**Why:** The "Percent of workers that use AI daily" chart has a hardcoded historical value of **10%** at 2025 (`historicalValues: { 2025: 10 }`). The commentary cited 12%, which does not appear anywhere in the chart data.

---

### Fix 4 — Key Insights, "Young workers" bullet (`sections/key_insights.tsx`)

| | Text |
|---|---|
| **Before** | "… expected to grow from the **current 6%** to 12% in 2035." |
| **After** | "… expected to grow from the **current 5%** to 12% in 2035." |

**Why:** Graduate unemployment chart: 2025 historical = **5.4%**. `Math.round(5.4) = 5`, so the correct rounded figure is 5%, not 6%.

---

## Files changed

- `front_end/src/app/(main)/labor-hub/jobs_insights.tsx` — Fix 1
- `front_end/src/app/(main)/labor-hub/page.tsx` — Fixes 2 & 3
- `front_end/src/app/(main)/labor-hub/sections/key_insights.tsx` — Fix 4

Supersedes #4709.

https://claude.ai/code/session_01DPu33M7AL7vit3EzNwMSbF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPu33M7AL7vit3EzNwMSbF)_