### PR TITLE
Add SQL full-text fallback when external search providers fail

### DIFF
--- a/posts/services/search.py
+++ b/posts/services/search.py
@@ -8,6 +8,7 @@ from django.contrib.postgres.search import SearchVector, SearchQuery
 from django.db.models import Value, Case, When, FloatField, QuerySet, Q
 from django.utils import timezone
 from pgvector.django import CosineDistance
+from rest_framework.exceptions import APIException
 
 from posts.models import Post
 from utils.openai import (
@@ -18,6 +19,12 @@ from utils.openai import (
 from utils.serper_google import get_google_search_results
 
 logger = logging.getLogger(__name__)
+
+
+class SearchUnavailable(APIException):
+    status_code = 503
+    default_detail = "Search is temporarily unavailable. Please try again later."
+    default_code = "search_unavailable"
 
 
 def generate_post_content_for_embedding_vectorization(post: Post):
@@ -72,28 +79,55 @@ def perform_post_search(qs, search_text: str):
     embedding_vector, semantic_scores_by_id = async_to_sync(gather_search_results)(
         search_text
     )
+
+    if embedding_vector is None and semantic_scores_by_id is None:
+        try:
+            return posts_full_text_search(qs, search_text).annotate(
+                rank=Value(0.3, output_field=FloatField())
+            )
+        except Exception:
+            logger.exception("Failed to perform full-text post search")
+            raise SearchUnavailable()
+
     semantic_scores_by_id = semantic_scores_by_id or {}
 
     semantic_whens = [
         When(id=key, then=Value(val)) for key, val in semantic_scores_by_id.items()
     ]
+    ranking_penalty = Case(
+        # Penalise closed and resolved questions in search by 10%
+        When(
+            Q(resolved=True) | Q(actual_close_time__lte=timezone.now()),
+            then=Value(0.9),
+        ),
+        default=1,
+        output_field=FloatField(),
+    )
+
+    if embedding_vector is None:
+        if not semantic_scores_by_id:
+            return qs.none()
+
+        return qs.filter(id__in=semantic_scores_by_id.keys()).annotate(
+            rank=Case(
+                *semantic_whens,
+                default=0,
+                output_field=FloatField(),
+            )
+            * ranking_penalty
+        )
 
     # Annotating embedding vector distance
-    qs = qs.filter(embedding_vector__isnull=False).annotate(
+    google_result_ids = semantic_scores_by_id.keys()
+    qs = qs.filter(
+        Q(embedding_vector__isnull=False) | Q(id__in=google_result_ids)
+    ).annotate(
         rank=Case(
             *semantic_whens,
             default=1 - CosineDistance("embedding_vector", embedding_vector),
             output_field=FloatField(),
         )
-        * Case(
-            # Penalise closed and resolved questions in search by 10%
-            When(
-                Q(resolved=True) | Q(actual_close_time__lte=timezone.now()),
-                then=Value(0.9),
-            ),
-            default=1,
-            output_field=FloatField(),
-        )
+        * ranking_penalty
     )
 
     return qs
@@ -101,16 +135,23 @@ def perform_post_search(qs, search_text: str):
 
 async def gather_search_results(
     search_text: str,
-) -> tuple[list[float], dict[int, float]]:
+) -> tuple[list[float] | None, dict[int, float] | None]:
     return await asyncio.gather(
-        generate_text_embed_vector_async(search_text),
+        perform_embedding_search(search_text),
         perform_google_search(search_text),
     )
 
 
+async def perform_embedding_search(search_text: str) -> list[float] | None:
+    try:
+        return await generate_text_embed_vector_async(search_text)
+    except Exception:
+        logger.exception("Failed to generate search embedding")
+
+
 async def perform_google_search(
     search_text: str,
-) -> dict[int, float]:
+) -> dict[int, float] | None:
     """
     Returns a dict of question IDs to Google scores.
     """
@@ -150,6 +191,8 @@ def posts_full_text_search(qs: QuerySet[Post], query: str):
     # Each word is matched using a prefix search operator (":*"), enabling partial word matches.
     # Words are joined with an AND operator ("&") to combine search criteria.
     query = " & ".join(f"{word.strip()}:*" for word in query.split() if word.strip())
+    if not query:
+        return qs.none()
 
     search_vector = (
         SearchVector("questions__title")

--- a/tests/unit/test_posts/test_services/test_search.py
+++ b/tests/unit/test_posts/test_services/test_search.py
@@ -1,0 +1,116 @@
+from asgiref.sync import async_to_sync
+
+from posts.models import Post
+from posts.services.search import (
+    SearchUnavailable,
+    gather_search_results,
+    perform_post_search,
+)
+from tests.unit.test_posts.factories import factory_post
+
+
+def test_gather_search_results_returns_google_results_when_embedding_fails(
+    monkeypatch,
+):
+    async def mock_generate_text_embed_vector_async(_search_text):
+        raise RuntimeError("OpenAI quota exhausted")
+
+    async def mock_perform_google_search(_search_text):
+        return {123: 0.9}
+
+    monkeypatch.setattr(
+        "posts.services.search.generate_text_embed_vector_async",
+        mock_generate_text_embed_vector_async,
+    )
+    monkeypatch.setattr(
+        "posts.services.search.perform_google_search",
+        mock_perform_google_search,
+    )
+
+    embedding_vector, google_scores = async_to_sync(gather_search_results)("test")
+
+    assert embedding_vector is None
+    assert google_scores == {123: 0.9}
+
+
+def test_perform_post_search_returns_google_matches_without_embedding(monkeypatch):
+    matching_post = factory_post()
+    factory_post()
+
+    async def mock_gather_search_results(_search_text):
+        return None, {matching_post.id: 0.9}
+
+    monkeypatch.setattr(
+        "posts.services.search.gather_search_results",
+        mock_gather_search_results,
+    )
+
+    posts = list(perform_post_search(Post.objects.all(), "test"))
+
+    assert len(posts) == 1
+    assert posts[0].id == matching_post.id
+    assert posts[0].rank == 0.9
+
+
+def test_perform_post_search_uses_full_text_when_providers_fail(monkeypatch):
+    matching_post = factory_post()
+    factory_post()
+
+    async def mock_gather_search_results(_search_text):
+        return None, None
+
+    def mock_posts_full_text_search(qs, _search_text):
+        return qs.filter(id=matching_post.id)
+
+    monkeypatch.setattr(
+        "posts.services.search.gather_search_results",
+        mock_gather_search_results,
+    )
+    monkeypatch.setattr(
+        "posts.services.search.posts_full_text_search",
+        mock_posts_full_text_search,
+    )
+
+    posts = list(perform_post_search(Post.objects.all(), "test"))
+
+    assert len(posts) == 1
+    assert posts[0].id == matching_post.id
+    assert posts[0].rank == 0.3
+
+
+def test_perform_post_search_errors_when_all_search_paths_fail(monkeypatch):
+    async def mock_gather_search_results(_search_text):
+        return None, None
+
+    def mock_posts_full_text_search(_qs, _search_text):
+        raise RuntimeError("database search unavailable")
+
+    monkeypatch.setattr(
+        "posts.services.search.gather_search_results",
+        mock_gather_search_results,
+    )
+    monkeypatch.setattr(
+        "posts.services.search.posts_full_text_search",
+        mock_posts_full_text_search,
+    )
+
+    try:
+        perform_post_search(Post.objects.all(), "test")
+    except SearchUnavailable as exc:
+        assert exc.status_code == 503
+    else:
+        raise AssertionError("Expected SearchUnavailable")
+
+
+def test_perform_post_search_returns_empty_when_google_succeeds_with_no_results(
+    monkeypatch,
+):
+    async def mock_gather_search_results(_search_text):
+        return None, {}
+
+    monkeypatch.setattr(
+        "posts.services.search.gather_search_results",
+        mock_gather_search_results,
+    )
+
+    assert not perform_post_search(Post.objects.all(), "test").exists()


### PR DESCRIPTION
## Summary
- Keep OpenAI embedding failures from blocking search results when Google/Serper still returns matches.
- Fall back to Postgres full-text search when both external providers fail.
- Return `503 SearchUnavailable` only when every available search path fails.
- Guard raw tsquery generation against empty queries.

## Testing
- Added unit coverage for OpenAI failure, Google-only fallback, SQL full-text fallback, and the all-paths-fail error case.
- Linting and syntax checks passed.
- Full pytest execution was not run locally because the PostgreSQL test database was unavailable in this environment.