### PR TITLE
feat(labor-hub): add Yale Budget Lab study to activity monitor

### DIFF
--- a/front_end/src/app/(main)/labor-hub/activity_data.tsx
+++ b/front_end/src/app/(main)/labor-hub/activity_data.tsx
@@ -118,4 +118,22 @@ export const RAW_ACTIVITY_MONITOR_DATA: RawActivityMonitorEntry[] = [
       </>
     ),
   },
+  {
+    date: "2026-05-07",
+    type: "news",
+    content: (
+      <>
+        The Budget Lab research center at Yale published a study on the effects
+        that AI tools are having on the labor market that found no clear effects
+        as of yet -{" "}
+        <a
+          href="https://budgetlab.yale.edu/research/what-we-do-and-dont-know-about-how-ai-affecting-labor-market"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          The Budget Lab at Yale
+        </a>
+      </>
+    ),
+  },
 ];


### PR DESCRIPTION
## Summary

Adds the May 7, 2026 Budget Lab at Yale study on AI's effects on the labor market as a news entry in the labor hub activity monitor.

Closes #4725

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new news item dated May 7, 2026, to the activity monitor, including a link to external research resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4726)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->