### PR TITLE
fix: labor hub commentary misalignments vs chart data (May 12)

### DIFF
--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -179,7 +179,7 @@ export default function LaborAutomationHubPage() {
               </span>
               , <strong>median wages are expected to grow.</strong> The workweek
               is also expected to become{" "}
-              <strong>about three hours shorter by 2035</strong> among all
+              <strong>about four hours shorter by 2035</strong> among all
               workers, while productivity grows.
             </ContentParagraph>
             <ContentParagraph>

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-05-11">May 11</time>
+              Commentary last updated: <time dateTime="2026-05-12">May 12</time>
             </div>
           </div>
         </div>

--- a/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
@@ -44,7 +44,7 @@ function describeOverallChange(value: number | null): string {
 
 function describeTradeSchoolGrowth(value: number | null): string {
   if (value == null) return "change meaningfully";
-  const rounded = Math.round(Math.abs(value));
+  const rounded = Math.round(Math.abs(value) * 10) / 10;
   return `${value < 0 ? "decline" : "grow"} ${rounded}%`;
 }
 


### PR DESCRIPTION
## Summary

Two misalignments found between commentary text and current forecast chart data on the Labor Automation Forecasting Hub:

### Fix 1 — Wages section (`page.tsx`): workweek hours
- **Section:** Hours, Pay, and Financial Well-Being
- **Old text:** "The workweek is also expected to become **about three hours shorter by 2035**"
- **Chart data:** 38.3h (2025 current) → 34.2h (2035 forecast) = **~4.1 hours shorter**
- **New text:** "The workweek is also expected to become **about four hours shorter by 2035**"

> Note: the prior fix (PR #4711) changed "four" → "three" based on a 2035 forecast of ~35.1h. The forecast has since updated to 34.2h, making "four hours" the correct description again.

### Fix 2 — Key Insights (`key_insights.tsx`): trade school growth
- **Section:** Key Insights → Young workers
- **Old text:** "trade school and community college certificates are expected to **grow 7%** from current levels by 2035"
- **Chart data label:** **+7.5%** (2035 forecast = 7.497%, displayed with 1 decimal)
- **New text:** "…expected to **grow 7.5%** from current levels by 2035" (achieved by changing `Math.round` integer rounding to one-decimal rounding in `describeTradeSchoolGrowth`)

### Also: updated commentary last updated date to May 12

## Test plan
- [ ] Visit `/labor-hub` and open the Key Insights panel — confirm trade school reads "grow 7.5%"
- [ ] In the Wages section, confirm the workweek sentence reads "about four hours shorter by 2035"
- [ ] Confirm "Commentary last updated: May 12" shows in the hero

https://claude.ai/code/session_0164cfe6Cps6a9CQS8sFLKh9

---
_Generated by [Claude Code](https://claude.ai/code/session_0164cfe6Cps6a9CQS8sFLKh9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated workweek duration projection in the Wages section from "about three hours shorter" to "about four hours shorter by 2035."
  * Refreshed commentary timestamp to May 12, 2026.
  * Enhanced trade school growth metrics display with increased precision (one decimal place).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4714)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->