### PR TITLE
Compact legend bar for MC + binary group forecaster

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -2168,7 +2168,7 @@
   "whyTrustMetaculusLessNoiseTitle": "Méně šumu, více pravdy",
   "whyTrustMetaculusLessNoise": "Předpovědi Metaculus, poháněné davem, prořezávají šum tím, že zakládají každou předpověď na transparentních důkazech, odpovědném skóre a desetiletí doložené přesnosti. Metaculus vybavuje politiky, výzkumníky, novináře a korporátní organizace předpověďmi založenými na důkazech, které poskytují jasný, kvantifikovatelný vhled do nejkritičtějších nejistot světa. Prozkoumejte naši nabídku <servicesLink>Business řešení</servicesLink> a zjistěte, jak může Metaculus zlepšit rozhodování vaší organizace.",
   "publishTimeLockedDescription": "Čas publikace nelze po vytvoření změnit.",
-  "nMore": "{count} více...",
+  "nMore": "{count} více",
   "noHistogramData": "Žádná data histogramu nejsou k dispozici",
   "thousandsOfOpenQuestions": "20 000+ otevřených otázek"
 }

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -767,7 +767,7 @@
   "aboutMetaculusTitle": "<blue>About</blue> Metaculus",
   "aboutMetaculusDescription": "Metaculus is an online forecasting platform and aggregation engine working to improve human reasoning and coordination on topics of global importance.",
   "more": "More",
-  "nMore": "{count} more...",
+  "nMore": "{count} more",
   "moreLikely": "percentage points higher",
   "afterElection": "under {winner}",
   "ifCandidateElected": "if {candidate} elected",

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -2168,7 +2168,7 @@
   "whyTrustMetaculusLessNoiseTitle": "Menos ruido, más verdad",
   "whyTrustMetaculusLessNoise": "Los pronósticos impulsados por la multitud de Metaculus cortan el ruido al basar cada predicción en evidencia transparente, puntuaciones responsables y una década de precisión demostrada. Metaculus equipa a los responsables de políticas, investigadores, periodistas y organizaciones corporativas con pronósticos basados en evidencia que ofrecen una visión clara y cuantificable de las incertidumbres más críticas del mundo. Explora nuestra suite de <servicesLink>Soluciones Empresariales</servicesLink> para aprender cómo Metaculus puede mejorar la toma de decisiones de tu organización.",
   "publishTimeLockedDescription": "La hora de publicación no puede cambiarse después de la creación.",
-  "nMore": "{count} más...",
+  "nMore": "{count} más",
   "noHistogramData": "No hay datos de histograma disponibles",
   "thousandsOfOpenQuestions": "20,000+ preguntas abiertas"
 }

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -2166,7 +2166,7 @@
   "whyTrustMetaculusLessNoiseTitle": "Menos ruído, mais verdade",
   "whyTrustMetaculusLessNoise": "As previsões baseadas na multidão do Metaculus cortam o ruído ao basear cada previsão em evidências transparentes, pontuações responsáveis e uma década de precisão demonstrada. O Metaculus equipa formuladores de políticas, pesquisadores, jornalistas e organizações corporativas com previsões baseadas em evidências que oferecem insights claros e quantificáveis sobre as incertezas mais críticas do mundo. Explore nosso conjunto de <servicesLink>Soluções Empresariais</servicesLink> para saber mais sobre como o Metaculus pode melhorar a tomada de decisões da sua organização.",
   "publishTimeLockedDescription": "O horário de publicação não pode ser alterado após a criação.",
-  "nMore": "{count} a mais...",
+  "nMore": "{count} a mais",
   "noHistogramData": "Não há dados de histograma disponíveis",
   "thousandsOfOpenQuestions": "20.000+ perguntas abertas"
 }

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -2165,7 +2165,7 @@
   "whyTrustMetaculusLessNoiseTitle": "更少的噪音，更多的真相",
   "whyTrustMetaculusLessNoise": "Metaculus 的群眾驅動預測通過將每一個預測植根於透明的證據、負責的計分和十年的已證準確性，抑制了噪音。Metaculus 為政策制定者、研究人員、記者和企業組織提供基於證據的預測，為全球最重要的不確定性提供清晰、可量化的洞察。探索我們的 <servicesLink>企業解決方案</servicesLink>，了解 Metaculus 如何改善貴組織的決策。",
   "publishTimeLockedDescription": "建立後將無法更改發佈時間。",
-  "nMore": "還有 {count} 個...",
+  "nMore": "還有 {count} 個",
   "noHistogramData": "沒有可用的直方圖資料",
   "thousandsOfOpenQuestions": "20,000+ 開放問題"
 }

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -2170,7 +2170,7 @@
   "whyTrustMetaculusLessNoiseTitle": "少噪音，多真相",
   "whyTrustMetaculusLessNoise": "Metaculus 的众包预测通过以透明证据、可追溯的评分以及十年证明的准确性为基础来削减预测中的噪音。Metaculus 为政策制定者、研究人员、记者和企业组织提供基于证据的预测，为世界上最重要的不确定性提供清晰、可量化的洞察。了解我们的<servicesLink>企业解决方案</servicesLink>，了解 Metaculus 如何改善贵组织的决策。",
   "publishTimeLockedDescription": "创建后将无法更改发布时间。",
-  "nMore": "{count} 更多...",
+  "nMore": "{count} 更多",
   "noHistogramData": "没有可用的直方图数据",
   "thousandsOfOpenQuestions": "20,000+ 开放问题"
 }

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
@@ -73,8 +73,10 @@ const CompactLegendBar: FC<Props> = ({
           <div
             key={item.choice}
             className={cn(
-              "flex cursor-pointer items-center gap-1 rounded px-1.5 py-0.5",
-              "hover:bg-gray-200 dark:hover:bg-gray-200-dark",
+              "flex items-center gap-1 rounded px-1.5 py-0.5",
+              resolvedNo
+                ? "cursor-default"
+                : "cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-200-dark",
               item.highlighted && "bg-gray-200 dark:bg-gray-200-dark"
             )}
             onMouseEnter={() =>
@@ -95,6 +97,7 @@ const CompactLegendBar: FC<Props> = ({
               <>
                 <span
                   role="checkbox"
+                  aria-label={item.label || item.choice}
                   aria-checked={item.active}
                   tabIndex={0}
                   className="flex size-4 shrink-0 cursor-pointer items-center justify-center rounded-[2px] border border-gray-500 dark:border-gray-500-dark"

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
@@ -1,9 +1,14 @@
-import { FC } from "react";
+"use client";
+import { useTranslations } from "next-intl";
+import { FC, useState } from "react";
 
+import { useBreakpoint } from "@/hooks/tailwind";
 import { ChoiceItem } from "@/types/choices";
 import { QuestionType } from "@/types/question";
 import cn from "@/utils/core/cn";
 import { getForecastPctDisplayValue } from "@/utils/formatters/prediction";
+
+const MOBILE_MAX_ITEMS = 5;
 
 type Props = {
   items: ChoiceItem[];
@@ -32,9 +37,35 @@ const CompactLegendBar: FC<Props> = ({
   onChoiceChange,
   onChoiceHighlight,
 }) => {
+  const t = useTranslations();
+  const isMd = useBreakpoint("md");
+  const [showAll, setShowAll] = useState(false);
+
+  const resolvedNoCount = items.filter((item) =>
+    isResolvedNo(item, questionType)
+  ).length;
+  const normalItems = items.filter((item) => !isResolvedNo(item, questionType));
+
+  let visibleItems: ChoiceItem[];
+  let hiddenCount: number;
+
+  if (showAll) {
+    visibleItems = items;
+    hiddenCount = 0;
+  } else if (!isMd) {
+    // Mobile: show up to MOBILE_MAX_ITEMS normal items only; resolved-NO always hidden
+    const mobileVisible = normalItems.slice(0, MOBILE_MAX_ITEMS);
+    visibleItems = mobileVisible;
+    hiddenCount = items.length - mobileVisible.length;
+  } else {
+    // Desktop: show all normal items; resolved-NO hidden
+    visibleItems = normalItems;
+    hiddenCount = resolvedNoCount;
+  }
+
   return (
-    <div className="mb-2 flex flex-wrap gap-x-3 gap-y-1.5 text-xs">
-      {items.map((item) => {
+    <div className="flex flex-wrap gap-x-3 gap-y-1.5">
+      {visibleItems.map((item) => {
         const resolvedNo = isResolvedNo(item, questionType);
         const pct = getForecastPctDisplayValue(getLastAggregationValue(item));
 
@@ -55,8 +86,8 @@ const CompactLegendBar: FC<Props> = ({
           >
             {resolvedNo ? (
               <>
-                <span className="size-2.5 shrink-0 rounded-full bg-gray-400 dark:bg-gray-400-dark" />
-                <span className="max-w-[120px] truncate text-gray-500 line-through dark:text-gray-500-dark">
+                <span className="size-3 shrink-0 rounded-full bg-gray-300 dark:bg-gray-300-dark" />
+                <span className="max-w-[120px] truncate text-sm font-medium leading-4 text-gray-400 line-through dark:text-gray-400-dark md:text-base md:leading-5">
                   {item.label || item.choice}
                 </span>
               </>
@@ -66,17 +97,14 @@ const CompactLegendBar: FC<Props> = ({
                   role="checkbox"
                   aria-checked={item.active}
                   tabIndex={0}
-                  className="flex size-3.5 shrink-0 cursor-pointer items-center justify-center rounded-[2px] border"
+                  className="flex size-4 shrink-0 cursor-pointer items-center justify-center rounded-[2px] border border-gray-500 dark:border-gray-500-dark"
                   style={
                     item.active
                       ? {
                           backgroundColor: item.color.DEFAULT,
                           borderColor: "transparent",
                         }
-                      : {
-                          borderColor: item.color.DEFAULT,
-                          backgroundColor: "transparent",
-                        }
+                      : undefined
                   }
                   onClick={() => onChoiceChange(item.choice, !item.active)}
                   onKeyDown={(e) => {
@@ -89,7 +117,7 @@ const CompactLegendBar: FC<Props> = ({
                   {item.active && (
                     <svg
                       viewBox="0 0 10 8"
-                      className="h-2 w-2.5 fill-none stroke-white stroke-2"
+                      className="h-2.5 w-3 fill-none stroke-white stroke-2"
                     >
                       <path
                         d="M1 4l3 3 5-6"
@@ -99,10 +127,10 @@ const CompactLegendBar: FC<Props> = ({
                     </svg>
                   )}
                 </span>
-                <span className="max-w-[120px] truncate text-gray-800 dark:text-gray-800-dark">
+                <span className="max-w-[120px] truncate text-sm font-medium leading-4 text-gray-800 dark:text-gray-800-dark md:text-base md:leading-5">
                   {item.label || item.choice}
                 </span>
-                <span className="shrink-0 tabular-nums text-gray-600 dark:text-gray-600-dark">
+                <span className="shrink-0 text-sm tabular-nums leading-4 text-gray-600 dark:text-gray-600-dark md:text-base md:leading-6">
                   {pct}
                 </span>
               </>
@@ -110,6 +138,16 @@ const CompactLegendBar: FC<Props> = ({
           </div>
         );
       })}
+
+      {hiddenCount > 0 && (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="overflow-hidden text-ellipsis text-sm font-medium leading-4 text-gray-500 underline decoration-gray-400 dark:text-gray-500-dark dark:decoration-gray-400-dark md:text-base md:leading-5"
+        >
+          {t("nMore", { count: hiddenCount })}
+        </button>
+      )}
     </div>
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
@@ -1,0 +1,117 @@
+import { FC } from "react";
+
+import { ChoiceItem } from "@/types/choices";
+import { QuestionType } from "@/types/question";
+import cn from "@/utils/core/cn";
+import { getForecastPctDisplayValue } from "@/utils/formatters/prediction";
+
+type Props = {
+  items: ChoiceItem[];
+  questionType: QuestionType.MultipleChoice | QuestionType.Binary;
+  onChoiceChange: (choice: string, checked: boolean) => void;
+  onChoiceHighlight: (choice: string, highlighted: boolean) => void;
+};
+
+function isResolvedNo(item: ChoiceItem, questionType: QuestionType): boolean {
+  if (questionType === QuestionType.Binary) return item.resolution === "no";
+  return item.displayedResolution === "No";
+}
+
+function getLastAggregationValue(item: ChoiceItem): number | null {
+  const values = item.aggregationValues;
+  for (let i = values.length - 1; i >= 0; i--) {
+    const v = values[i];
+    if (v != null) return v;
+  }
+  return null;
+}
+
+const CompactLegendBar: FC<Props> = ({
+  items,
+  questionType,
+  onChoiceChange,
+  onChoiceHighlight,
+}) => {
+  return (
+    <div className="mb-2 flex flex-wrap gap-x-3 gap-y-1.5 text-xs">
+      {items.map((item) => {
+        const resolvedNo = isResolvedNo(item, questionType);
+        const pct = getForecastPctDisplayValue(getLastAggregationValue(item));
+
+        return (
+          <div
+            key={item.choice}
+            className={cn(
+              "flex cursor-pointer items-center gap-1 rounded px-1.5 py-0.5",
+              "hover:bg-gray-200 dark:hover:bg-gray-200-dark",
+              item.highlighted && "bg-gray-200 dark:bg-gray-200-dark"
+            )}
+            onMouseEnter={() =>
+              !resolvedNo && onChoiceHighlight(item.choice, true)
+            }
+            onMouseLeave={() =>
+              !resolvedNo && onChoiceHighlight(item.choice, false)
+            }
+          >
+            {resolvedNo ? (
+              <>
+                <span className="size-2.5 shrink-0 rounded-full bg-gray-400 dark:bg-gray-400-dark" />
+                <span className="max-w-[120px] truncate text-gray-500 line-through dark:text-gray-500-dark">
+                  {item.label || item.choice}
+                </span>
+              </>
+            ) : (
+              <>
+                <span
+                  role="checkbox"
+                  aria-checked={item.active}
+                  tabIndex={0}
+                  className="flex size-3.5 shrink-0 cursor-pointer items-center justify-center rounded-[2px] border"
+                  style={
+                    item.active
+                      ? {
+                          backgroundColor: item.color.DEFAULT,
+                          borderColor: "transparent",
+                        }
+                      : {
+                          borderColor: item.color.DEFAULT,
+                          backgroundColor: "transparent",
+                        }
+                  }
+                  onClick={() => onChoiceChange(item.choice, !item.active)}
+                  onKeyDown={(e) => {
+                    if (e.key === " " || e.key === "Enter") {
+                      e.preventDefault();
+                      onChoiceChange(item.choice, !item.active);
+                    }
+                  }}
+                >
+                  {item.active && (
+                    <svg
+                      viewBox="0 0 10 8"
+                      className="h-2 w-2.5 fill-none stroke-white stroke-2"
+                    >
+                      <path
+                        d="M1 4l3 3 5-6"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
+                </span>
+                <span className="max-w-[120px] truncate text-gray-800 dark:text-gray-800-dark">
+                  {item.label || item.choice}
+                </span>
+                <span className="shrink-0 tabular-nums text-gray-600 dark:text-gray-600-dark">
+                  {pct}
+                </span>
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default CompactLegendBar;

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
@@ -289,7 +289,7 @@ const MultiChoicesChartView: FC<Props> = ({
                 <div {...legendEnterProps}>
                   <CompactLegendBar
                     items={choiceItems}
-                    questionType={QuestionType.Binary}
+                    questionType={QuestionType.MultipleChoice}
                     onChoiceChange={handleChoiceChange}
                     onChoiceHighlight={handleChoiceHighlight}
                   />

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
@@ -18,6 +18,7 @@ import cn from "@/utils/core/cn";
 import { buildChoicesWithOthers } from "@/utils/questions/choices";
 
 import ChoicesLegend from "./choices_legend";
+import CompactLegendBar from "./compact_legend_bar";
 
 type Props = {
   choiceItems: ChoiceItem[];
@@ -259,6 +260,17 @@ const MultiChoicesChartView: FC<Props> = ({
         isChartReady ? "opacity-100" : "opacity-0"
       )}
     >
+      {withLegend && (isMC || questionType === QuestionType.Binary) && (
+        <CompactLegendBar
+          items={choiceItems}
+          questionType={
+            isMC ? QuestionType.MultipleChoice : QuestionType.Binary
+          }
+          onChoiceChange={handleChoiceChange}
+          onChoiceHighlight={handleChoiceHighlight}
+        />
+      )}
+
       <div
         ref={refs.setReference}
         {...getReferenceProps()}
@@ -304,7 +316,7 @@ const MultiChoicesChartView: FC<Props> = ({
         )}
       </div>
 
-      {withLegend && (
+      {withLegend && !isMC && questionType !== QuestionType.Binary && (
         <div className="-ml-1 mt-3" ref={legendContainerRef}>
           <ChoicesLegend
             choices={choiceItems}

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
@@ -91,6 +91,11 @@ const MultiChoicesChartView: FC<Props> = ({
   const { user } = useAuth();
   const isInteracted = useRef(false);
   const [isChartReady, setIsChartReady] = useState(false);
+  const [isCursorOverLegend, setIsCursorOverLegend] = useState(false);
+  const legendEnterProps = {
+    onMouseEnter: () => setIsCursorOverLegend(true),
+    onMouseLeave: () => setIsCursorOverLegend(false),
+  };
   const handleChartReady = useCallback(() => setIsChartReady(true), []);
   const t = useTranslations();
 
@@ -260,17 +265,6 @@ const MultiChoicesChartView: FC<Props> = ({
         isChartReady ? "opacity-100" : "opacity-0"
       )}
     >
-      {withLegend && (isMC || questionType === QuestionType.Binary) && (
-        <CompactLegendBar
-          items={choiceItems}
-          questionType={
-            isMC ? QuestionType.MultipleChoice : QuestionType.Binary
-          }
-          onChoiceChange={handleChoiceChange}
-          onChoiceHighlight={handleChoiceHighlight}
-        />
-      )}
-
       <div
         ref={refs.setReference}
         {...getReferenceProps()}
@@ -290,13 +284,37 @@ const MultiChoicesChartView: FC<Props> = ({
             activeTimelineMarkerId={activeTimelineMarkerId}
             onTimelineMarkerEnter={onTimelineMarkerEnter}
             onTimelineMarkerLeave={onTimelineMarkerLeave}
+            headerLeft={
+              withLegend ? (
+                <div {...legendEnterProps}>
+                  <CompactLegendBar
+                    items={choiceItems}
+                    questionType={QuestionType.Binary}
+                    onChoiceChange={handleChoiceChange}
+                    onChoiceHighlight={handleChoiceHighlight}
+                  />
+                </div>
+              ) : undefined
+            }
           />
         ) : isMC ? (
           <MultipleChoiceChart
             {...commonChartProps}
             isEmbedded={embedMode}
-            chartTitle={!embedMode ? title : undefined}
+            chartTitle={!embedMode && !withLegend ? title : undefined}
             choiceItems={chartChoiceItems}
+            headerLeft={
+              withLegend ? (
+                <div {...legendEnterProps}>
+                  <CompactLegendBar
+                    items={choiceItems}
+                    questionType={QuestionType.MultipleChoice}
+                    onChoiceChange={handleChoiceChange}
+                    onChoiceHighlight={handleChoiceHighlight}
+                  />
+                </div>
+              ) : undefined
+            }
           />
         ) : (
           <GroupChart
@@ -312,6 +330,18 @@ const MultiChoicesChartView: FC<Props> = ({
             activeTimelineMarkerId={activeTimelineMarkerId}
             onTimelineMarkerEnter={onTimelineMarkerEnter}
             onTimelineMarkerLeave={onTimelineMarkerLeave}
+            headerLeft={
+              withLegend && questionType === QuestionType.Binary ? (
+                <div {...legendEnterProps}>
+                  <CompactLegendBar
+                    items={choiceItems}
+                    questionType={QuestionType.Binary}
+                    onChoiceChange={handleChoiceChange}
+                    onChoiceHighlight={handleChoiceHighlight}
+                  />
+                </div>
+              ) : undefined
+            }
           />
         )}
       </div>
@@ -337,6 +367,7 @@ const MultiChoicesChartView: FC<Props> = ({
       )}
 
       {isTooltipActive &&
+        !isCursorOverLegend &&
         !hideCP &&
         !forecastAvailability?.cpRevealsOn &&
         !activeTimelineMarkerId &&

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -80,6 +80,9 @@ export const ForecasterShell: FC<
 
   const isResolved = postData.status === PostStatus.RESOLVED;
   const isGroup = isGroupOfQuestionsPost(postData);
+  const showChartDivider =
+    isMultipleChoicePost(postData) ||
+    (isGroup && checkGroupOfQuestionsPostType(postData, QuestionType.Binary));
 
   return (
     <Fragment>
@@ -107,6 +110,9 @@ export const ForecasterShell: FC<
             />
           </div>
           <ActionRow post={postData} variant="forecaster" />
+          {showChartDivider && (
+            <div className="mb-2 h-px bg-gray-400 opacity-30 dark:bg-gray-400-dark lg:mb-3" />
+          )}
           <div className="-mt-2 lg:-mt-3">
             {isQuestionPost(postData) && (
               <DetailedQuestionCard
@@ -227,6 +233,11 @@ export const ConsumerShell: FC<{
         <div className="order-2 sm:order-none">
           <ActionRow post={postData} variant="consumer" />
         </div>
+        {(isMultipleChoice ||
+          (isNonFanGroup &&
+            checkGroupOfQuestionsPostType(postData, QuestionType.Binary))) && (
+          <div className="order-2 h-px bg-gray-400 opacity-30 dark:bg-gray-400-dark sm:order-none md:mb-2 lg:mb-3" />
+        )}
         <div className="order-1 mt-3 sm:order-none sm:mt-0 md:-mt-2 lg:-mt-3">
           {showClosedMessageMultipleChoice && (
             <p className="m-0 mb-8 text-center text-sm leading-[20px] text-gray-700 dark:text-gray-700-dark">

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
@@ -142,7 +142,7 @@ const MetaRow: FC<Props> = ({ post, className, variant }) => {
           {hiddenChips.length > 0 && (
             <Popover className="relative shrink-0">
               <PopoverButton className="inline-flex cursor-pointer select-none items-center justify-center gap-1 rounded bg-gray-300 p-1.5 text-sm font-medium leading-4 text-gray-900 hover:bg-gray-400 dark:bg-gray-300-dark dark:text-gray-900-dark dark:hover:bg-gray-400-dark">
-                {t("nMore", { count: hiddenChips.length })}
+                {t("nMore", { count: hiddenChips.length })}...
               </PopoverButton>
               <PopoverPanel className="absolute right-0 top-full z-10 mt-1 flex max-w-[250px] flex-wrap gap-2 rounded border border-gray-300 bg-gray-0 p-3 shadow-lg dark:border-gray-300-dark dark:bg-gray-0-dark">
                 {hiddenChips.map((element) => (

--- a/front_end/src/components/charts/group_chart.tsx
+++ b/front_end/src/components/charts/group_chart.tsx
@@ -2,7 +2,15 @@
 
 import { isNil, merge } from "lodash";
 import { useTranslations } from "next-intl";
-import React, { FC, memo, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  FC,
+  memo,
+  ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   CursorCoordinatesPropType,
   DomainTuple,
@@ -92,6 +100,7 @@ type Props = {
   leftPadding?: number;
   withHighlightArea?: boolean;
   withHighlightEndpoint?: boolean;
+  headerLeft?: ReactNode;
 };
 
 const LABEL_FONT_FAMILY = "Inter";
@@ -137,6 +146,7 @@ const GroupChart: FC<Props> = ({
   leftPadding = 0,
   withHighlightArea = true,
   withHighlightEndpoint = false,
+  headerLeft,
 }) => {
   const t = useTranslations();
   const {
@@ -344,6 +354,7 @@ const GroupChart: FC<Props> = ({
         height={height}
         zoom={withZoomPicker ? zoom : undefined}
         onZoomChange={setZoom}
+        headerLeft={headerLeft}
       >
         {!!chartWidth && (
           <div className="relative h-full">

--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -2,7 +2,15 @@
 
 import { isNil, merge } from "lodash";
 import { useTranslations } from "next-intl";
-import React, { FC, memo, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  FC,
+  memo,
+  ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { v4 } from "uuid";
 import {
   CursorCoordinatesPropType,
@@ -89,6 +97,7 @@ type Props = {
   forecastAvailability?: ForecastAvailability;
   forFeedPage?: boolean;
   chartTitle?: string;
+  headerLeft?: ReactNode;
   animate?: object;
   leftPadding?: number;
 };
@@ -120,6 +129,7 @@ const MultipleChoiceChart: FC<Props> = ({
   forecastAvailability,
   forFeedPage,
   chartTitle,
+  headerLeft,
   animate,
   leftPadding = 0,
 }) => {
@@ -280,6 +290,7 @@ const MultipleChoiceChart: FC<Props> = ({
         zoom={withZoomPicker ? zoom : undefined}
         onZoomChange={setZoom}
         chartTitle={chartTitle}
+        headerLeft={headerLeft}
       >
         {shouldDisplayChart && (
           <VictoryChart

--- a/front_end/src/components/charts/primitives/chart_container.tsx
+++ b/front_end/src/components/charts/primitives/chart_container.tsx
@@ -19,6 +19,7 @@ type Props = {
   zoom?: TimelineChartZoomOption;
   onZoomChange?: (zoom: TimelineChartZoomOption) => void;
   chartTitle?: ReactNode;
+  headerLeft?: ReactNode;
   leftLegend?: React.ReactNode;
   headerExtra?: React.ReactNode;
 };
@@ -31,6 +32,7 @@ const ChartContainer = forwardRef<HTMLDivElement, PropsWithChildren<Props>>(
       onZoomChange,
       children,
       chartTitle,
+      headerLeft,
       leftLegend,
       headerExtra,
     },
@@ -53,61 +55,75 @@ const ChartContainer = forwardRef<HTMLDivElement, PropsWithChildren<Props>>(
 
     return (
       <div className="relative flex w-full flex-col">
-        {(!!chartTitle || !!zoom) && !isEmbed && (
-          <div
-            className={cn("flex w-full", !isEmbed ? "mb-2.5 md:mb-5" : "mb-3")}
-          >
-            {!!chartTitle && (
-              <div
-                className={cn(
-                  isEmbed
-                    ? "text-xs text-gray-600 dark:text-gray-600-dark"
-                    : "text-xs font-normal text-blue-900 dark:text-gray-900-dark md:text-base"
-                )}
-              >
-                {chartTitle}
-              </div>
-            )}
-            {(!!zoom || !!headerExtra) && (
-              <div className="ml-auto flex items-center gap-2 self-end">
-                {!!zoom && (
-                  <TabGroup
-                    selectedIndex={selectedIndex}
-                    onChange={handleTabChange}
-                    manual
-                  >
-                    <TabList className="flex gap-0.5">
-                      {tabOptions.map((option) => (
-                        <Tab as={Fragment} key={option.value}>
-                          {({ selected, hover }) => (
-                            <button
-                              className={cn(
-                                "ChartZoomButton rounded px-1 py-0.5 text-xs font-normal uppercase leading-4 text-gray-600 hover:text-blue-800 focus:outline-none dark:text-gray-600-dark hover:dark:text-blue-800-dark md:text-sm",
-                                {
-                                  "text-gray-900 dark:text-gray-900-dark":
-                                    selected,
-                                },
-                                {
-                                  "bg-gray-300 dark:bg-gray-300-dark":
-                                    hover || selected,
-                                },
-                                isEmbed &&
-                                  "uppercase text-gray-600 dark:text-gray-600-dark md:text-xs"
-                              )}
-                            >
-                              {option.label}
-                            </button>
-                          )}
-                        </Tab>
-                      ))}
-                    </TabList>
-                  </TabGroup>
-                )}
-                {headerExtra}
-              </div>
-            )}
-          </div>
-        )}
+        {(!!chartTitle || !!headerLeft || !!zoom || !!headerExtra) &&
+          !isEmbed && (
+            <div
+              className={cn(
+                "flex w-full",
+                !!headerLeft
+                  ? "flex-col items-start gap-1 md:flex-row md:items-center md:gap-0"
+                  : "items-center",
+                !isEmbed ? "mb-2.5 md:mb-5" : "mb-3"
+              )}
+            >
+              {!!headerLeft ? (
+                <div className="w-full min-w-0 md:flex-1">{headerLeft}</div>
+              ) : !!chartTitle ? (
+                <div
+                  className={cn(
+                    isEmbed
+                      ? "text-xs text-gray-600 dark:text-gray-600-dark"
+                      : "text-xs font-normal text-blue-900 dark:text-gray-900-dark md:text-base"
+                  )}
+                >
+                  {chartTitle}
+                </div>
+              ) : null}
+              {(!!zoom || !!headerExtra) && (
+                <div
+                  className={cn(
+                    "hidden items-center gap-2 self-end md:flex",
+                    !!headerLeft ? "md:ml-auto" : "ml-auto"
+                  )}
+                >
+                  {!!zoom && (
+                    <TabGroup
+                      selectedIndex={selectedIndex}
+                      onChange={handleTabChange}
+                      manual
+                    >
+                      <TabList className="flex gap-0.5">
+                        {tabOptions.map((option) => (
+                          <Tab as={Fragment} key={option.value}>
+                            {({ selected, hover }) => (
+                              <button
+                                className={cn(
+                                  "ChartZoomButton rounded px-1 py-0.5 text-xs font-normal uppercase leading-4 text-gray-600 hover:text-blue-800 focus:outline-none dark:text-gray-600-dark hover:dark:text-blue-800-dark md:text-sm",
+                                  {
+                                    "text-gray-900 dark:text-gray-900-dark":
+                                      selected,
+                                  },
+                                  {
+                                    "bg-gray-300 dark:bg-gray-300-dark":
+                                      hover || selected,
+                                  },
+                                  isEmbed &&
+                                    "uppercase text-gray-600 dark:text-gray-600-dark md:text-xs"
+                                )}
+                              >
+                                {option.label}
+                              </button>
+                            )}
+                          </Tab>
+                        ))}
+                      </TabList>
+                    </TabGroup>
+                  )}
+                  {headerExtra}
+                </div>
+              )}
+            </div>
+          )}
 
         {leftLegend ? (
           <div


### PR DESCRIPTION
Related to #4643

### Summary

This PR adds a compact horizontal legend bar to the forecaster view for MC and binary group questions, rendered above the timeline.

Implemented:

- **Compact legend bar** (`CompactLegendBar`): new component showing a colored checkbox, truncated label, and current % per option; checkbox toggles series visibility by reusing the existing `ChoiceItem.active` state in `MultiChoicesChartView`; options resolved NO render a gray dot with strikethrough label and no checkbox, detected data-driven via `item.resolution` for binary subquestions and `item.displayedResolution` for MC options
- **Chart header integration** (`ChartContainer`, `MultipleChoiceChart`, `GroupChart`): added `headerLeft` slot to the chart header row so the legend shares the same line as zoom buttons on desktop; on mobile the header stacks vertically giving the legend full row width; zoom buttons hidden on mobile
- **Mobile item cap** (`CompactLegendBar`): on mobile shows up to 5 normal items only (resolved-NO always hidden); remaining items collapsed behind a single "{n} more" button that expands all; on desktop all normal items shown with resolved-NO collapsed separately
- **UX polish** (`MultiChoicesChartView`, `question_page_shell`): tooltip suppressed when cursor is over the legend; divider added between the action row and chart section for MC and binary group questions

### Demo video

https://github.com/user-attachments/assets/7b6490c4-b9ca-4553-961f-5de2fb7da828


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compact, responsive legend display for multiple-choice and binary charts with enhanced mobile experience.

* **Localization**
  * Removed trailing ellipsis from "show more" text across Czech, English, Spanish, Portuguese, and Chinese translations for cleaner UI presentation.

* **UI/Visual Updates**
  * Added visual dividers to chart sections for improved layout clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4724)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->