### PR TITLE
fix: correct OWID report link on services page

### DIFF
--- a/front_end/src/app/(main)/services/components/case_studies/constants.tsx
+++ b/front_end/src/app/(main)/services/components/case_studies/constants.tsx
@@ -105,7 +105,7 @@ export const CASE_STUDIES: TCaseStudyCard[] = [
     },
     cta: {
       labelKey: "readFullReport",
-      href: "/files/forecasting-owid-report.pdf",
+      href: "/files/OWID%2Breport",
     },
   },
 ];

--- a/front_end/src/app/(main)/services/components/case_studies/constants.tsx
+++ b/front_end/src/app/(main)/services/components/case_studies/constants.tsx
@@ -105,7 +105,7 @@ export const CASE_STUDIES: TCaseStudyCard[] = [
     },
     cta: {
       labelKey: "readFullReport",
-      href: "/files/OWID%2Breport",
+      href: "https://www.metaculus.com/files/OWID%2Breport",
     },
   },
 ];


### PR DESCRIPTION
Fixes #4717

The "Forecasting Our World in Data" case study CTA on the services page pointed to `/files/forecasting-owid-report.pdf`, which was being rewritten to a CDN URL with a duplicated `.pdf` extension and 404'd. Updated to the relative path `/files/OWID%2Breport`.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the case study resource link to direct users to the correct external destination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4719)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->