### PR TITLE
feat(notebooks): raise short title limit to 80 characters

### DIFF
--- a/front_end/src/app/(main)/questions/components/notebook_form.tsx
+++ b/front_end/src/app/(main)/questions/components/notebook_form.tsx
@@ -54,8 +54,8 @@ const createNotebookSchema = (t: ReturnType<typeof useTranslations>) => {
       .min(4, {
         message: t("errorMinLength", { field: "String", minLength: 4 }),
       })
-      .max(60, {
-        message: t("errorMaxLength", { field: "String", maxLength: 60 }),
+      .max(80, {
+        message: t("errorMaxLength", { field: "String", maxLength: 80 }),
       }),
     default_project: z.number(),
     markdown: z.string().min(1, {


### PR DESCRIPTION
Closes #4727

## Summary

Raise the notebook `short_title` max length from 60 to 80 characters in `notebook_form.tsx`.

## Notes

- `question_form.tsx` and `group_form.tsx` already use `max(80)` on `short_title` on `main`, so no changes were needed there.
- The DB column `Post.short_title` is `max_length=2000`, and no DRF serializer adds a length validator, so no backend changes are needed.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notebook titles can now contain up to 80 characters (increased from 60), allowing for more descriptive and detailed titles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->