### PR TITLE
fix: make "view" button in comments feed an anchor link

### DIFF
--- a/front_end/src/components/comment_feed/comment_card.tsx
+++ b/front_end/src/components/comment_feed/comment_card.tsx
@@ -31,7 +31,7 @@ type Props = {
   keyFactorVotesScore: number;
   className?: string;
   expandOverride?: "auto" | "expanded" | "collapsed";
-  onViewComment?: () => void;
+  commentUrl?: string;
   disableVoting?: boolean;
   collapsedHeight?: number;
 };
@@ -84,14 +84,14 @@ const ExpandableCommentContent = ({
   isExpanded,
   needsExpand,
   contentRef,
-  onViewComment,
+  commentUrl,
   collapsedHeight,
 }: {
   comment: BECommentType;
   isExpanded: boolean;
   needsExpand: boolean;
   contentRef: React.RefObject<HTMLDivElement | null>;
-  onViewComment?: () => void;
+  commentUrl?: string;
   collapsedHeight: number;
 }) => {
   const locale = useLocale();
@@ -125,10 +125,12 @@ const ExpandableCommentContent = ({
             })}
           </span>
         </div>
-        {onViewComment && (
+        {commentUrl && (
           <Button
             variant="text"
-            onClick={onViewComment}
+            href={commentUrl}
+            target="_blank"
+            rel="noopener noreferrer"
             size="sm"
             className="gap-2 border-none px-2.5 py-1 font-normal text-blue-700 dark:text-blue-700-dark"
           >
@@ -177,7 +179,7 @@ const CommentCard: FC<Props> = ({
   changedMyMindCount,
   keyFactorVotesScore,
   expandOverride = "auto",
-  onViewComment,
+  commentUrl,
   disableVoting = false,
   collapsedHeight = DEFAULT_collapsedHeight,
 }) => {
@@ -278,7 +280,7 @@ const CommentCard: FC<Props> = ({
         isExpanded={effectiveExpanded}
         needsExpand={needsExpand}
         contentRef={contentRef}
-        onViewComment={onViewComment}
+        commentUrl={commentUrl}
         collapsedHeight={collapsedHeight}
       />
 

--- a/front_end/src/components/comment_feed/comment_feed_card.tsx
+++ b/front_end/src/components/comment_feed/comment_feed_card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FC, memo, useCallback } from "react";
+import { FC, memo } from "react";
 
 import CommentCard from "@/components/comment_feed/comment_card";
 import CommentPostPreview from "@/components/comment_feed/comment_post_preview";
@@ -14,12 +14,7 @@ type Props = {
 };
 
 const CommentFeedCard: FC<Props> = ({ comment, post }) => {
-  const handleViewComment = useCallback(() => {
-    window.open(
-      `/questions/${comment.on_post}/#comment-${comment.id}`,
-      "_blank"
-    );
-  }, [comment.on_post, comment.id]);
+  const commentUrl = `/questions/${comment.on_post}/#comment-${comment.id}`;
 
   return (
     <div
@@ -48,7 +43,7 @@ const CommentFeedCard: FC<Props> = ({ comment, post }) => {
             className="mt-0 border-none dark:border-none md:mt-0"
             expandOverride="collapsed"
             collapsedHeight={222}
-            onViewComment={handleViewComment}
+            commentUrl={commentUrl}
           />
         </div>
       </div>


### PR DESCRIPTION
Fixes #4585

## Summary

The "view" control in the comments feed was a `<button>` that called `window.open` on click. Because the underlying element was a `<button>`, mouse-wheel (middle) click triggered the browser's autoscroll cursor instead of opening a new tab.

This PR changes the control to a real anchor link (via the shared `Button` component's `href` prop, which renders as a Next.js `Link`) with `target="_blank"`, so middle-click and ctrl/cmd-click open a new tab natively.

## Test plan
- [ ] In the comments feed, left-click on "view" opens the comment in a new tab.
- [ ] Mouse-wheel (middle) click on "view" opens the comment in a new tab (no more autoscroll cursor).
- [ ] Ctrl/Cmd+Click behaves like a normal link.

Generated with [Claude Code](https://claude.ai/code)