### PR TITLE
Tweak the calculation of lambda in ridge regression

### DIFF
--- a/scoring/management/commands/update_global_bot_leaderboard.py
+++ b/scoring/management/commands/update_global_bot_leaderboard.py
@@ -447,7 +447,9 @@ def estimate_variances_from_head_to_head(
     )
     skill_variance = 1 if np.isnan(skill_variance) else skill_variance
 
-    alpha = (error / skill_variance) ** 2
+    # Ridge regularization: λ = σ²_error / σ²_true (ratio of variances).
+    # `error` is a standard deviation, `skill_variance` is already a variance.
+    alpha = error**2 / skill_variance
     if verbose:
         print(
             f"Found {len(rematch_variances)} matchups with >={min_paired_matches} rematches"
@@ -456,8 +458,8 @@ def estimate_variances_from_head_to_head(
         print(
             f"Found {len(high_match_skills)} players with >={min_questions_for_true} questions"
         )
-        print(f"σ_true (skill variance): {skill_variance:.4f}")
-        print(f"alpha = (σ_error / σ_true)² = {alpha:.4f}")
+        print(f"σ²_true (skill variance): {skill_variance:.4f}")
+        print(f"alpha = σ²_error / σ²_true = {alpha:.4f}")
     return alpha
 
 


### PR DESCRIPTION
The alpha calculation (which is actually lambda in ridge regression but that gets reserved as a keyword in Python) previously did:

(std_of_match_noise / skill_variance) ** 2

but the Bayesian interpretation of ridge regression tells us the optimal lambda value is:

(std_of_match_noise **2 / skill_variance)

This is explained well here:

https://machinelearningplus.com/statistics/ridge-regression-as-map-estimation-supporting-notes/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bot leaderboard scoring calculation methodology for improved accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->