### PR TITLE
privatize comments from user admin panel

### DIFF
--- a/comments/services/common.py
+++ b/comments/services/common.py
@@ -1,5 +1,6 @@
 import datetime
 import difflib
+from collections import defaultdict
 
 from django.db import IntegrityError, transaction
 from django.db.models import (
@@ -453,3 +454,61 @@ def update_top_comments_of_week(week_start_date: datetime.date):
     ).exclude(
         id__in=[entry.id for entry in created_entries],
     ).delete()
+
+
+def privatize_user_comments(user) -> int:
+    """
+    Sets is_private=True on all of the user's comments that have no descendant
+    comments authored by a different user. Skips comments that already have
+    replies (direct or nested) from other users, since hiding those would break
+    the conversation context for the other participants.
+
+    Returns the number of comments that were privatized.
+    """
+    from django.db.models import Q
+
+    user_comments = list(
+        Comment.objects.filter(author=user).values("id", "root_id", "is_private")
+    )
+    if not user_comments:
+        return 0
+
+    # Collect thread root IDs: root-level comments are their own root
+    thread_root_ids: set[int] = set()
+    for c in user_comments:
+        if c["root_id"] is None:
+            thread_root_ids.add(c["id"])
+        else:
+            thread_root_ids.add(c["root_id"])
+
+    # Load every comment in those threads so we can traverse the reply tree
+    all_thread_comments = list(
+        Comment.objects.filter(
+            Q(id__in=thread_root_ids) | Q(root_id__in=thread_root_ids)
+        ).values("id", "author_id", "parent_id")
+    )
+
+    children_map: dict[int, list[int]] = defaultdict(list)
+    for c in all_thread_comments:
+        if c["parent_id"] is not None:
+            children_map[c["parent_id"]].append(c["id"])
+    comment_author_map = {c["id"]: c["author_id"] for c in all_thread_comments}
+
+    def has_non_user_descendant(comment_id: int) -> bool:
+        stack = list(children_map.get(comment_id, []))
+        while stack:
+            child_id = stack.pop()
+            if comment_author_map.get(child_id) != user.id:
+                return True
+            stack.extend(children_map.get(child_id, []))
+        return False
+
+    to_privatize = [
+        c["id"]
+        for c in user_comments
+        if not c["is_private"] and not has_non_user_descendant(c["id"])
+    ]
+
+    if to_privatize:
+        Comment.objects.filter(id__in=to_privatize).update(is_private=True)
+    return len(to_privatize)

--- a/templates/admin/users/user_change_form.html
+++ b/templates/admin/users/user_change_form.html
@@ -1,0 +1,16 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+{% if original.pk and original.is_bot %}
+<li>
+    <a href="{% url 'admin:privatize-user-comments' original.pk %}"
+       class="button"
+       style="background:#ba2121;color:#fff;padding:5px 10px;border-radius:4px;text-decoration:none;"
+       onclick="return confirm('Privatize all eligible comments for {{ original.username }}? Comments with replies from other users will be skipped. This cannot be undone.')">
+        Privatize Comments
+    </a>
+</li>
+{% endif %}
+{{ block.super }}
+{% endblock %}

--- a/users/admin.py
+++ b/users/admin.py
@@ -5,7 +5,8 @@ from admin_auto_filters.filters import AutocompleteFilterFactory
 from django.contrib import admin, messages
 from django.contrib.admin.models import CHANGE, LogEntry
 from django.db.models import Count, Exists, OuterRef, Q, F, QuerySet
-from django.urls import reverse
+from django.shortcuts import get_object_or_404, redirect
+from django.urls import path, reverse
 from django.utils.html import format_html
 from sql_util.aggregates import SubqueryAggregate
 
@@ -203,6 +204,7 @@ class BotInline(admin.TabularInline):
 
 @admin.register(User)
 class UserAdmin(admin.ModelAdmin):
+    change_form_template = "admin/users/user_change_form.html"
     list_display = [
         "username",
         "id",
@@ -375,6 +377,29 @@ class UserAdmin(admin.ModelAdmin):
             )
 
     generate_password_reset_links.short_description = "Generate password reset link"
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "<int:user_id>/privatize-comments/",
+                self.admin_site.admin_view(self.privatize_comments_view),
+                name="privatize-user-comments",
+            ),
+        ]
+        return custom_urls + urls
+
+    def privatize_comments_view(self, request, user_id):
+        from comments.services.common import privatize_user_comments
+
+        user = get_object_or_404(User, pk=user_id)
+        count = privatize_user_comments(user)
+        self.message_user(
+            request,
+            f"Privatized {count} comment(s) for {user.username}.",
+            level=messages.SUCCESS,
+        )
+        return redirect("admin:users_user_change", user_id)
 
     def get_fields(self, request, obj=None):
         fields = list(super().get_fields(request, obj))


### PR DESCRIPTION
Adds a `Privatize Comments` button to bot user admin panel. Asks for confirmation before activating.

https://metaculus.slack.com/archives/C01Q9AQBVHB/p1779289076522979

related to #4583 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to bulk privatize a user's comments from the admin interface
  * "Privatize Comments" button now appears for bot user accounts with confirmation prompt
  * System reports the number of comments privatized upon completion

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->