### PR TITLE
fix: labor hub commentary — graduates unemployment "doubled" → "more than doubled"

### DIFF
--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -427,7 +427,7 @@ export default function LaborAutomationHubPage() {
             </ContentParagraph>
             <ContentParagraph>
               The unemployment rate for new graduates is expected to have{" "}
-              <strong>doubled</strong> in 2035 compared to 2025.
+              <strong>more than doubled</strong> in 2035 compared to 2025.
             </ContentParagraph>
             <ContentParagraph>
               The number of degrees awarded overall and for STEM and humanities

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-05-12">May 12</time>
+              Commentary last updated: <time dateTime="2026-05-13">May 13</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated commentary audit of https://www.metaculus.com/labor-hub found one misalignment between forecast data and commentary text.

### Fix

**Section:** Impact on the Next Generation of Workers (Graduates)

**Old text:**
> The unemployment rate for new graduates is expected to have **doubled** in 2035 compared to 2025.

**Chart data:**
- 2025 actual unemployment rate (recent college graduates, 22–27 age range): **5.5%**
- 2035 forecast: **12.23%**
- Ratio: 12.23 / 5.5 = **2.22×** (more than doubled, not exactly doubled)

**New text:**
> The unemployment rate for new graduates is expected to have **more than doubled** in 2035 compared to 2025.

Also updates the "Commentary last updated" date from May 12 → May 13.

## Test plan

- [ ] Visit /labor-hub and confirm the Graduates section now reads "more than doubled"
- [ ] Confirm commentary last updated shows May 13

https://claude.ai/code/session_017hdtR8CFhCFS2khE9UVaZy

---
_Generated by [Claude Code](https://claude.ai/code/session_017hdtR8CFhCFS2khE9UVaZy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refined unemployment rate projection language in the Graduates section to reflect "more than doubled" growth by 2035
  * Updated commentary last modified date to May 13, 2026

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4716)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->