### PR TITLE
fix: skip questions without forecasts in bulk withdraw

### DIFF
--- a/questions/services/forecasts.py
+++ b/questions/services/forecasts.py
@@ -187,7 +187,6 @@ def withdraw_forecast_bulk(user: User = None, withdrawals: list[dict] = None):
     for withdrawal in withdrawals:
         question = cast(Question, withdrawal["question"])
         post = question.get_post()
-        posts.add(post)
 
         withdraw_at = withdrawal["withdraw_at"]
 
@@ -205,6 +204,8 @@ def withdraw_forecast_bulk(user: User = None, withdrawals: list[dict] = None):
         # questions the user never forecasted on).
         if not user_forecasts.exists():
             continue
+
+        posts.add(post)
 
         forecast_to_terminate = user_forecasts.first()
         forecast_to_terminate.end_time = withdraw_at

--- a/questions/services/forecasts.py
+++ b/questions/services/forecasts.py
@@ -7,8 +7,6 @@ import sentry_sdk
 from django.db import IntegrityError, transaction
 from django.db.models import F, Q, QuerySet, Subquery, OuterRef, Count
 from django.utils import timezone
-from rest_framework.exceptions import ValidationError
-
 from notifications.constants import MailingTags
 from posts.models import PostUserSnapshot, PostSubscription
 from posts.services.subscriptions import (
@@ -201,11 +199,12 @@ def withdraw_forecast_bulk(user: User = None, withdrawals: list[dict] = None):
             author=user,
         ).order_by("start_time")
 
+        # Skip questions where the user has no active forecast at withdraw_at.
+        # This allows bulk "withdraw all" requests to succeed even when some
+        # questions in a group have no forecast from the user (e.g. resolved
+        # questions the user never forecasted on).
         if not user_forecasts.exists():
-            raise ValidationError(
-                f"User {user.id} has no forecast at {withdraw_at} to "
-                f"withdraw for question {question.id}"
-            )
+            continue
 
         forecast_to_terminate = user_forecasts.first()
         forecast_to_terminate.end_time = withdraw_at

--- a/tests/unit/test_questions/test_views.py
+++ b/tests/unit/test_questions/test_views.py
@@ -426,15 +426,22 @@ class TestQuestionWithdraw:
         )
         assert response.status_code == 201
 
-    def test_cant_withdraw_forecast_if_no_forecast(
-        self, question_binary_with_forecast_user_1, user2_client
+    def test_withdraw_forecast_no_forecast_is_noop(
+        self, question_binary_with_forecast_user_1, user2, user2_client
     ):
+        # Withdrawing for a question the user never forecasted on is a no-op
+        # so that bulk "withdraw all" works across mixed groups containing
+        # questions the user did not forecast on (e.g. resolved siblings).
         response = user2_client.post(
             self.url,
             data=json.dumps([{"question": question_binary_with_forecast_user_1.id}]),
             content_type="application/json",
         )
-        assert response.status_code == 400
+        assert response.status_code == 201
+        assert not Forecast.objects.filter(
+            question=question_binary_with_forecast_user_1,
+            author=user2,
+        ).exists()
 
 
 class TestQuestionResolve:


### PR DESCRIPTION
## Summary
- `withdraw_forecast_bulk` now skips questions where the user has no active forecast at `withdraw_at` instead of raising `ValidationError`, so "Withdraw all" works on mixed question groups.
- Updated the corresponding test to assert the new no-op behavior.

Fixes #4707

## Test plan
- [ ] `pytest tests/unit/test_questions/test_views.py::TestQuestionWithdraw`
- [ ] Manual: click "Withdraw all" on a group where at least one question has no user forecast — expect success, remaining forecasts withdrawn.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Bulk forecast withdrawal requests are now more resilient: items without an active forecast are skipped so batch withdrawals can complete.
  * Submitting a withdraw for a question you never forecasted is now a no-op and returns success rather than an error.
  * Follow-up actions (e.g., post-processing) are only scheduled for items that were actually withdrawn.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4720)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->