### PR TITLE
Consumer side-by-side shell, row restyle, and expand/collapse for N-row question types

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/group_timeline.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/group_timeline.tsx
@@ -52,11 +52,14 @@ type Props = QuestionsDataProps & {
   embedMode?: boolean;
   withLegend?: boolean;
   className?: string;
+  externalHighlightedChoice?: string | null;
   prioritizeOpen?: boolean;
   timelineMarkers?: GroupTimelineMarker[];
   activeTimelineMarkerId?: string | null;
   onTimelineMarkerEnter?: (marker: GroupTimelineMarker) => void;
   onTimelineMarkerLeave?: (marker: GroupTimelineMarker) => void;
+  withHighlightArea?: boolean;
+  withHighlightEndpoint?: boolean;
 };
 
 /**
@@ -86,6 +89,9 @@ const GroupTimeline: FC<Props> = ({
   activeTimelineMarkerId,
   onTimelineMarkerEnter,
   onTimelineMarkerLeave,
+  externalHighlightedChoice,
+  withHighlightArea,
+  withHighlightEndpoint,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -167,6 +173,17 @@ const GroupTimeline: FC<Props> = ({
   useEffect(() => {
     setChoiceItems(generateList(questions, group, preselectedQuestionId));
   }, [questions, preselectedQuestionId, generateList, group]);
+
+  // apply external highlight from parent (e.g. consumer row hover)
+  useEffect(() => {
+    if (externalHighlightedChoice === undefined) return;
+    setChoiceItems((prev) =>
+      prev.map((item) => ({
+        ...item,
+        highlighted: item.choice === externalHighlightedChoice,
+      }))
+    );
+  }, [externalHighlightedChoice]);
 
   const [cursorTimestamp, _tooltipDate, handleCursorChange] =
     useTimestampCursor(timestamps);
@@ -335,6 +352,8 @@ const GroupTimeline: FC<Props> = ({
       activeTimelineMarkerId={activeTimelineMarkerId}
       onTimelineMarkerEnter={onTimelineMarkerEnter}
       onTimelineMarkerLeave={onTimelineMarkerLeave}
+      withHighlightArea={withHighlightArea}
+      withHighlightEndpoint={withHighlightEndpoint}
     />
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
@@ -49,6 +49,8 @@ type Props = {
   activeTimelineMarkerId?: string | null;
   onTimelineMarkerEnter?: (marker: GroupTimelineMarker) => void;
   onTimelineMarkerLeave?: (marker: GroupTimelineMarker) => void;
+  withHighlightArea?: boolean;
+  withHighlightEndpoint?: boolean;
 };
 
 const MultiChoicesChartView: FC<Props> = ({
@@ -82,6 +84,8 @@ const MultiChoicesChartView: FC<Props> = ({
   activeTimelineMarkerId,
   onTimelineMarkerEnter,
   onTimelineMarkerLeave,
+  withHighlightArea = true,
+  withHighlightEndpoint = false,
 }) => {
   const { user } = useAuth();
   const isInteracted = useRef(false);
@@ -243,6 +247,8 @@ const MultiChoicesChartView: FC<Props> = ({
     forceAutoZoom: isInteracted.current,
     forecastAvailability,
     attachRef,
+    withHighlightArea,
+    withHighlightEndpoint,
   } as const;
 
   return (

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -47,9 +47,9 @@ import QuestionHeaderCPStatus from "../question_view/forecaster_question_view/qu
 import RevealCPButton from "../reveal_cp_button";
 
 const baseSectionClassName =
-  "relative z-10 flex w-[59rem] max-w-full flex-col gap-6 overflow-x-clip rounded border border-blue-400 p-4 text-gray-900 dark:border-blue-200-dark dark:text-gray-900-dark lg:p-8";
+  "relative flex w-[59rem] max-w-full flex-col gap-6 overflow-x-clip rounded border border-blue-400 p-4 text-gray-900 dark:border-blue-200-dark dark:text-gray-900-dark lg:p-8";
 
-const mainSectionClassName = `${baseSectionClassName} bg-gray-0 dark:bg-gray-0-dark`;
+const mainSectionClassName = `${baseSectionClassName} z-10 bg-gray-0 dark:bg-gray-0-dark`;
 const commentSectionClassName = `${baseSectionClassName} bg-blue-100 dark:bg-gray-0-dark`;
 
 type ShellProps = {

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -6,6 +6,7 @@ import { FC, Fragment, ReactNode, useEffect } from "react";
 import useCoherenceLinksContext from "@/app/(main)/components/coherence_links_provider";
 import { PostStatusBox } from "@/app/(main)/questions/[id]/components/post_status_box";
 import NumericForecastCard from "@/components/consumer_post_card/group_forecast_card/numeric_forecast_card";
+import PercentageForecastCard from "@/components/consumer_post_card/group_forecast_card/percentage_forecast_card";
 import TimeSeriesChart from "@/components/consumer_post_card/time_series_chart";
 import UpcomingCP from "@/components/consumer_post_card/upcoming_cp";
 import DetailedGroupCard from "@/components/detailed_question_card/detailed_group_card";
@@ -167,7 +168,8 @@ export const ConsumerShell: FC<{
     isNonFanGroup &&
     !isDateGroup &&
     !isMultipleChoice &&
-    checkGroupOfQuestionsPostType(postData, QuestionType.Numeric);
+    (checkGroupOfQuestionsPostType(postData, QuestionType.Numeric) ||
+      checkGroupOfQuestionsPostType(postData, QuestionType.Discrete));
 
   const binaryForecastAvailability =
     isBinarySingleQuestion && isQuestionPost(postData)
@@ -271,7 +273,7 @@ export const ConsumerShell: FC<{
           ) : isNRowBody ? (
             <>
               <ConsumerListChartShell
-                stretchListContent={isContinuousNumericGroup && !hideCP}
+                stretchListContent={!hideCP && !isFanGraph}
                 listContent={
                   hideCP ? (
                     <RevealCPButton />
@@ -284,9 +286,10 @@ export const ConsumerShell: FC<{
                   ) : isContinuousNumericGroup ? (
                     <NumericForecastCard post={postData} fillHeight />
                   ) : (
-                    <ConsumerQuestionPrediction
-                      postData={postData}
-                      className="md:mb-0 md:mt-0"
+                    <PercentageForecastCard
+                      post={postData}
+                      forceColorful
+                      fillHeight
                     />
                   )
                 }

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -15,13 +15,13 @@ import { useHideCP } from "@/contexts/cp_context";
 import { useContentTranslatedBannerContext } from "@/contexts/translations_banner_context";
 import {
   GroupOfQuestionsGraphType,
+  GroupOfQuestionsPost,
   PostStatus,
   PostWithForecasts,
   QuestionStatus,
 } from "@/types/post";
 import { TournamentType } from "@/types/projects";
-import { QuestionType } from "@/types/question";
-import cn from "@/utils/core/cn";
+import { QuestionType, QuestionWithNumericForecasts } from "@/types/question";
 import { getQuestionForecastAvailability } from "@/utils/questions/forecastAvailability";
 import {
   checkGroupOfQuestionsPostType,
@@ -40,6 +40,7 @@ import PostScoreData from "../post_score_data";
 import { QuestionLayoutProvider } from "../question_layout/question_layout_context";
 import { QuestionVariantComposer } from "../question_variant_composer";
 import ActionRow from "../question_view/action_row";
+import ConsumerListChartShell from "../question_view/consumer_question_view/consumer_list_chart_shell";
 import ConsumerQuestionPrediction from "../question_view/consumer_question_view/prediction";
 import QuestionTimeline from "../question_view/consumer_question_view/timeline";
 import QuestionHeaderCPStatus from "../question_view/forecaster_question_view/question_header/question_header_cp_status";
@@ -147,9 +148,6 @@ export const ConsumerShell: FC<{
   const isMultipleChoice = isMultipleChoicePost(postData);
   const isNonFanGroup = isGroupOfQuestionsPost(postData) && !isFanGraph;
 
-  const reverseOrder =
-    (isMultipleChoice || isGroupOfQuestionsPost(postData)) && !isDateGroup;
-
   const isContinuousSingleQuestion =
     isQuestionPost(postData) && isContinuousQuestion(postData.question);
 
@@ -158,16 +156,13 @@ export const ConsumerShell: FC<{
     !isContinuousSingleQuestion &&
     !isMultipleChoice;
 
+  const isNRowBody =
+    isMultipleChoice || (isNonFanGroup && !isDateGroup) || isFanGraph;
+
   const binaryForecastAvailability =
     isBinarySingleQuestion && isQuestionPost(postData)
       ? getQuestionForecastAvailability(postData.question)
       : null;
-
-  const showSideBySide =
-    isMultipleChoice ||
-    isNonFanGroup ||
-    isBinarySingleQuestion ||
-    isContinuousSingleQuestion;
 
   const showClosedMessageMultipleChoice =
     isMultipleChoicePost(postData) &&
@@ -218,21 +213,8 @@ export const ConsumerShell: FC<{
               {t("predictionClosedMessage")}
             </p>
           )}
-          <div
-            className={cn(
-              "flex flex-col",
-              reverseOrder &&
-                !isMultipleChoice &&
-                !isNonFanGroup &&
-                "flex-col-reverse",
-              showSideBySide &&
-                cn("sm:flex-row sm:items-center", {
-                  "sm:gap-0 md:gap-8": isBinarySingleQuestion,
-                  "sm:gap-8": !isBinarySingleQuestion,
-                })
-            )}
-          >
-            {isBinarySingleQuestion && isQuestionPost(postData) ? (
+          {isBinarySingleQuestion && isQuestionPost(postData) ? (
+            <div className="flex flex-col sm:flex-row sm:items-center sm:gap-0 md:gap-8">
               <div className="order-1 flex w-64 flex-col items-center justify-center gap-[18px] self-center sm:self-stretch">
                 {hideCP ? (
                   <RevealCPButton />
@@ -247,47 +229,65 @@ export const ConsumerShell: FC<{
                   />
                 )}
               </div>
-            ) : (
-              <div
-                className={cn(
-                  showSideBySide && !isDateGroup ? "order-1" : undefined,
-                  isContinuousSingleQuestion && "md:hidden",
-                  showSideBySide &&
-                    !isDateGroup &&
-                    !isContinuousSingleQuestion &&
-                    "sm:max-w-[200px]",
-                  hideCP &&
-                    !isContinuousSingleQuestion &&
-                    (isDateGroup || isFanGraph) &&
-                    "flex w-full justify-center"
-                )}
-              >
-                {hideCP && !isContinuousSingleQuestion ? (
-                  <RevealCPButton />
-                ) : (
-                  <ConsumerQuestionPrediction postData={postData} />
-                )}
-              </div>
-            )}
-            {!isFanGraph && !isDateGroup && (
               <QuestionTimeline
                 postData={postData}
                 keyFactors={postData.key_factors}
-                isConsumerView={true}
+                isConsumerView
                 preselectedGroupQuestionId={preselectedGroupQuestionId}
-                className={cn(
-                  "hidden sm:block",
-                  showSideBySide && "order-2 mt-0 flex-1",
-                  isContinuousSingleQuestion && "mt-0"
-                )}
+                className="order-2 mt-0 hidden flex-1 sm:block"
               />
-            )}
-            {showClosedMessageFanGraph && (
-              <p className="my-8 text-center text-sm leading-[20px] text-gray-700 dark:text-gray-700-dark">
-                {t("predictionClosedMessage")}
-              </p>
-            )}
-          </div>
+            </div>
+          ) : isContinuousSingleQuestion ? (
+            <div className="flex flex-col sm:flex-row sm:items-center sm:gap-8">
+              <div className="order-1 md:hidden">
+                <ConsumerQuestionPrediction postData={postData} />
+              </div>
+              <QuestionTimeline
+                postData={postData}
+                keyFactors={postData.key_factors}
+                isConsumerView={false}
+                preselectedGroupQuestionId={preselectedGroupQuestionId}
+                className="order-2 mt-0 hidden flex-1 sm:block"
+              />
+            </div>
+          ) : isNRowBody ? (
+            <>
+              <ConsumerListChartShell
+                listContent={
+                  hideCP ? (
+                    <RevealCPButton />
+                  ) : (
+                    <ConsumerQuestionPrediction postData={postData} />
+                  )
+                }
+                chartContent={
+                  isFanGraph ? (
+                    <DetailedGroupCard
+                      post={
+                        postData as GroupOfQuestionsPost<QuestionWithNumericForecasts>
+                      }
+                      preselectedQuestionId={preselectedGroupQuestionId}
+                    />
+                  ) : (
+                    <QuestionTimeline
+                      postData={postData}
+                      keyFactors={postData.key_factors}
+                      isConsumerView
+                      preselectedGroupQuestionId={preselectedGroupQuestionId}
+                      className="mt-0"
+                    />
+                  )
+                }
+              />
+              {showClosedMessageFanGraph && (
+                <p className="my-8 text-center text-sm leading-[20px] text-gray-700 dark:text-gray-700-dark">
+                  {t("predictionClosedMessage")}
+                </p>
+              )}
+            </>
+          ) : (
+            <ConsumerQuestionPrediction postData={postData} />
+          )}
         </div>
         {shouldShowKeyFactorsSection && (
           <div className="order-3 sm:order-none">

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -5,6 +5,7 @@ import { FC, Fragment, ReactNode, useEffect } from "react";
 
 import useCoherenceLinksContext from "@/app/(main)/components/coherence_links_provider";
 import { PostStatusBox } from "@/app/(main)/questions/[id]/components/post_status_box";
+import TimeSeriesChart from "@/components/consumer_post_card/time_series_chart";
 import UpcomingCP from "@/components/consumer_post_card/upcoming_cp";
 import DetailedGroupCard from "@/components/detailed_question_card/detailed_group_card";
 import DetailedQuestionCard from "@/components/detailed_question_card/detailed_question_card";
@@ -23,6 +24,7 @@ import {
 import { TournamentType } from "@/types/projects";
 import { QuestionType, QuestionWithNumericForecasts } from "@/types/question";
 import { getQuestionForecastAvailability } from "@/utils/questions/forecastAvailability";
+import { sortGroupPredictionOptions } from "@/utils/questions/groupOrdering";
 import {
   checkGroupOfQuestionsPostType,
   isContinuousQuestion,
@@ -171,6 +173,14 @@ export const ConsumerShell: FC<{
   const showClosedMessageFanGraph =
     isFanGraph && postData.status === PostStatus.CLOSED;
 
+  const fanGraphQuestions = isFanGraph
+    ? sortGroupPredictionOptions(
+        (postData.group_of_questions?.questions ??
+          []) as QuestionWithNumericForecasts[],
+        postData.group_of_questions
+      )
+    : null;
+
   const questionLinkAggregates =
     aggregateCoherenceLinks?.data.filter(isDisplayableQuestionLink) ?? [];
   const hasKeyFactors = (postData.key_factors?.length ?? 0) > 0;
@@ -256,6 +266,12 @@ export const ConsumerShell: FC<{
                 listContent={
                   hideCP ? (
                     <RevealCPButton />
+                  ) : isFanGraph && fanGraphQuestions ? (
+                    <TimeSeriesChart
+                      questions={fanGraphQuestions}
+                      variant="colorful"
+                      height={180}
+                    />
                   ) : (
                     <ConsumerQuestionPrediction
                       postData={postData}

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -257,7 +257,10 @@ export const ConsumerShell: FC<{
                   hideCP ? (
                     <RevealCPButton />
                   ) : (
-                    <ConsumerQuestionPrediction postData={postData} />
+                    <ConsumerQuestionPrediction
+                      postData={postData}
+                      className="md:mb-0 md:mt-0"
+                    />
                   )
                 }
                 chartContent={

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -5,6 +5,7 @@ import { FC, Fragment, ReactNode, useEffect } from "react";
 
 import useCoherenceLinksContext from "@/app/(main)/components/coherence_links_provider";
 import { PostStatusBox } from "@/app/(main)/questions/[id]/components/post_status_box";
+import NumericForecastCard from "@/components/consumer_post_card/group_forecast_card/numeric_forecast_card";
 import TimeSeriesChart from "@/components/consumer_post_card/time_series_chart";
 import UpcomingCP from "@/components/consumer_post_card/upcoming_cp";
 import DetailedGroupCard from "@/components/detailed_question_card/detailed_group_card";
@@ -42,6 +43,7 @@ import PostScoreData from "../post_score_data";
 import { QuestionLayoutProvider } from "../question_layout/question_layout_context";
 import { QuestionVariantComposer } from "../question_variant_composer";
 import ActionRow from "../question_view/action_row";
+import ConsumerGroupChart from "../question_view/consumer_question_view/consumer_group_chart";
 import ConsumerListChartShell from "../question_view/consumer_question_view/consumer_list_chart_shell";
 import ConsumerQuestionPrediction from "../question_view/consumer_question_view/prediction";
 import QuestionTimeline from "../question_view/consumer_question_view/timeline";
@@ -161,6 +163,12 @@ export const ConsumerShell: FC<{
   const isNRowBody =
     isMultipleChoice || (isNonFanGroup && !isDateGroup) || isFanGraph;
 
+  const isContinuousNumericGroup =
+    isNonFanGroup &&
+    !isDateGroup &&
+    !isMultipleChoice &&
+    checkGroupOfQuestionsPostType(postData, QuestionType.Numeric);
+
   const binaryForecastAvailability =
     isBinarySingleQuestion && isQuestionPost(postData)
       ? getQuestionForecastAvailability(postData.question)
@@ -263,6 +271,7 @@ export const ConsumerShell: FC<{
           ) : isNRowBody ? (
             <>
               <ConsumerListChartShell
+                stretchListContent={isContinuousNumericGroup && !hideCP}
                 listContent={
                   hideCP ? (
                     <RevealCPButton />
@@ -272,6 +281,8 @@ export const ConsumerShell: FC<{
                       variant="colorful"
                       height={180}
                     />
+                  ) : isContinuousNumericGroup ? (
+                    <NumericForecastCard post={postData} fillHeight />
                   ) : (
                     <ConsumerQuestionPrediction
                       postData={postData}
@@ -282,6 +293,13 @@ export const ConsumerShell: FC<{
                 chartContent={
                   isFanGraph ? (
                     <DetailedGroupCard
+                      post={
+                        postData as GroupOfQuestionsPost<QuestionWithNumericForecasts>
+                      }
+                      preselectedQuestionId={preselectedGroupQuestionId}
+                    />
+                  ) : isContinuousNumericGroup ? (
+                    <ConsumerGroupChart
                       post={
                         postData as GroupOfQuestionsPost<QuestionWithNumericForecasts>
                       }

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_group_chart.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { FC } from "react";
+
+import GroupTimeline from "@/app/(main)/questions/[id]/components/group_timeline";
+import { GroupOfQuestionsPost, PostStatus } from "@/types/post";
+import { QuestionWithNumericForecasts } from "@/types/question";
+import { getPostDrivenTime } from "@/utils/questions/helpers";
+
+import { useListChartExpanded } from "./consumer_list_chart_shell";
+
+type Props = {
+  post: GroupOfQuestionsPost<QuestionWithNumericForecasts>;
+  preselectedQuestionId?: number;
+};
+
+const ConsumerGroupChart: FC<Props> = ({ post, preselectedQuestionId }) => {
+  const { hoveredChoiceName, setHoveredChoiceName } = useListChartExpanded();
+  const { open_time, actual_close_time, scheduled_close_time, status } = post;
+  const refCloseTime = actual_close_time ?? scheduled_close_time;
+
+  return (
+    <div onMouseLeave={() => setHoveredChoiceName(null)}>
+      <GroupTimeline
+        group={post.group_of_questions}
+        actualCloseTime={getPostDrivenTime(refCloseTime)}
+        openTime={getPostDrivenTime(open_time)}
+        isClosed={status === PostStatus.CLOSED}
+        preselectedQuestionId={preselectedQuestionId}
+        withLegend={false}
+        withHighlightArea={false}
+        withHighlightEndpoint
+        externalHighlightedChoice={hoveredChoiceName}
+      />
+    </div>
+  );
+};
+
+export default ConsumerGroupChart;

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
@@ -6,10 +6,14 @@ import cn from "@/utils/core/cn";
 
 type ListChartExpandedContextType = {
   setIsExpanded: (value: boolean) => void;
+  hoveredChoiceName: string | null;
+  setHoveredChoiceName: (name: string | null) => void;
 };
 
 const ListChartExpandedContext = createContext<ListChartExpandedContextType>({
   setIsExpanded: () => {},
+  hoveredChoiceName: null,
+  setHoveredChoiceName: () => {},
 });
 
 export const useListChartExpanded = () => useContext(ListChartExpandedContext);
@@ -17,18 +21,25 @@ export const useListChartExpanded = () => useContext(ListChartExpandedContext);
 type Props = {
   listContent: ReactNode;
   chartContent: ReactNode;
+  stretchListContent?: boolean;
   className?: string;
 };
 
 const ConsumerListChartShell: React.FC<Props> = ({
   listContent,
   chartContent,
+  stretchListContent = false,
   className,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [hoveredChoiceName, setHoveredChoiceName] = useState<string | null>(
+    null
+  );
 
   return (
-    <ListChartExpandedContext.Provider value={{ setIsExpanded }}>
+    <ListChartExpandedContext.Provider
+      value={{ setIsExpanded, hoveredChoiceName, setHoveredChoiceName }}
+    >
       <div
         className={cn(
           "flex flex-col sm:rounded-lg sm:border sm:border-gray-400/40 dark:sm:border-gray-400-dark/40",
@@ -36,7 +47,14 @@ const ConsumerListChartShell: React.FC<Props> = ({
           className
         )}
       >
-        <div className="order-1 sm:w-80 sm:shrink-0 sm:p-5">{listContent}</div>
+        <div
+          className={cn(
+            "order-1 sm:w-80 sm:shrink-0 sm:p-5",
+            stretchListContent && "sm:flex sm:flex-col"
+          )}
+        >
+          {listContent}
+        </div>
         <div
           className={cn(
             "relative order-2 hidden flex-1 sm:block sm:p-5",

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
@@ -1,6 +1,18 @@
-import { ReactNode } from "react";
+"use client";
+
+import { createContext, ReactNode, useContext, useState } from "react";
 
 import cn from "@/utils/core/cn";
+
+type ListChartExpandedContextType = {
+  setIsExpanded: (value: boolean) => void;
+};
+
+const ListChartExpandedContext = createContext<ListChartExpandedContextType>({
+  setIsExpanded: () => {},
+});
+
+export const useListChartExpanded = () => useContext(ListChartExpandedContext);
 
 type Props = {
   listContent: ReactNode;
@@ -12,19 +24,31 @@ const ConsumerListChartShell: React.FC<Props> = ({
   listContent,
   chartContent,
   className,
-}) => (
-  <div
-    className={cn(
-      "flex flex-col sm:rounded-lg sm:border sm:border-gray-400/40 dark:sm:border-gray-400-dark/40",
-      "sm:flex-row sm:items-stretch",
-      className
-    )}
-  >
-    <div className="order-1 sm:w-[200px] sm:shrink-0 sm:p-5">{listContent}</div>
-    <div className="order-2 hidden flex-1 sm:block sm:border-l sm:border-gray-400/40 sm:p-5 dark:sm:border-gray-400-dark/40">
-      {chartContent}
-    </div>
-  </div>
-);
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <ListChartExpandedContext.Provider value={{ setIsExpanded }}>
+      <div
+        className={cn(
+          "flex flex-col sm:rounded-lg sm:border sm:border-gray-400/40 dark:sm:border-gray-400-dark/40",
+          "sm:flex-row sm:items-stretch",
+          className
+        )}
+      >
+        <div className="order-1 sm:w-80 sm:shrink-0 sm:p-5">{listContent}</div>
+        <div
+          className={cn(
+            "relative order-2 hidden flex-1 sm:block sm:p-5",
+            "sm:before:absolute sm:before:bottom-0 sm:before:left-0 sm:before:w-px sm:before:bg-gray-400/40 sm:before:content-[''] dark:sm:before:bg-gray-400-dark/40",
+            isExpanded ? "sm:before:top-2" : "sm:before:top-0"
+          )}
+        >
+          {chartContent}
+        </div>
+      </div>
+    </ListChartExpandedContext.Provider>
+  );
+};
 
 export default ConsumerListChartShell;

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from "react";
+
+import cn from "@/utils/core/cn";
+
+type Props = {
+  listContent: ReactNode;
+  chartContent: ReactNode;
+  className?: string;
+};
+
+const ConsumerListChartShell: React.FC<Props> = ({
+  listContent,
+  chartContent,
+  className,
+}) => (
+  <div
+    className={cn(
+      "flex flex-col sm:rounded-lg sm:border sm:border-gray-400/40 dark:sm:border-gray-400-dark/40",
+      "sm:flex-row sm:items-stretch",
+      className
+    )}
+  >
+    <div className="order-1 sm:max-w-[200px] sm:p-5">{listContent}</div>
+    <div className="order-2 hidden flex-1 sm:block sm:border-l sm:border-gray-400/40 sm:p-5 dark:sm:border-gray-400-dark/40">
+      {chartContent}
+    </div>
+  </div>
+);
+
+export default ConsumerListChartShell;

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
@@ -20,7 +20,7 @@ const ConsumerListChartShell: React.FC<Props> = ({
       className
     )}
   >
-    <div className="order-1 sm:max-w-[200px] sm:p-5">{listContent}</div>
+    <div className="order-1 sm:w-[200px] sm:shrink-0 sm:p-5">{listContent}</div>
     <div className="order-2 hidden flex-1 sm:block sm:border-l sm:border-gray-400/40 sm:p-5 dark:sm:border-gray-400-dark/40">
       {chartContent}
     </div>

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, ReactNode, useContext, useState } from "react";
+import { createContext, ReactNode, useContext, useMemo, useState } from "react";
 
 import cn from "@/utils/core/cn";
 
@@ -36,10 +36,14 @@ const ConsumerListChartShell: React.FC<Props> = ({
     null
   );
 
+  // Memoize so isExpanded changes don't re-render context consumers (e.g. the chart).
+  const contextValue = useMemo(
+    () => ({ setIsExpanded, hoveredChoiceName, setHoveredChoiceName }),
+    [hoveredChoiceName, setHoveredChoiceName, setIsExpanded]
+  );
+
   return (
-    <ListChartExpandedContext.Provider
-      value={{ setIsExpanded, hoveredChoiceName, setHoveredChoiceName }}
-    >
+    <ListChartExpandedContext.Provider value={contextValue}>
       <div
         className={cn(
           "flex flex-col sm:rounded-lg sm:border sm:border-gray-400/40 dark:sm:border-gray-400-dark/40",

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/group_of_questions_prediction/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/group_of_questions_prediction/index.tsx
@@ -4,6 +4,7 @@ import PercentageForecastCard from "@/components/consumer_post_card/group_foreca
 import TimeSeriesChart from "@/components/consumer_post_card/time_series_chart";
 import { GroupOfQuestionsGraphType, PostWithForecasts } from "@/types/post";
 import { QuestionType } from "@/types/question";
+import cn from "@/utils/core/cn";
 import { getGroupForecastAvailability } from "@/utils/questions/forecastAvailability";
 import { sortGroupPredictionOptions } from "@/utils/questions/groupOrdering";
 import {
@@ -13,9 +14,13 @@ import {
 
 type Props = {
   postData: PostWithForecasts;
+  className?: string;
 };
 
-const GroupOfQuestionsPrediction: React.FC<Props> = ({ postData }) => {
+const GroupOfQuestionsPrediction: React.FC<Props> = ({
+  postData,
+  className,
+}) => {
   let content: React.ReactNode | null = null;
 
   if (
@@ -72,7 +77,7 @@ const GroupOfQuestionsPrediction: React.FC<Props> = ({ postData }) => {
       ? "md:mb-7"
       : "md:mt-7";
 
-  return <div className={wrapperClass}>{content}</div>;
+  return <div className={cn(wrapperClass, className)}>{content}</div>;
 };
 
 export default GroupOfQuestionsPrediction;

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/index.tsx
@@ -14,9 +14,13 @@ import SingleQuestionPrediction from "./single_question_prediction";
 
 type Props = {
   postData: PostWithForecasts;
+  className?: string;
 };
 
-const ConsumerQuestionPrediction: React.FC<Props> = ({ postData }) => {
+const ConsumerQuestionPrediction: React.FC<Props> = ({
+  postData,
+  className,
+}) => {
   const { user } = useAuth();
 
   if (isQuestionPost(postData) && !isMultipleChoicePost(postData)) {
@@ -29,7 +33,9 @@ const ConsumerQuestionPrediction: React.FC<Props> = ({ postData }) => {
   }
 
   if (isMultipleChoicePost(postData) || isGroupOfQuestionsPost(postData)) {
-    return <GroupOfQuestionsPrediction postData={postData} />;
+    return (
+      <GroupOfQuestionsPrediction postData={postData} className={className} />
+    );
   }
 
   return null;

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/timeline/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/timeline/index.tsx
@@ -87,6 +87,7 @@ const QuestionTimeline: React.FC<Props> = ({
           <DetailedGroupCard
             post={postData}
             preselectedQuestionId={preselectedGroupQuestionId}
+            withLegend={!isConsumerView}
           />
         )}
       </div>

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/similar_question_prediction_chip.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/similar_question_prediction_chip.tsx
@@ -36,14 +36,19 @@ const SimilarPredictionChip: FC<Props> = ({ post, variant }) => {
     ) {
       return (
         <div className="w-full">
-          <PercentageForecastCard post={post} forceColorful compact />
+          <PercentageForecastCard
+            post={post}
+            forceColorful
+            compact
+            buttonVariant="minimal"
+          />
         </div>
       );
     }
     if (isGroupOfQuestionsPost(post)) {
       return (
         <div className="w-full">
-          <GroupForecastCard post={post} compact />
+          <GroupForecastCard post={post} compact buttonVariant="minimal" />
         </div>
       );
     }

--- a/front_end/src/components/charts/group_chart.tsx
+++ b/front_end/src/components/charts/group_chart.tsx
@@ -90,6 +90,8 @@ type Props = {
   onTimelineMarkerLeave?: (marker: GroupTimelineMarker) => void;
   animate?: object;
   leftPadding?: number;
+  withHighlightArea?: boolean;
+  withHighlightEndpoint?: boolean;
 };
 
 const LABEL_FONT_FAMILY = "Inter";
@@ -133,6 +135,8 @@ const GroupChart: FC<Props> = ({
   onTimelineMarkerLeave,
   animate,
   leftPadding = 0,
+  withHighlightArea = true,
+  withHighlightEndpoint = false,
 }) => {
   const t = useTranslations();
   const {
@@ -377,10 +381,14 @@ const GroupChart: FC<Props> = ({
                       }
                     },
                     onMouseLeave: () => {
-                      if (!onCursorChange) return;
                       inPlotRef.current = false;
                       setIsCursorActive(false);
                       setLocalCursorTimestamp(null);
+                      // Reset to last timestamp so lines don't stay frozen at last hovered position.
+                      const lastTs = timestamps.at(-1);
+                      if (onCursorChange && !isNil(lastTs)) {
+                        onCursorChange(lastTs, () => "");
+                      }
                     },
                   },
                 },
@@ -509,13 +517,45 @@ const GroupChart: FC<Props> = ({
                           : highlighted
                             ? 1
                             : 0.3,
-                        strokeWidth: 1.5,
+                        strokeWidth: isHighlightActive && highlighted ? 3 : 1.5,
                       },
                     }}
                     interpolation="stepAfter"
                   />
                 );
               })}
+              {/* Line endpoint dot */}
+              {withHighlightEndpoint &&
+                graphs.map(
+                  ({ color, active, line, highlighted, isClosed }, index) => {
+                    if (!active) return null;
+                    const filteredLine = filteredLines[index];
+                    if (!filteredLine) return null;
+                    const point = {
+                      x: isClosed
+                        ? line?.at(-1)?.x ?? Number(xDomain[1])
+                        : Number(xDomain[1]),
+                      y: line?.at(-1)?.y ?? 0,
+                    };
+                    return (
+                      <VictoryScatter
+                        key={`group-endpoint-${index}`}
+                        data={[point]}
+                        size={4}
+                        style={{
+                          data: {
+                            fill: getThemeColor(color),
+                            fillOpacity: !isHighlightActive
+                              ? baseLineOpacity
+                              : highlighted
+                                ? 1
+                                : 0.3,
+                          },
+                        }}
+                      />
+                    );
+                  }
+                )}
               {/* Line cursor points */}
               {graphs.map(
                 ({ color, active, line, highlighted, isClosed }, index) => {
@@ -569,7 +609,7 @@ const GroupChart: FC<Props> = ({
                     style={{
                       data: {
                         fill: getThemeColor(color),
-                        opacity: highlighted ? 0.3 : 0,
+                        opacity: withHighlightArea && highlighted ? 0.3 : 0,
                       },
                     }}
                     interpolation="stepAfter"

--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
@@ -1,3 +1,5 @@
+import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslations } from "next-intl";
 import { FC, PropsWithChildren } from "react";
 
@@ -8,21 +10,28 @@ type Props = {
   othersTotal?: number;
   expanded?: boolean;
   onExpand?: () => void;
+  onCollapse?: () => void;
   hideOthersValue?: boolean;
   compact?: boolean;
 };
 
 const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
   otherItemsCount,
-  othersTotal = 0,
   expanded = false,
   onExpand,
-  hideOthersValue = false,
+  onCollapse,
   compact = false,
   children,
 }) => {
   const t = useTranslations();
-  const showRow = !expanded && otherItemsCount > 0;
+  const showExpandRow = !expanded && otherItemsCount > 0;
+
+  const toggleButtonClassName = cn(
+    "flex w-full self-stretch items-center gap-2 rounded-lg px-[13px]",
+    "bg-blue-500/20 dark:bg-blue-500-dark/20",
+    "text-sm font-medium leading-4 text-blue-700 dark:text-blue-700-dark",
+    compact ? "h-6 md:h-8" : "h-8"
+  );
 
   return (
     <div
@@ -33,55 +42,27 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
     >
       {children}
 
-      {showRow && (
+      {showExpandRow && (
         <button
           type="button"
           onClick={onExpand}
           aria-pressed={false}
-          className={cn(
-            "group relative flex w-full items-center justify-between gap-3 rounded-[8px]",
-            compact
-              ? "h-6 px-2 py-0.5 md:h-8 md:px-[10px] md:py-1"
-              : "h-8 px-[10px] py-1",
-            "border border-blue-400 bg-white",
-            "dark:border-blue-400-dark dark:bg-transparent"
-          )}
+          className={toggleButtonClassName}
         >
-          <span
-            className={cn(
-              "absolute -inset-[1px] inline-flex items-center text-nowrap rounded-[8px] px-3 py-1 text-gray-700 dark:text-gray-700-dark",
-              compact && "text-xs md:text-base",
-              "border border-gray-500 dark:border-gray-500-dark",
-              "group-hover:border-gray-600 group-hover:dark:border-gray-600-dark",
-              "bg-gray-100 transition-colors dark:bg-gray-100-dark",
-              "group-hover:bg-gray-200 dark:group-hover:bg-gray-200-dark",
-              "group-active:bg-gray-300 dark:group-active:bg-gray-300-dark",
-              "group-hover:text-gray-800 dark:group-hover:text-gray-800-dark"
-            )}
-            style={{
-              width: (() => {
-                const hasPct =
-                  typeof othersTotal === "number" && !Number.isNaN(othersTotal);
-                const pct = hasPct
-                  ? Math.min(100, Math.max(0, othersTotal))
-                  : Math.min(100, Math.max(0, otherItemsCount));
-                return `calc(${pct}% + 2px)`;
-              })(),
-            }}
-          >
-            {t("otherWithCount", { count: otherItemsCount })}
-          </span>
+          <FontAwesomeIcon icon={faChevronDown} className="h-4 w-4" />
+          {t("otherWithCount", { count: otherItemsCount })}
+        </button>
+      )}
 
-          {!hideOthersValue && (
-            <span
-              className={cn(
-                "ml-auto font-semibold text-gray-900 dark:text-gray-900-dark",
-                compact && "text-xs font-normal md:text-base md:font-semibold"
-              )}
-            >
-              {Math.round(othersTotal)}%
-            </span>
-          )}
+      {expanded && onCollapse && (
+        <button
+          type="button"
+          onClick={onCollapse}
+          aria-pressed={true}
+          className={toggleButtonClassName}
+        >
+          <FontAwesomeIcon icon={faChevronUp} className="h-4 w-4" />
+          {t("collapse")}
         </button>
       )}
     </div>

--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
@@ -1,4 +1,8 @@
-import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
+import {
+  faChevronDown,
+  faChevronUp,
+  faEllipsis,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslations } from "next-intl";
 import { FC, PropsWithChildren } from "react";
@@ -13,6 +17,7 @@ type Props = {
   onCollapse?: () => void;
   hideOthersValue?: boolean;
   compact?: boolean;
+  buttonVariant?: "primary" | "minimal";
 };
 
 const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
@@ -21,16 +26,21 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
   onExpand,
   onCollapse,
   compact = false,
+  buttonVariant = "primary",
   children,
 }) => {
   const t = useTranslations();
   const showExpandRow = !expanded && otherItemsCount > 0;
 
+  const isMinimal = buttonVariant === "minimal";
+
   const toggleButtonClassName = cn(
     "flex w-full self-stretch items-center gap-2 rounded-lg px-[13px]",
-    "bg-blue-500/20 dark:bg-blue-500-dark/20",
-    "text-sm font-medium leading-4 text-blue-700 dark:text-blue-700-dark",
-    compact ? "h-6 md:h-8" : "h-8"
+    "font-medium leading-4",
+    compact ? "h-6 md:h-8" : "h-8",
+    isMinimal
+      ? "border border-gray-300 text-xs text-gray-700 sm:text-sm dark:border-gray-300-dark dark:text-gray-700-dark"
+      : "bg-blue-500/20 text-sm text-blue-700 dark:bg-blue-500-dark/20 dark:text-blue-700-dark"
   );
 
   return (
@@ -45,11 +55,16 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
       {showExpandRow && (
         <button
           type="button"
-          onClick={onExpand}
+          onClick={isMinimal ? undefined : onExpand}
           aria-pressed={false}
           className={toggleButtonClassName}
         >
-          <FontAwesomeIcon icon={faChevronDown} className="h-4 w-4" />
+          <FontAwesomeIcon
+            icon={isMinimal ? faEllipsis : faChevronDown}
+            className={cn(
+              isMinimal ? "h-3 w-3 opacity-[0.45] sm:h-4 sm:w-4" : "h-4 w-4"
+            )}
+          />
           {t("otherWithCount", { count: otherItemsCount })}
         </button>
       )}
@@ -61,7 +76,12 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
           aria-pressed={true}
           className={toggleButtonClassName}
         >
-          <FontAwesomeIcon icon={faChevronUp} className="h-4 w-4" />
+          <FontAwesomeIcon
+            icon={isMinimal ? faEllipsis : faChevronUp}
+            className={cn(
+              isMinimal ? "h-3 w-3 opacity-[0.45] sm:h-4 sm:w-4" : "h-4 w-4"
+            )}
+          />
           {t("collapse")}
         </button>
       )}

--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
@@ -11,13 +11,12 @@ import cn from "@/utils/core/cn";
 
 type Props = {
   otherItemsCount: number;
-  othersTotal?: number;
   expanded?: boolean;
   onExpand?: () => void;
   onCollapse?: () => void;
-  hideOthersValue?: boolean;
   compact?: boolean;
   buttonVariant?: "primary" | "minimal";
+  className?: string;
 };
 
 const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
@@ -27,6 +26,7 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
   onCollapse,
   compact = false,
   buttonVariant = "primary",
+  className,
   children,
 }) => {
   const t = useTranslations();
@@ -47,7 +47,8 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
     <div
       className={cn(
         "flex w-full flex-col",
-        compact ? "gap-1 md:gap-2" : "gap-2"
+        compact ? "gap-1 md:gap-2" : "gap-2",
+        className
       )}
     >
       {children}

--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
@@ -53,22 +53,26 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
     >
       {children}
 
-      {showExpandRow && (
-        <button
-          type="button"
-          onClick={isMinimal ? undefined : onExpand}
-          aria-pressed={false}
-          className={toggleButtonClassName}
-        >
-          <FontAwesomeIcon
-            icon={isMinimal ? faEllipsis : faChevronDown}
-            className={cn(
-              isMinimal ? "h-3 w-3 opacity-[0.45] sm:h-4 sm:w-4" : "h-4 w-4"
-            )}
-          />
-          {t("otherWithCount", { count: otherItemsCount })}
-        </button>
-      )}
+      {showExpandRow &&
+        (isMinimal ? (
+          <div className={toggleButtonClassName}>
+            <FontAwesomeIcon
+              icon={faEllipsis}
+              className="h-3 w-3 opacity-[0.45] sm:h-4 sm:w-4"
+            />
+            {t("otherWithCount", { count: otherItemsCount })}
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={onExpand}
+            aria-pressed={false}
+            className={toggleButtonClassName}
+          >
+            <FontAwesomeIcon icon={faChevronDown} className="h-4 w-4" />
+            {t("otherWithCount", { count: otherItemsCount })}
+          </button>
+        ))}
 
       {expanded && onCollapse && (
         <button

--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_choice_bar.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_choice_bar.tsx
@@ -37,6 +37,7 @@ const ForecastChoiceBar: FC<Props> = ({
   displayedResolution,
   resolution,
   color,
+  isBordered = true,
   unit,
   forceColorful = false,
   compact = false,
@@ -50,7 +51,10 @@ const ForecastChoiceBar: FC<Props> = ({
   return (
     <div
       className={cn(
-        "relative flex w-full items-center justify-between gap-2 rounded-lg border border-blue-400 bg-transparent font-medium text-gray-800 dark:border-blue-400-dark dark:text-gray-800-dark",
+        "relative flex w-full items-center justify-between gap-2 rounded-lg bg-transparent font-medium text-gray-800 dark:text-gray-800-dark",
+        isBordered
+          ? "border border-blue-400 dark:border-blue-400-dark"
+          : "border border-transparent",
         compact
           ? "h-6 px-2 py-0.5 text-xs leading-4 md:h-8 md:px-2.5 md:py-1 md:text-base md:leading-6"
           : "h-8 px-2.5 py-1 text-base leading-6",

--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_choice_bar.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_choice_bar.tsx
@@ -59,7 +59,9 @@ const ForecastChoiceBar: FC<Props> = ({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className={cn(
-        "group relative flex w-full items-center justify-between gap-2 rounded-lg bg-transparent font-medium text-gray-800 transition-colors hover:bg-blue-500/20 dark:text-gray-800-dark dark:hover:bg-blue-500-dark/20",
+        "relative flex w-full items-center justify-between gap-2 rounded-lg bg-transparent font-medium text-gray-800 dark:text-gray-800-dark",
+        onMouseEnter &&
+          "group transition-colors hover:bg-blue-500/20 dark:hover:bg-blue-500-dark/20",
         className,
         isBordered
           ? "border border-blue-400 dark:border-blue-400-dark"
@@ -109,7 +111,9 @@ const ForecastChoiceBar: FC<Props> = ({
       {isCpRevealed && (
         <div
           className={cn(
-            "absolute -inset-[1px] z-0 rounded-lg border opacity-75 transition-opacity group-hover:opacity-100",
+            "absolute -inset-[1px] z-0 rounded-lg border",
+            onMouseEnter &&
+              "opacity-75 transition-opacity group-hover:opacity-100",
             {
               "border-2": resolution,
             }

--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_choice_bar.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_choice_bar.tsx
@@ -25,6 +25,9 @@ type Props = {
   unit?: string;
   forceColorful?: boolean;
   compact?: boolean;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+  className?: string;
 };
 
 const WIDTH_ADJUSTMENT = 2;
@@ -41,6 +44,9 @@ const ForecastChoiceBar: FC<Props> = ({
   unit,
   forceColorful = false,
   compact = false,
+  onMouseEnter,
+  onMouseLeave,
+  className,
 }) => {
   const t = useTranslations();
   const { getThemeColor } = useAppTheme();
@@ -50,8 +56,11 @@ const ForecastChoiceBar: FC<Props> = ({
   const isResolutionSuccessful = isSuccessfullyResolved(resolution);
   return (
     <div
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       className={cn(
-        "relative flex w-full items-center justify-between gap-2 rounded-lg bg-transparent font-medium text-gray-800 dark:text-gray-800-dark",
+        "group relative flex w-full items-center justify-between gap-2 rounded-lg bg-transparent font-medium text-gray-800 transition-colors hover:bg-blue-500/20 dark:text-gray-800-dark dark:hover:bg-blue-500-dark/20",
+        className,
         isBordered
           ? "border border-blue-400 dark:border-blue-400-dark"
           : "border border-transparent",
@@ -100,8 +109,7 @@ const ForecastChoiceBar: FC<Props> = ({
       {isCpRevealed && (
         <div
           className={cn(
-            "absolute -inset-[1px] z-0 rounded-lg border",
-            compact ? "h-6 md:h-8" : "h-8",
+            "absolute -inset-[1px] z-0 rounded-lg border opacity-75 transition-opacity group-hover:opacity-100",
             {
               "border-2": resolution,
             }
@@ -122,12 +130,12 @@ const ForecastChoiceBar: FC<Props> = ({
                   mounted
                     ? getThemeColor(METAC_COLORS.gray["500"])
                     : METAC_COLORS.gray["500"].DEFAULT,
-                  0.3
+                  0.4
                 );
               }
               return addOpacityToHex(
                 mounted ? getThemeColor(color) : color.DEFAULT,
-                0.3
+                0.4
               );
             })(),
             borderColor: (() => {

--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_choice_bar.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_choice_bar.tsx
@@ -37,7 +37,6 @@ const ForecastChoiceBar: FC<Props> = ({
   displayedResolution,
   resolution,
   color,
-  isBordered = false,
   unit,
   forceColorful = false,
   compact = false,
@@ -56,7 +55,6 @@ const ForecastChoiceBar: FC<Props> = ({
           ? "h-6 px-2 py-0.5 text-xs leading-4 md:h-8 md:px-2.5 md:py-1 md:text-base md:leading-6"
           : "h-8 px-2.5 py-1 text-base leading-6",
         {
-          "border-transparent": !isBordered,
           "text-purple-800 dark:text-purple-800-dark": isResolutionSuccessful,
           "border-2 border-gray-400 text-gray-700 dark:border-gray-400-dark dark:text-gray-700-dark":
             !isNil(resolution) && !isResolutionSuccessful,

--- a/front_end/src/components/consumer_post_card/group_forecast_card/index.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/index.tsx
@@ -17,9 +17,10 @@ import PercentageForecastCard from "./percentage_forecast_card";
 type Props = {
   post: PostWithForecasts;
   compact?: boolean;
+  buttonVariant?: "primary" | "minimal";
 };
 
-const GroupForecastCard: FC<Props> = ({ post, compact }) => {
+const GroupForecastCard: FC<Props> = ({ post, compact, buttonVariant }) => {
   // Check forecast availability for group posts
   const forecastAvailability = post.group_of_questions
     ? getGroupForecastAvailability(post.group_of_questions.questions)
@@ -47,20 +48,38 @@ const GroupForecastCard: FC<Props> = ({ post, compact }) => {
     isMultipleChoicePost(post) ||
     checkGroupOfQuestionsPostType(post, QuestionType.Binary)
   ) {
-    return <PercentageForecastCard post={post} compact={compact} />;
+    return (
+      <PercentageForecastCard
+        post={post}
+        compact={compact}
+        buttonVariant={buttonVariant}
+      />
+    );
   }
   if (
     checkGroupOfQuestionsPostType(post, QuestionType.Numeric) ||
     checkGroupOfQuestionsPostType(post, QuestionType.Discrete)
   ) {
-    return <NumericForecastCard post={post} compact={compact} />;
+    return (
+      <NumericForecastCard
+        post={post}
+        compact={compact}
+        buttonVariant={buttonVariant}
+      />
+    );
   }
   if (
     post.group_of_questions &&
     checkGroupOfQuestionsPostType(post, QuestionType.Date)
   ) {
     if (compact) {
-      return <NumericForecastCard post={post} compact />;
+      return (
+        <NumericForecastCard
+          post={post}
+          compact
+          buttonVariant={buttonVariant}
+        />
+      );
     }
     return (
       <DateForecastCard post={post} questionsGroup={post.group_of_questions} />

--- a/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
@@ -23,9 +23,15 @@ type Props = {
   post: PostWithForecasts;
   forceColorful?: boolean;
   compact?: boolean;
+  buttonVariant?: "primary" | "minimal";
 };
 
-const NumericForecastCard: FC<Props> = ({ post, forceColorful, compact }) => {
+const NumericForecastCard: FC<Props> = ({
+  post,
+  forceColorful,
+  compact,
+  buttonVariant,
+}) => {
   const locale = useLocale();
   const t = useTranslations();
   const [expanded, setExpanded] = useState(false);
@@ -147,6 +153,7 @@ const NumericForecastCard: FC<Props> = ({ post, forceColorful, compact }) => {
           }}
           hideOthersValue
           compact={compact}
+          buttonVariant={buttonVariant}
         >
           {renderBars(collapsedChoices)}
         </ForecastCardWrapper>
@@ -163,6 +170,7 @@ const NumericForecastCard: FC<Props> = ({ post, forceColorful, compact }) => {
             }}
             hideOthersValue
             compact={compact}
+            buttonVariant={buttonVariant}
           >
             {renderBars(sortedChoices)}
           </ForecastCardWrapper>

--- a/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
@@ -87,20 +87,27 @@ const NumericForecastCard: FC<Props> = ({
   const maxScaledValue = Math.max(...scaledValues);
   const minScaledValue = Math.min(...scaledValues);
 
-  const renderBars = (choices: typeof sortedChoices, stretchBars = false) =>
+  const renderBars = (
+    choices: typeof sortedChoices,
+    stretchBars = false,
+    hoverUpTo = Infinity
+  ) =>
     choices.map(
-      ({
-        closeTime,
-        aggregationValues,
-        scaling,
-        resolution,
-        id,
-        color,
-        displayedResolution,
-        choice,
-        actual_resolve_time,
-        unit,
-      }) => {
+      (
+        {
+          closeTime,
+          aggregationValues,
+          scaling,
+          resolution,
+          id,
+          color,
+          displayedResolution,
+          choice,
+          actual_resolve_time,
+          unit,
+        },
+        index
+      ) => {
         const isChoiceClosed = closeTime ? closeTime < Date.now() : false;
         const rawChoiceValue =
           aggregationValues[aggregationValues.length - 1] ?? null;
@@ -140,36 +147,38 @@ const NumericForecastCard: FC<Props> = ({
             forceColorful={forceColorful}
             compact={compact}
             isBordered={false}
-            onMouseEnter={() => setHoveredChoiceName(choice)}
-            onMouseLeave={() => setHoveredChoiceName(null)}
+            onMouseEnter={
+              index < hoverUpTo ? () => setHoveredChoiceName(choice) : undefined
+            }
+            onMouseLeave={
+              index < hoverUpTo ? () => setHoveredChoiceName(null) : undefined
+            }
             className={stretchBars ? "flex-1" : undefined}
           />
         );
       }
     );
 
+  // Only fill height when all items are visible (no expand button).
+  const effectiveFillHeight = fillHeight && hiddenCount === 0;
+
   return (
-    <div className={cn("relative", fillHeight && "flex flex-1 flex-col")}>
-      <div
-        className={cn(
-          fillHeight && "flex flex-1 flex-col",
-          expanded && "invisible"
-        )}
+    <div
+      className={cn("relative", effectiveFillHeight && "flex flex-1 flex-col")}
+    >
+      <ForecastCardWrapper
+        otherItemsCount={hiddenCount}
+        expanded={false}
+        onExpand={() => {
+          setExpanded(true);
+          setIsExpanded(true);
+        }}
+        compact={compact}
+        buttonVariant={buttonVariant}
+        className={effectiveFillHeight ? "flex-1" : undefined}
       >
-        <ForecastCardWrapper
-          otherItemsCount={hiddenCount}
-          expanded={false}
-          onExpand={() => {
-            setExpanded(true);
-            setIsExpanded(true);
-          }}
-          compact={compact}
-          buttonVariant={buttonVariant}
-          className={fillHeight ? "flex-1" : undefined}
-        >
-          {renderBars(collapsedChoices, fillHeight)}
-        </ForecastCardWrapper>
-      </div>
+        {renderBars(collapsedChoices, effectiveFillHeight)}
+      </ForecastCardWrapper>
 
       {expanded && (
         <div className="absolute -left-[21px] -top-[21px] z-20 w-[calc(100%+42px)] rounded-lg border border-gray-400/40 bg-gray-0 p-5 dark:border-gray-400-dark/40 dark:bg-gray-0-dark">
@@ -183,7 +192,7 @@ const NumericForecastCard: FC<Props> = ({
             compact={compact}
             buttonVariant={buttonVariant}
           >
-            {renderBars(sortedChoices)}
+            {renderBars(sortedChoices, false, visibleChoicesCount)}
           </ForecastCardWrapper>
         </div>
       )}

--- a/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
@@ -8,6 +8,7 @@ import { useListChartExpanded } from "@/app/(main)/questions/[id]/components/que
 import { getEffectiveVisibleCount } from "@/constants/questions";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import { QuestionType, Scaling } from "@/types/question";
+import cn from "@/utils/core/cn";
 import { getPredictionDisplayValue } from "@/utils/formatters/prediction";
 import { scaleInternalLocation } from "@/utils/math";
 import { generateChoiceItemsFromGroupQuestions } from "@/utils/questions/choices";
@@ -24,6 +25,7 @@ type Props = {
   forceColorful?: boolean;
   compact?: boolean;
   buttonVariant?: "primary" | "minimal";
+  fillHeight?: boolean;
 };
 
 const NumericForecastCard: FC<Props> = ({
@@ -31,11 +33,12 @@ const NumericForecastCard: FC<Props> = ({
   forceColorful,
   compact,
   buttonVariant,
+  fillHeight = false,
 }) => {
   const locale = useLocale();
   const t = useTranslations();
   const [expanded, setExpanded] = useState(false);
-  const { setIsExpanded } = useListChartExpanded();
+  const { setIsExpanded, setHoveredChoiceName } = useListChartExpanded();
 
   if (!isGroupOfQuestionsPost(post)) {
     return null;
@@ -84,7 +87,7 @@ const NumericForecastCard: FC<Props> = ({
   const maxScaledValue = Math.max(...scaledValues);
   const minScaledValue = Math.min(...scaledValues);
 
-  const renderBars = (choices: typeof sortedChoices) =>
+  const renderBars = (choices: typeof sortedChoices, stretchBars = false) =>
     choices.map(
       ({
         closeTime,
@@ -136,14 +139,23 @@ const NumericForecastCard: FC<Props> = ({
             unit={unit}
             forceColorful={forceColorful}
             compact={compact}
+            isBordered={false}
+            onMouseEnter={() => setHoveredChoiceName(choice)}
+            onMouseLeave={() => setHoveredChoiceName(null)}
+            className={stretchBars ? "flex-1" : undefined}
           />
         );
       }
     );
 
   return (
-    <div className="relative">
-      <div className={expanded ? "invisible" : undefined}>
+    <div className={cn("relative", fillHeight && "flex flex-1 flex-col")}>
+      <div
+        className={cn(
+          fillHeight && "flex flex-1 flex-col",
+          expanded && "invisible"
+        )}
+      >
         <ForecastCardWrapper
           otherItemsCount={hiddenCount}
           expanded={false}
@@ -151,11 +163,11 @@ const NumericForecastCard: FC<Props> = ({
             setExpanded(true);
             setIsExpanded(true);
           }}
-          hideOthersValue
           compact={compact}
           buttonVariant={buttonVariant}
+          className={fillHeight ? "flex-1" : undefined}
         >
-          {renderBars(collapsedChoices)}
+          {renderBars(collapsedChoices, fillHeight)}
         </ForecastCardWrapper>
       </div>
 
@@ -168,7 +180,6 @@ const NumericForecastCard: FC<Props> = ({
               setExpanded(false);
               setIsExpanded(false);
             }}
-            hideOthersValue
             compact={compact}
             buttonVariant={buttonVariant}
           >

--- a/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
@@ -4,6 +4,7 @@ import { isNil } from "lodash";
 import { useLocale, useTranslations } from "next-intl";
 import { FC, useState } from "react";
 
+import { useListChartExpanded } from "@/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell";
 import { getEffectiveVisibleCount } from "@/constants/questions";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import { QuestionType, Scaling } from "@/types/question";
@@ -28,6 +29,7 @@ const NumericForecastCard: FC<Props> = ({ post, forceColorful, compact }) => {
   const locale = useLocale();
   const t = useTranslations();
   const [expanded, setExpanded] = useState(false);
+  const { setIsExpanded } = useListChartExpanded();
 
   if (!isGroupOfQuestionsPost(post)) {
     return null;
@@ -58,10 +60,8 @@ const NumericForecastCard: FC<Props> = ({ post, forceColorful, compact }) => {
   });
 
   const isPostClosed = post.status === PostStatus.CLOSED;
-
-  const visibleChoices = expanded
-    ? sortedChoices
-    : sortedChoices.slice(0, visibleChoicesCount);
+  const hiddenCount = Math.max(0, sortedChoices.length - visibleChoicesCount);
+  const collapsedChoices = sortedChoices.slice(0, visibleChoicesCount);
 
   const scaledValues = [...sortedChoices]
     .filter((choice) => isNil(choice.resolution))
@@ -78,79 +78,97 @@ const NumericForecastCard: FC<Props> = ({ post, forceColorful, compact }) => {
   const maxScaledValue = Math.max(...scaledValues);
   const minScaledValue = Math.min(...scaledValues);
 
-  return (
-    <ForecastCardWrapper
-      otherItemsCount={
-        expanded ? 0 : Math.max(0, sortedChoices.length - visibleChoicesCount)
+  const renderBars = (choices: typeof sortedChoices) =>
+    choices.map(
+      ({
+        closeTime,
+        aggregationValues,
+        scaling,
+        resolution,
+        id,
+        color,
+        displayedResolution,
+        choice,
+        actual_resolve_time,
+        unit,
+      }) => {
+        const isChoiceClosed = closeTime ? closeTime < Date.now() : false;
+        const rawChoiceValue =
+          aggregationValues[aggregationValues.length - 1] ?? null;
+        const normalizedScaling: Scaling = {
+          range_min: scaling?.range_min ?? 0,
+          range_max: scaling?.range_max ?? 1,
+          zero_point: scaling?.zero_point ?? null,
+        };
+        const formattedChoiceValue = getPredictionDisplayValue(rawChoiceValue, {
+          questionType: isDateGroup ? QuestionType.Date : QuestionType.Numeric,
+          scaling: normalizedScaling,
+          actual_resolve_time: actual_resolve_time ?? null,
+          emptyLabel: t("Upcoming"),
+        });
+        const scaledChoiceValue = !isNil(rawChoiceValue)
+          ? scaleInternalLocation(rawChoiceValue, normalizedScaling)
+          : NaN;
+        const relativeWidth = !isNil(resolution)
+          ? 100
+          : calculateRelativeWidth({
+              scaledChoiceValue,
+              maxScaledValue,
+              minScaledValue,
+            });
+
+        return (
+          <ForecastChoiceBar
+            key={id}
+            choiceLabel={choice}
+            choiceValue={formattedChoiceValue}
+            isClosed={isChoiceClosed || isPostClosed}
+            displayedResolution={displayedResolution}
+            resolution={resolution}
+            progress={relativeWidth}
+            color={color}
+            unit={unit}
+            forceColorful={forceColorful}
+            compact={compact}
+          />
+        );
       }
-      expanded={expanded}
-      onExpand={() => setExpanded(true)}
-      hideOthersValue
-      compact={compact}
-    >
-      {visibleChoices.map(
-        ({
-          closeTime,
-          aggregationValues,
-          scaling,
-          resolution,
-          id,
-          color,
-          displayedResolution,
-          choice,
-          actual_resolve_time,
-          unit,
-        }) => {
-          const isChoiceClosed = closeTime ? closeTime < Date.now() : false;
-          const rawChoiceValue =
-            aggregationValues[aggregationValues.length - 1] ?? null;
-          const normalizedScaling: Scaling = {
-            range_min: scaling?.range_min ?? 0,
-            range_max: scaling?.range_max ?? 1,
-            zero_point: scaling?.zero_point ?? null,
-          };
-          const formattedChoiceValue = getPredictionDisplayValue(
-            rawChoiceValue,
-            {
-              questionType: isDateGroup
-                ? QuestionType.Date
-                : QuestionType.Numeric,
-              scaling: normalizedScaling,
-              actual_resolve_time: actual_resolve_time ?? null,
-              emptyLabel: t("Upcoming"),
-            }
-          );
+    );
 
-          const scaledChoiceValue = !isNil(rawChoiceValue)
-            ? scaleInternalLocation(rawChoiceValue, normalizedScaling)
-            : NaN;
+  return (
+    <div className="relative">
+      <div className={expanded ? "invisible" : undefined}>
+        <ForecastCardWrapper
+          otherItemsCount={hiddenCount}
+          expanded={false}
+          onExpand={() => {
+            setExpanded(true);
+            setIsExpanded(true);
+          }}
+          hideOthersValue
+          compact={compact}
+        >
+          {renderBars(collapsedChoices)}
+        </ForecastCardWrapper>
+      </div>
 
-          const relativeWidth = !isNil(resolution)
-            ? 100
-            : calculateRelativeWidth({
-                scaledChoiceValue,
-                maxScaledValue,
-                minScaledValue,
-              });
-
-          return (
-            <ForecastChoiceBar
-              key={id}
-              choiceLabel={choice}
-              choiceValue={formattedChoiceValue}
-              isClosed={isChoiceClosed || isPostClosed}
-              displayedResolution={displayedResolution}
-              resolution={resolution}
-              progress={relativeWidth}
-              color={color}
-              unit={unit}
-              forceColorful={forceColorful}
-              compact={compact}
-            />
-          );
-        }
+      {expanded && (
+        <div className="absolute -left-[21px] -top-[21px] z-20 w-[calc(100%+42px)] rounded-lg border border-gray-400/40 bg-gray-0 p-5 dark:border-gray-400-dark/40 dark:bg-gray-0-dark">
+          <ForecastCardWrapper
+            otherItemsCount={0}
+            expanded={true}
+            onCollapse={() => {
+              setExpanded(false);
+              setIsExpanded(false);
+            }}
+            hideOthersValue
+            compact={compact}
+          >
+            {renderBars(sortedChoices)}
+          </ForecastCardWrapper>
+        </div>
       )}
-    </ForecastCardWrapper>
+    </div>
   );
 };
 

--- a/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
@@ -168,7 +168,7 @@ const NumericForecastCard: FC<Props> = ({
     >
       <ForecastCardWrapper
         otherItemsCount={hiddenCount}
-        expanded={false}
+        expanded={expanded}
         onExpand={() => {
           setExpanded(true);
           setIsExpanded(true);

--- a/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
@@ -3,6 +3,7 @@
 import { useLocale, useTranslations } from "next-intl";
 import { FC, useMemo, useState } from "react";
 
+import { useListChartExpanded } from "@/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell";
 import { getEffectiveVisibleCount } from "@/constants/questions";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import { QuestionType } from "@/types/question";
@@ -33,6 +34,7 @@ const PercentageForecastCard: FC<Props> = ({
   const locale = useLocale();
   const t = useTranslations();
   const [expanded, setExpanded] = useState(false);
+  const { setIsExpanded } = useListChartExpanded();
 
   const isMC = isMultipleChoicePost(post);
   const isGroupBinary =
@@ -87,43 +89,70 @@ const PercentageForecastCard: FC<Props> = ({
 
   const isPostClosed = post.status === PostStatus.CLOSED;
 
-  const visible = expanded
-    ? allChoices
-    : allChoices.slice(0, visibleChoicesCount);
-  const hidden = expanded ? [] : allChoices.slice(visibleChoicesCount);
+  const collapsedChoices = allChoices.slice(0, visibleChoicesCount);
+  const hiddenCount = allChoices.length - visibleChoicesCount;
 
-  const visibleSumMC = visible.reduce((s, c) => s + c.percent, 0);
+  const collapsedSumMC = collapsedChoices.reduce((s, c) => s + c.percent, 0);
   const othersTotal = isMC
-    ? Math.max(0, Math.min(100, 100 - Math.round(visibleSumMC)))
+    ? Math.max(0, Math.min(100, 100 - Math.round(collapsedSumMC)))
     : 0;
 
+  const renderBars = (choices: typeof allChoices) =>
+    choices.map((choice) => (
+      <ForecastChoiceBar
+        key={choice.id ?? choice.choice}
+        choiceLabel={choice.choice}
+        choiceValue={choice.valueStr}
+        isClosed={choice.isChoiceClosed || isPostClosed}
+        displayedResolution={choice.displayedResolution}
+        resolution={choice.resolution}
+        progress={choice.percent}
+        color={choice.color}
+        forceColorful={forceColorful}
+        compact={compact}
+      />
+    ));
+
   return (
-    <ForecastCardWrapper
-      otherItemsCount={hidden.length}
-      othersTotal={othersTotal}
-      expanded={expanded}
-      onExpand={() => setExpanded(true)}
-      hideOthersValue={isGroupBinary}
-      compact={compact}
-    >
-      {visible.map((choice) => (
-        <ForecastChoiceBar
-          key={choice.id ?? choice.choice}
-          choiceLabel={choice.choice}
-          choiceValue={choice.valueStr}
-          isClosed={choice.isChoiceClosed || isPostClosed}
-          displayedResolution={choice.displayedResolution}
-          resolution={choice.resolution}
-          progress={choice.percent}
-          color={choice.color}
-          isBordered={true}
-          forceColorful={forceColorful}
+    <div className="relative">
+      {/* Always in normal flow — keeps the left panel and shell at collapsed height */}
+      <div className={expanded ? "invisible" : undefined}>
+        <ForecastCardWrapper
+          otherItemsCount={hiddenCount}
+          othersTotal={othersTotal}
+          expanded={false}
+          onExpand={() => {
+            setExpanded(true);
+            setIsExpanded(true);
+          }}
+          hideOthersValue={isGroupBinary}
           compact={compact}
-        />
-      ))}
-    </ForecastCardWrapper>
+        >
+          {renderBars(collapsedChoices)}
+        </ForecastCardWrapper>
+      </div>
+
+      {/* Expanded panel — absolutely positioned so it overflows below the shell */}
+      {expanded && (
+        <div className="absolute -left-[21px] -top-[21px] z-20 w-[calc(100%+42px)] rounded-lg border border-gray-400/40 bg-gray-0 p-5 dark:border-gray-400-dark/40 dark:bg-gray-0-dark">
+          <ForecastCardWrapper
+            otherItemsCount={0}
+            expanded={true}
+            onCollapse={() => {
+              setExpanded(false);
+              setIsExpanded(false);
+            }}
+            hideOthersValue={isGroupBinary}
+            compact={compact}
+          >
+            {renderBars(allChoices)}
+          </ForecastCardWrapper>
+        </div>
+      )}
+    </div>
   );
 };
+
 function generateChoiceItems(
   post: PostWithForecasts,
   visibleChoicesCount: number,
@@ -150,4 +179,5 @@ function generateChoiceItems(
   }
   return [];
 }
+
 export default PercentageForecastCard;

--- a/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
@@ -7,6 +7,7 @@ import { useListChartExpanded } from "@/app/(main)/questions/[id]/components/que
 import { getEffectiveVisibleCount } from "@/constants/questions";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import { QuestionType } from "@/types/question";
+import cn from "@/utils/core/cn";
 import { getPredictionDisplayValue } from "@/utils/formatters/prediction";
 import {
   generateChoiceItemsFromGroupQuestions,
@@ -25,6 +26,7 @@ type Props = {
   forceColorful?: boolean;
   compact?: boolean;
   buttonVariant?: "primary" | "minimal";
+  fillHeight?: boolean;
 };
 
 const PercentageForecastCard: FC<Props> = ({
@@ -32,6 +34,7 @@ const PercentageForecastCard: FC<Props> = ({
   forceColorful,
   compact,
   buttonVariant,
+  fillHeight = false,
 }) => {
   const locale = useLocale();
   const t = useTranslations();
@@ -89,7 +92,7 @@ const PercentageForecastCard: FC<Props> = ({
   const collapsedChoices = allChoices.slice(0, visibleChoicesCount);
   const hiddenCount = allChoices.length - visibleChoicesCount;
 
-  const renderBars = (choices: typeof allChoices) =>
+  const renderBars = (choices: typeof allChoices, stretchBars = false) =>
     choices.map((choice) => (
       <ForecastChoiceBar
         key={choice.id ?? choice.choice}
@@ -102,28 +105,30 @@ const PercentageForecastCard: FC<Props> = ({
         color={choice.color}
         forceColorful={forceColorful}
         compact={compact}
+        className={stretchBars ? "flex-1" : undefined}
       />
     ));
 
-  return (
-    <div className="relative">
-      {/* Always in normal flow — keeps the left panel and shell at collapsed height */}
-      <div className={expanded ? "invisible" : undefined}>
-        <ForecastCardWrapper
-          otherItemsCount={hiddenCount}
-          expanded={false}
-          onExpand={() => {
-            setExpanded(true);
-            setIsExpanded(true);
-          }}
-          compact={compact}
-          buttonVariant={buttonVariant}
-        >
-          {renderBars(collapsedChoices)}
-        </ForecastCardWrapper>
-      </div>
+  // Only fill height when all items are visible (no expand button).
+  const effectiveFillHeight = fillHeight && hiddenCount === 0;
 
-      {/* Expanded panel — absolutely positioned so it overflows below the shell */}
+  return (
+    <div
+      className={cn("relative", effectiveFillHeight && "flex flex-1 flex-col")}
+    >
+      <ForecastCardWrapper
+        otherItemsCount={hiddenCount}
+        expanded={false}
+        onExpand={() => {
+          setExpanded(true);
+          setIsExpanded(true);
+        }}
+        compact={compact}
+        buttonVariant={buttonVariant}
+        className={effectiveFillHeight ? "flex-1" : undefined}
+      >
+        {renderBars(collapsedChoices, effectiveFillHeight)}
+      </ForecastCardWrapper>
       {expanded && (
         <div className="absolute -left-[21px] -top-[21px] z-20 w-[calc(100%+42px)] rounded-lg border border-gray-400/40 bg-gray-0 p-5 dark:border-gray-400-dark/40 dark:bg-gray-0-dark">
           <ForecastCardWrapper

--- a/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
@@ -24,12 +24,14 @@ type Props = {
   post: PostWithForecasts;
   forceColorful?: boolean;
   compact?: boolean;
+  buttonVariant?: "primary" | "minimal";
 };
 
 const PercentageForecastCard: FC<Props> = ({
   post,
   forceColorful,
   compact,
+  buttonVariant,
 }) => {
   const locale = useLocale();
   const t = useTranslations();
@@ -127,6 +129,7 @@ const PercentageForecastCard: FC<Props> = ({
           }}
           hideOthersValue={isGroupBinary}
           compact={compact}
+          buttonVariant={buttonVariant}
         >
           {renderBars(collapsedChoices)}
         </ForecastCardWrapper>
@@ -144,6 +147,7 @@ const PercentageForecastCard: FC<Props> = ({
             }}
             hideOthersValue={isGroupBinary}
             compact={compact}
+            buttonVariant={buttonVariant}
           >
             {renderBars(allChoices)}
           </ForecastCardWrapper>

--- a/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
@@ -90,7 +90,7 @@ const PercentageForecastCard: FC<Props> = ({
   const isPostClosed = post.status === PostStatus.CLOSED;
 
   const collapsedChoices = allChoices.slice(0, visibleChoicesCount);
-  const hiddenCount = allChoices.length - visibleChoicesCount;
+  const hiddenCount = Math.max(0, allChoices.length - visibleChoicesCount);
 
   const renderBars = (choices: typeof allChoices, stretchBars = false) =>
     choices.map((choice) => (
@@ -118,7 +118,7 @@ const PercentageForecastCard: FC<Props> = ({
     >
       <ForecastCardWrapper
         otherItemsCount={hiddenCount}
-        expanded={false}
+        expanded={expanded}
         onExpand={() => {
           setExpanded(true);
           setIsExpanded(true);

--- a/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
@@ -39,11 +39,6 @@ const PercentageForecastCard: FC<Props> = ({
   const { setIsExpanded } = useListChartExpanded();
 
   const isMC = isMultipleChoicePost(post);
-  const isGroupBinary =
-    isGroupOfQuestionsPost(post) &&
-    post.group_of_questions?.questions?.every(
-      (q) => q.type === QuestionType.Binary
-    );
   const cpRevealTime = post.question?.cp_reveal_time;
   const emptyLabel =
     cpRevealTime && new Date(cpRevealTime).getTime() > Date.now()
@@ -94,11 +89,6 @@ const PercentageForecastCard: FC<Props> = ({
   const collapsedChoices = allChoices.slice(0, visibleChoicesCount);
   const hiddenCount = allChoices.length - visibleChoicesCount;
 
-  const collapsedSumMC = collapsedChoices.reduce((s, c) => s + c.percent, 0);
-  const othersTotal = isMC
-    ? Math.max(0, Math.min(100, 100 - Math.round(collapsedSumMC)))
-    : 0;
-
   const renderBars = (choices: typeof allChoices) =>
     choices.map((choice) => (
       <ForecastChoiceBar
@@ -121,13 +111,11 @@ const PercentageForecastCard: FC<Props> = ({
       <div className={expanded ? "invisible" : undefined}>
         <ForecastCardWrapper
           otherItemsCount={hiddenCount}
-          othersTotal={othersTotal}
           expanded={false}
           onExpand={() => {
             setExpanded(true);
             setIsExpanded(true);
           }}
-          hideOthersValue={isGroupBinary}
           compact={compact}
           buttonVariant={buttonVariant}
         >
@@ -145,7 +133,6 @@ const PercentageForecastCard: FC<Props> = ({
               setExpanded(false);
               setIsExpanded(false);
             }}
-            hideOthersValue={isGroupBinary}
             compact={compact}
             buttonVariant={buttonVariant}
           >

--- a/front_end/src/components/consumer_post_card/index.tsx
+++ b/front_end/src/components/consumer_post_card/index.tsx
@@ -50,7 +50,9 @@ const ConsumerPostCard: FC<Props> = ({
           )}
 
           {(isGroupOfQuestionsPost(post) || isMultipleChoicePost(post)) && (
-            <GroupForecastCard post={post} />
+            <div className="w-full">
+              <GroupForecastCard post={post} buttonVariant="minimal" />
+            </div>
           )}
 
           {[PostStatus.PENDING_RESOLUTION, PostStatus.CLOSED].includes(

--- a/front_end/src/components/detailed_question_card/detailed_group_card/index.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_group_card/index.tsx
@@ -44,6 +44,7 @@ type Props = {
   onLegendHeightChange?: (height: number) => void;
   chartTheme?: VictoryThemeDefinition;
   defaultZoom?: TimelineChartZoomOption;
+  withLegend?: boolean;
 };
 
 const DetailedGroupCard: FC<Props> = ({
@@ -56,6 +57,7 @@ const DetailedGroupCard: FC<Props> = ({
   onLegendHeightChange,
   chartTheme,
   defaultZoom,
+  withLegend,
 }) => {
   const {
     open_time,
@@ -186,6 +188,7 @@ const DetailedGroupCard: FC<Props> = ({
           chartHeight={embedChartHeight}
           chartTheme={chartTheme}
           defaultZoom={defaultZoom}
+          withLegend={withLegend}
         />
       );
     }

--- a/front_end/src/components/detailed_question_card/detailed_question_card/index.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/index.tsx
@@ -99,6 +99,7 @@ const DetailedQuestionCard: FC<Props> = ({
             onLegendHeightChange={onLegendHeightChange}
             chartTheme={chartTheme}
             defaultZoom={defaultZoom}
+            isConsumerView={isConsumerView}
           />
         </DetailsQuestionCardErrorBoundary>
       );

--- a/front_end/src/components/detailed_question_card/detailed_question_card/multiple_choice_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/multiple_choice_chart_card.tsx
@@ -33,6 +33,7 @@ type Props = {
   forecastAvailability?: ForecastAvailability;
   onLegendHeightChange?: (height: number) => void;
   hideTitle?: boolean;
+  isConsumerView?: boolean;
 };
 
 const DetailedMultipleChoiceChartCard: FC<Props> = ({
@@ -45,6 +46,7 @@ const DetailedMultipleChoiceChartCard: FC<Props> = ({
   forecastAvailability,
   onLegendHeightChange,
   hideTitle,
+  isConsumerView,
 }) => {
   const t = useTranslations();
   const [isChartHovered, setIsChartHovered] = useState(false);
@@ -308,6 +310,7 @@ const DetailedMultipleChoiceChartCard: FC<Props> = ({
       defaultZoom={defaultZoom}
       forecastAvailability={forecastAvailability}
       openTime={openTime}
+      withLegend={!isConsumerView}
     />
   );
 };


### PR DESCRIPTION
Related to #4643

### Summary

This PR introduces `ConsumerListChartShell`, a shared layout primitive for consumer N-row body types, extending the side-by-side layout from iter 2 (single binary/continuous) to all four group-style body types. It also restyls the expand/collapse affordance across forecast cards with a new `buttonVariant` prop, introduces a minimal ellipsis variant for the sidebar, and hides the legend bar in consumer chart views. For continuous numeric group questions, the left pane now renders proportional colored bars that vertically scale to fill the panel height (applied to all N-row bar types), with a mounted `GroupTimeline` on the right. Hovering a bar row isolates that subquestion's line on the chart - others dim, the highlighted line gets a heavier stroke, and endpoint dots mark the latest forecast value.

---

### Consumer side-by-side shell for N-row bodies (MC / binary group / continuous group / time series)

- **ConsumerListChartShell**: new layout primitive with list-on-left / chart-on-right, single shared border with vertical divider
- **MC consumer**: left: `PercentageForecastCard`, right: `QuestionTimeline → DetailedMultipleChoiceChartCard`
- **Binary group consumer**: left: `PercentageForecastCard`, right: `QuestionTimeline → GroupTimeline`
- **Continuous/numeric group consumer**: left: `NumericForecastCard`, right: `QuestionTimeline → GroupTimeline`
- **Fan graph / time series consumer**: left: `TimeSeriesChart` (colorful vertical bars), right: `DetailedGroupCard` (fan chart)
- **hideCP** wired so `RevealCPButton` replaces the left slot for all four body types when CP is hidden
- **ConsumerShell** refactored: unified conditional replaced with explicit per-type branches (binary, continuous, N-row, fan graph, date-group fallback)
- **Forecaster view**: unchanged, keeps its stacked layout

---

### Restyle colored-bar row + list-level expand/collapse (MC + binary group consumer)

- **ForecastCardWrapper**: replaced the old progress-bar expand button with chevron-down / chevron-up text buttons; added `buttonVariant` prop (`"primary"` | `"minimal"`) — minimal renders an ellipsis icon with a gray border for sidebar use
- **Sidebar similar-questions chip**: passes `buttonVariant="minimal"` so the expand affordance uses the three-dot style instead of the primary blue chevron
- **Legend hidden in consumer view**: threaded `withLegend={false}` through `DetailedGroupCard → GroupTimeline` (binary group) and `DetailedMultipleChoiceChartCard` (MC) so the legend bar is suppressed in consumer view only

---

### Continuous group consumer side-by-side: row restyle + mount combined timeline + hover-sync

- **ConsumerListChartShell**: added `hoveredChoiceName` context state and `stretchListContent` prop (enables flex column on left panel so bars fill available height)
- **ForecastChoiceBar**: added `onMouseEnter`/`onMouseLeave`/`className` props; fill height; fill fades up on hover; unfilled area gets a blue tint only on the hovered row
- **NumericForecastCard**: `fillHeight` prop threads `flex-1` through wrapper and bars so fewer items scale up; wires per-row mouse events to `hoveredChoiceName` context
- **ConsumerGroupChart** *(new)*: reads `hoveredChoiceName` from context, renders `GroupTimeline` with `externalHighlightedChoice`, `withLegend={false}`, `withHighlightArea={false}`, `withHighlightEndpoint`
- **GroupTimeline**: `externalHighlightedChoice` prop syncs into `choiceItems.highlighted` via `useEffect`; threaded `withHighlightArea`/`withHighlightEndpoint` to `MultiChoicesChartView`
- **GroupChart**: non-highlighted lines dim, highlighted line gets heavier stroke; endpoint dot rendered at last data point; `onMouseLeave` resets cursor so lines don't freeze
- **question_page_shell**: routes `isContinuousNumericGroup` to `NumericForecastCard fillHeight` (left) + `ConsumerGroupChart` (right)



### Demo videos

New consumer side-by-side layout (MC / binary group / continuous group / time series)


https://github.com/user-attachments/assets/f7b62b76-4e2b-4c4e-8723-c2d02dcb4ff7



Expandable Modal Behavior


https://github.com/user-attachments/assets/57b316e3-92b7-4086-91a2-863fb7d49cda


Proportional Bars + Hover-Synced Timeline (Continuous group consumer)


https://github.com/user-attachments/assets/82417afd-5708-4468-9def-ec85df249078



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced chart highlighting with improved external controls
  * New forecast card button styling options
  * Improved interactive hover feedback for choice selections

* **Refactor**
  * Restructured layouts for better responsive display of grouped questions and forecasts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4712)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->