### PR TITLE
fix: labor hub commentary – match forecast numbers to chart decimal precision

### DIFF
--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-05-13">May 13</time>
+              Commentary last updated: <time dateTime="2026-05-16">May 16</time>
             </div>
           </div>
         </div>

--- a/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
@@ -86,11 +86,11 @@ export async function KeyInsightsSection({
   const govBaseline2035 = GOVERNMENT_BASELINES["2035"].toFixed(1);
   const hoursDisplay =
     insightsData.hoursWorked2035 != null
-      ? Math.round(insightsData.hoursWorked2035)
+      ? Math.round(insightsData.hoursWorked2035 * 10) / 10
       : null;
   const youthDisplay =
     insightsData.youthUnemployment2035 != null
-      ? Math.round(insightsData.youthUnemployment2035)
+      ? Math.round(insightsData.youthUnemployment2035 * 10) / 10
       : null;
   const mostVulnerableText = formatJobList(mostVulnerable2035);
   const leastVulnerableText = formatJobList(leastVulnerable2035);


### PR DESCRIPTION
## Summary

Two forecast values in the Key Insights section were being rounded to whole numbers, while the corresponding charts display them with one decimal place, creating a mismatch between commentary and chart labels.

### Fixes

**Section: Key Insights — Young workers**
- Old: "unemployment for 4-year college graduates in the 22-27 age range expected to grow from the current 6% **to 12%** in 2035"
- Chart label: **12.2%**
- Fix: Changed `Math.round(youthUnemployment2035)` → `Math.round(youthUnemployment2035 * 10) / 10` so commentary now says "to **12.2%** in 2035"

**Section: Key Insights — Wages and hours worked**
- Old: "hours worked are expected to decline **to 34 hours a week** in 2035"
- Chart label: **34.2**
- Fix: Changed `Math.round(hoursWorked2035)` → `Math.round(hoursWorked2035 * 10) / 10` so commentary now says "to **34.2 hours a week** in 2035"

Also updated commentary last-updated date from May 13 → May 16.

https://claude.ai/code/session_01Ga1xho3nmih5wYJY1CEpod

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ga1xho3nmih5wYJY1CEpod)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Labor Hub key metrics now display values with one decimal place for improved precision.
  * Updated timestamp information in the Labor Hub hero section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4735?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->