### PR TITLE
Question page redesign improvements

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -12,10 +12,13 @@ import UpcomingCP from "@/components/consumer_post_card/upcoming_cp";
 import DetailedGroupCard from "@/components/detailed_question_card/detailed_group_card";
 import DetailedQuestionCard from "@/components/detailed_question_card/detailed_question_card";
 import ForecastMaker from "@/components/forecast_maker";
+import MarkdownEditor from "@/components/markdown_editor";
 import CommunityDisclaimer from "@/components/post_card/community_disclaimer";
+import SectionToggle from "@/components/ui/section_toggle";
 import { ContinuousChartCursorProvider } from "@/contexts/continuous_chart_cursor_context";
 import { useHideCP } from "@/contexts/cp_context";
 import { useContentTranslatedBannerContext } from "@/contexts/translations_banner_context";
+import { usePostTextSections } from "@/hooks/use_post_text_sections";
 import {
   GroupOfQuestionsGraphType,
   GroupOfQuestionsPost,
@@ -80,6 +83,7 @@ export const ForecasterShell: FC<
     };
   }, [postData.is_current_content_translated, locale, setBannerIsVisible]);
 
+  const sections = usePostTextSections(postData, { excludeFinePrint: true });
   const isResolved = postData.status === PostStatus.RESOLVED;
   const isGroup = isGroupOfQuestionsPost(postData);
   const showChartDivider =
@@ -141,6 +145,21 @@ export const ForecasterShell: FC<
               ))}
           </div>
           {(!isResolved || isGroup) && <ForecastMaker post={postData} />}
+          {sections.length > 0 && (
+            <div className="flex flex-col gap-2">
+              {sections.map((section) => (
+                <SectionToggle
+                  key={section.title}
+                  title={section.title}
+                  variant="dark"
+                  wrapperClassName="bg-opacity-50"
+                  className="font-medium"
+                >
+                  <MarkdownEditor withCodeBlocks markdown={section.markdown} />
+                </SectionToggle>
+              ))}
+            </div>
+          )}
           <PostScoreData post={postData} noSectionWrapper />
         </section>
         <section className={commentSectionClassName}>

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/question_info.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/question_info.tsx
@@ -5,6 +5,7 @@ import { FC } from "react";
 
 import MarkdownEditor from "@/components/markdown_editor";
 import Chip from "@/components/ui/chip";
+import { usePostTextSections } from "@/hooks/use_post_text_sections";
 import { PostWithForecasts } from "@/types/post";
 import { sendAnalyticsEvent } from "@/utils/analytics";
 import { getProjectLink } from "@/utils/navigation";
@@ -16,71 +17,9 @@ type Props = {
   post: PostWithForecasts;
 };
 
-type MarkdownSection = { title: string; markdown: string };
-
-const useTextSections = (post: PostWithForecasts): MarkdownSection[] => {
-  const t = useTranslations();
-
-  if (post.conditional) {
-    const { condition, condition_child } = post.conditional;
-    const sections: MarkdownSection[] = [];
-    if (condition.resolution_criteria) {
-      sections.push({
-        title: t("parentResolutionCriteria"),
-        markdown: condition.resolution_criteria,
-      });
-    }
-    if (condition.fine_print) {
-      sections.push({ title: t("finePrint"), markdown: condition.fine_print });
-    }
-    if (condition.description) {
-      sections.push({
-        title: t("parentBackgroundInfo"),
-        markdown: condition.description,
-      });
-    }
-    if (condition_child.resolution_criteria) {
-      sections.push({
-        title: t("childResolutionCriteria"),
-        markdown: condition_child.resolution_criteria,
-      });
-    }
-    if (condition_child.fine_print) {
-      sections.push({
-        title: t("finePrint"),
-        markdown: condition_child.fine_print,
-      });
-    }
-    if (condition_child.description) {
-      sections.push({
-        title: t("childBackgroundInfo"),
-        markdown: condition_child.description,
-      });
-    }
-    return sections;
-  }
-
-  const resolution =
-    post.group_of_questions?.resolution_criteria ??
-    post.question?.resolution_criteria ??
-    "";
-  const finePrint =
-    post.group_of_questions?.fine_print ?? post.question?.fine_print ?? "";
-  const description =
-    post.group_of_questions?.description ?? post.question?.description ?? "";
-
-  const sections: MarkdownSection[] = [];
-  if (resolution)
-    sections.push({ title: t("resolutionCriteria"), markdown: resolution });
-  if (finePrint) sections.push({ title: t("finePrint"), markdown: finePrint });
-  if (description)
-    sections.push({ title: t("backgroundInfo"), markdown: description });
-  return sections;
-};
-
 const QuestionInfoTab: FC<Props> = ({ post }) => {
   const t = useTranslations();
-  const sections = useTextSections(post);
+  const sections = usePostTextSections(post);
 
   const projectsData = post.projects;
   const allProjects = projectsData

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
@@ -30,6 +30,7 @@ const TitleRow: FC<Props> = ({ post, variant, className }) => {
   const { hideCP } = useHideCP();
   const cursorCtx = useContinuousChartCursor();
   const cursorForecast = cursorCtx?.activeForecast ?? null;
+  const cursorUserForecastValues = cursorCtx?.activeUserForecastValues ?? null;
 
   if (isConditionalPost(post)) {
     return (
@@ -69,6 +70,9 @@ const TitleRow: FC<Props> = ({ post, variant, className }) => {
                   size="md"
                   hideLabel={isContinuous}
                   cursorForecast={isContinuous ? cursorForecast : undefined}
+                  cursorUserForecastValues={
+                    isContinuous ? cursorUserForecastValues : undefined
+                  }
                 />
               )}
             </div>

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
@@ -29,6 +29,7 @@ const ContinuousQuestionPrediction: React.FC<Props> = ({
   const forecastAvailability = getQuestionForecastAvailability(question);
   const cursorCtx = useContinuousChartCursor();
   const cursorForecast = cursorCtx?.activeForecast ?? null;
+  const cursorUserForecastValues = cursorCtx?.activeUserForecastValues ?? null;
   const { hideCP } = useHideCP();
 
   const shouldHideChart =
@@ -44,7 +45,7 @@ const ContinuousQuestionPrediction: React.FC<Props> = ({
   // Null when cursor is inactive — chart falls back to the latest aggregate.
   const cursorChartData = useMemo<ContinuousAreaGraphInput | null>(() => {
     if (!cursorForecastValues) return null;
-    return [
+    const data: ContinuousAreaGraphInput = [
       {
         pmf: cdfToPmf(cursorForecastValues),
         cdf: cursorForecastValues,
@@ -53,7 +54,15 @@ const ContinuousQuestionPrediction: React.FC<Props> = ({
           : "community") as ContinuousAreaType,
       },
     ];
-  }, [cursorForecastValues, question.status]);
+    if (cursorUserForecastValues) {
+      data.push({
+        pmf: cdfToPmf(cursorUserForecastValues),
+        cdf: cursorUserForecastValues,
+        type: "user",
+      });
+    }
+    return data;
+  }, [cursorForecastValues, cursorUserForecastValues, question.status]);
 
   if (hideCP) {
     return (

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
@@ -40,6 +40,7 @@ type Props = {
   colorOverride?: string;
   chartTheme?: VictoryThemeDefinition;
   cursorForecast?: NumericAggregateForecast | null;
+  cursorUserForecastValues?: number[] | null;
 };
 
 const QuestionHeaderCPStatus: FC<Props> = ({
@@ -49,6 +50,7 @@ const QuestionHeaderCPStatus: FC<Props> = ({
   colorOverride,
   chartTheme,
   cursorForecast,
+  cursorUserForecastValues,
 }) => {
   const locale = useLocale();
   const t = useTranslations();
@@ -74,18 +76,28 @@ const QuestionHeaderCPStatus: FC<Props> = ({
   const cursorForecastValues = cursorForecast?.forecast_values ?? null;
   const cursorAreaChartData = useMemo<ContinuousAreaGraphInput | null>(() => {
     if (!cursorForecastValues) return null;
-    return [
+    const communityType: ContinuousAreaType =
+      question.status === QuestionStatus.RESOLVED
+        ? "community_resolved"
+        : question.status === QuestionStatus.CLOSED
+          ? "community_closed"
+          : "community";
+    const data: ContinuousAreaGraphInput = [
       {
         pmf: cdfToPmf(cursorForecastValues),
         cdf: cursorForecastValues,
-        type: (question.status === QuestionStatus.RESOLVED
-          ? "community_resolved"
-          : question.status === QuestionStatus.CLOSED
-            ? "community_closed"
-            : "community") as ContinuousAreaType,
+        type: communityType,
       },
     ];
-  }, [cursorForecastValues, question.status]);
+    if (cursorUserForecastValues) {
+      data.push({
+        pmf: cdfToPmf(cursorUserForecastValues),
+        cdf: cursorUserForecastValues,
+        type: "user",
+      });
+    }
+    return data;
+  }, [cursorForecastValues, cursorUserForecastValues, question.status]);
 
   if (question.status === QuestionStatus.RESOLVED && question.resolution) {
     // Resolved/Annulled/Ambiguous
@@ -337,7 +349,7 @@ const QuestionHeaderCPStatus: FC<Props> = ({
             question={question}
             className={cn("mx-auto pb-1 text-center", {
               "w-max max-w-32": size === "md",
-              "-mt-[55px]": size === "lg",
+              "mt-6": size === "lg",
             })}
             size="sm"
             unit={"%"}

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -43,6 +43,7 @@ import {
   CHART_FONT_STYLE,
 } from "@/constants/chart_typography";
 import { METAC_COLORS } from "@/constants/colors";
+import { useBreakpoint } from "@/hooks/tailwind";
 import useAppTheme from "@/hooks/use_app_theme";
 import useChartTooltip from "@/hooks/use_chart_tooltip";
 import useContainerSize from "@/hooks/use_container_size";
@@ -70,6 +71,11 @@ import { resolveToCssColor } from "@/utils/resolve_color";
 import ForecastAvailabilityChartOverflow from "../post_card/chart_overflow";
 import ChartValueBox from "./primitives/chart_value_box";
 import ResolutionTooltip from "./primitives/resolution_tooltip";
+
+// VictoryPortal fixes SVG z-ordering but causes an infinite loop on mobile
+// (touch-move → new JSX ref → addChild → setState → re-render → repeat).
+const wrapPortal = (element: React.ReactElement, disabled: boolean) =>
+  disabled ? element : <VictoryPortal>{element}</VictoryPortal>;
 
 type ChartData = {
   line: Line;
@@ -116,6 +122,7 @@ type Props = {
 };
 
 const BOTTOM_PADDING = 20;
+const fallbackTimestamp = Date.now() / 1000;
 const NEWS_ANNOTATION_MARKER_SIZE = 18;
 
 const NumericChart: FC<Props> = ({
@@ -154,6 +161,7 @@ const NumericChart: FC<Props> = ({
   const { theme, getThemeColor } = useAppTheme();
   const [isChartReady, setIsChartReady] = useState(false);
   const [zoom, setZoom] = useState(defaultZoom);
+  const isMobile = !useBreakpoint("md");
 
   const [isCursorActive, setIsCursorActive] = useState(false);
   const isContinuousConsumerView =
@@ -169,7 +177,7 @@ const NumericChart: FC<Props> = ({
   );
   const shouldAdjustCursorLabel = line.at(-1)?.x !== xDomain.at(-1);
   const defaultCursor = useMemo(
-    () => line.at(-1)?.x ?? Date.now() / 1000,
+    () => line.at(-1)?.x ?? fallbackTimestamp,
     [line]
   );
   const cursorValue = useMemo(() => {
@@ -289,18 +297,17 @@ const NumericChart: FC<Props> = ({
             />
           )
         }
-        cursorLabelComponent={
-          <VictoryPortal>
-            <ChartCursorLabel
-              positionY={height - 10}
-              {...(hasExternalTheme
-                ? {}
-                : { fill: getThemeColor(METAC_COLORS.gray["700"]) })}
-              style={CHART_FONT_STYLE.cursor}
-              isActive={isCursorActive}
-            />
-          </VictoryPortal>
-        }
+        cursorLabelComponent={wrapPortal(
+          <ChartCursorLabel
+            positionY={height - 10}
+            {...(hasExternalTheme
+              ? {}
+              : { fill: getThemeColor(METAC_COLORS.gray["700"]) })}
+            style={CHART_FONT_STYLE.cursor}
+            isActive={isCursorActive}
+          />,
+          isMobile
+        )}
         onCursorChange={(value: CursorCoordinatesPropType) => {
           if (typeof value === "number") {
             handleCursorChange(value);
@@ -320,6 +327,7 @@ const NumericChart: FC<Props> = ({
     isCursorEnabled,
     isCursorActive,
     isContinuousConsumerView,
+    isMobile,
   ]);
 
   const chartEvents = useMemo(() => {
@@ -736,20 +744,19 @@ const NumericChart: FC<Props> = ({
                         ? () => ""
                         : xScale.tickFormat
                   }
-                  tickLabelComponent={
-                    <VictoryPortal>
-                      <XTickLabel
-                        chartWidth={chartWidth}
-                        fontSize={tickLabelFontSize}
-                        {...(!extraTheme && {
-                          style: {
-                            ...CHART_FONT_STYLE.tick,
-                            fill: getThemeColor(METAC_COLORS.gray["700"]),
-                          },
-                        })}
-                      />
-                    </VictoryPortal>
-                  }
+                  tickLabelComponent={wrapPortal(
+                    <XTickLabel
+                      chartWidth={chartWidth}
+                      fontSize={tickLabelFontSize}
+                      {...(!extraTheme && {
+                        style: {
+                          ...CHART_FONT_STYLE.tick,
+                          fill: getThemeColor(METAC_COLORS.gray["700"]),
+                        },
+                      })}
+                    />,
+                    isMobile
+                  )}
                 />
 
                 {/* CP range */}
@@ -796,7 +803,7 @@ const NumericChart: FC<Props> = ({
                 ) : null}
 
                 {/* Prediction points */}
-                <VictoryPortal>
+                {wrapPortal(
                   <VictoryScatter
                     data={clampedPoints}
                     dataComponent={
@@ -804,56 +811,60 @@ const NumericChart: FC<Props> = ({
                         colorOverride={colorOverride ?? colorPalette.chip}
                       />
                     }
-                  />
-                </VictoryPortal>
+                  />,
+                  isMobile
+                )}
 
                 {/* Resolution marker */}
                 {!!resolutionPoint &&
                 !isCursorActive &&
-                resolutionPlacement === "in" ? (
-                  <VictoryPortal>
-                    <VictoryScatter
-                      data={resolutionPoint}
-                      size={() => 4}
-                      style={{
-                        data: {
-                          stroke: getThemeColor(METAC_COLORS.purple["800"]),
-                          fill: getThemeColor(METAC_COLORS.gray["0"]),
-                          strokeWidth: 2.5,
-                        },
-                      }}
-                    />
-                  </VictoryPortal>
-                ) : null}
+                resolutionPlacement === "in"
+                  ? wrapPortal(
+                      <VictoryScatter
+                        data={resolutionPoint}
+                        size={() => 4}
+                        style={{
+                          data: {
+                            stroke: getThemeColor(METAC_COLORS.purple["800"]),
+                            fill: getThemeColor(METAC_COLORS.gray["0"]),
+                            strokeWidth: 2.5,
+                          },
+                        }}
+                      />,
+                      isMobile
+                    )
+                  : null}
 
                 {/* Cursor value chip / box */}
                 {resolutionClamped &&
                 resolutionPlacement &&
-                resolutionPlacement !== "in" ? (
-                  <VictoryPortal>
-                    <VictoryScatter
-                      data={[
-                        {
-                          x: resolutionClamped.x,
-                          y: resolutionClamped.y,
-                          placement: resolutionPlacement,
-                          primary: colorOverride ?? METAC_COLORS.purple["800"],
-                          secondary: METAC_COLORS.purple["500"],
-                        },
-                      ]}
-                      dataComponent={
-                        <ResolutionDiamond
-                          isHovered={isDiamondActive}
-                          refProps={{
-                            ...getDiamondRefProps(),
-                            ref: diamondRefs.setReference,
-                            style: { pointerEvents: "visiblePainted" },
-                          }}
-                        />
-                      }
-                    />
-                  </VictoryPortal>
-                ) : null}
+                resolutionPlacement !== "in"
+                  ? wrapPortal(
+                      <VictoryScatter
+                        data={[
+                          {
+                            x: resolutionClamped.x,
+                            y: resolutionClamped.y,
+                            placement: resolutionPlacement,
+                            primary:
+                              colorOverride ?? METAC_COLORS.purple["800"],
+                            secondary: METAC_COLORS.purple["500"],
+                          },
+                        ]}
+                        dataComponent={
+                          <ResolutionDiamond
+                            isHovered={isDiamondActive}
+                            refProps={{
+                              ...getDiamondRefProps(),
+                              ref: diamondRefs.setReference,
+                              style: { pointerEvents: "visiblePainted" },
+                            }}
+                          />
+                        }
+                      />,
+                      isMobile
+                    )
+                  : null}
 
                 {isCursorActive &&
                 !isNil(highlightedPoint) &&
@@ -878,32 +889,31 @@ const NumericChart: FC<Props> = ({
                 !(hideCursorValueLabel && isCursorActive) ? (
                   <VictoryScatter
                     data={[highlightedPoint]}
-                    dataComponent={
-                      <VictoryPortal>
-                        {useSimplifiedCursor ? (
-                          <CursorChip
-                            shouldRender={
-                              (isCursorActive && !isNil(resolution)) ||
-                              isNil(resolution)
-                            }
-                            colorOverride={colorOverride ?? colorPalette.chip}
-                            isEmbedded={isEmbedded}
-                          />
-                        ) : (
-                          <ChartValueBox
-                            isCursorActive={
-                              shouldAdjustCursorLabel || isCursorActive
-                            }
-                            chartWidth={chartWidth}
-                            rightPadding={maxRightPadding}
-                            getCursorValue={getCursorValue}
-                            resolution={resolution}
-                            questionType={questionType}
-                            colorOverride={colorOverride ?? colorPalette.chip}
-                          />
-                        )}
-                      </VictoryPortal>
-                    }
+                    dataComponent={wrapPortal(
+                      useSimplifiedCursor ? (
+                        <CursorChip
+                          shouldRender={
+                            (isCursorActive && !isNil(resolution)) ||
+                            isNil(resolution)
+                          }
+                          colorOverride={colorOverride ?? colorPalette.chip}
+                          isEmbedded={isEmbedded}
+                        />
+                      ) : (
+                        <ChartValueBox
+                          isCursorActive={
+                            shouldAdjustCursorLabel || isCursorActive
+                          }
+                          chartWidth={chartWidth}
+                          rightPadding={maxRightPadding}
+                          getCursorValue={getCursorValue}
+                          resolution={resolution}
+                          questionType={questionType}
+                          colorOverride={colorOverride ?? colorPalette.chip}
+                        />
+                      ),
+                      isMobile
+                    )}
                   />
                 ) : null}
               </VictoryChart>

--- a/front_end/src/components/consumer_post_card/binary_cp_bar.tsx
+++ b/front_end/src/components/consumer_post_card/binary_cp_bar.tsx
@@ -97,7 +97,7 @@ const BinaryCPBar: FC<Props> = ({
           "scale-[0.5]": size === "xs",
           "scale-[0.85]": size === "sm",
           "scale-100": size === "md",
-          "mb-4 scale-[1.25]": size === "lg",
+          "scale-[1.25]": size === "lg",
         },
         isEmbed && "scale-100",
         className

--- a/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
@@ -212,6 +212,18 @@ const DetailedContinuousChartCard: FC<Props> = ({
 
   const isBinary = question.type === QuestionType.Binary;
 
+  const cursorUserForecastValues = useMemo<number[] | null>(() => {
+    if (!isContinuous || cursorTimestamp === null) return null;
+    const history = question.my_forecasts?.history;
+    if (!history?.length) return null;
+    const forecast = history.findLast(
+      (f) =>
+        f.start_time <= cursorTimestamp &&
+        (!f.end_time || f.end_time > cursorTimestamp)
+    );
+    return forecast?.forecast_values ?? null;
+  }, [isContinuous, cursorTimestamp, question.my_forecasts]);
+
   const activeForecast = useMemo<NumericAggregateForecast | null>(() => {
     if (
       isCpHidden ||
@@ -227,11 +239,27 @@ const DetailedContinuousChartCard: FC<Props> = ({
 
   const cursorCtx = useContinuousChartCursor();
   const setCursorForecast = cursorCtx?.setActiveForecast;
+  const setCursorUserForecast = cursorCtx?.setActiveUserForecastValues;
   useEffect(() => {
-    if (!isContinuousQuestion(question) || !setCursorForecast) return;
+    if (
+      !isContinuousQuestion(question) ||
+      !setCursorForecast ||
+      !setCursorUserForecast
+    )
+      return;
     setCursorForecast(activeForecast);
-    return () => setCursorForecast(null);
-  }, [activeForecast, setCursorForecast, question]);
+    setCursorUserForecast(cursorUserForecastValues);
+    return () => {
+      setCursorForecast(null);
+      setCursorUserForecast(null);
+    };
+  }, [
+    activeForecast,
+    cursorUserForecastValues,
+    setCursorForecast,
+    setCursorUserForecast,
+    question,
+  ]);
 
   const handleCursorChange = useCallback((value: number | null) => {
     setCursorTimestamp(value);
@@ -356,6 +384,7 @@ const DetailedContinuousChartCard: FC<Props> = ({
       colorOverride={cpColorOverride}
       chartTheme={extraTheme}
       cursorForecast={activeForecast}
+      cursorUserForecastValues={cursorUserForecastValues}
     />
   );
 
@@ -462,6 +491,7 @@ const DetailedContinuousChartCard: FC<Props> = ({
                 size="lg"
                 hideLabel={true}
                 cursorForecast={activeForecast}
+                cursorUserForecastValues={cursorUserForecastValues}
               />
             )}
 

--- a/front_end/src/components/forecast_maker/index.tsx
+++ b/front_end/src/components/forecast_maker/index.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { FC } from "react";
+import { FC, ReactNode } from "react";
 
 import PredictionStatusMessage from "@/components/forecast_maker/prediction_status_message";
+import MarkdownEditor from "@/components/markdown_editor";
+import SectionToggle from "@/components/ui/section_toggle";
 import { useAuth } from "@/contexts/auth_context";
+import { usePostTextSections } from "@/hooks/use_post_text_sections";
 import { PostWithForecasts } from "@/types/post";
 import {
   canPredictQuestion,
@@ -23,6 +26,7 @@ type Props = {
 const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
   const t = useTranslations();
   const { user } = useAuth();
+  const sections = usePostTextSections(post, { excludeFinePrint: true });
 
   const { group_of_questions: groupOfQuestions, conditional, question } = post;
   const canPredict = canPredictQuestion(post, user);
@@ -31,8 +35,23 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
 
   const predictionMessage = <PredictionStatusMessage post={post} />;
 
+  const infoDrawers = sections.length ? (
+    <div className="flex flex-col gap-2">
+      {sections.map((section) => (
+        <SectionToggle
+          key={section.title}
+          title={section.title}
+          variant="light"
+        >
+          <MarkdownEditor withCodeBlocks markdown={section.markdown} />
+        </SectionToggle>
+      ))}
+    </div>
+  ) : null;
+
+  let content: ReactNode = null;
   if (groupOfQuestions) {
-    return (
+    content = (
       <ForecastMakerGroup
         post={post}
         questions={groupOfQuestions.questions}
@@ -43,10 +62,8 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
         onPredictionSubmit={onPredictionSubmit}
       />
     );
-  }
-
-  if (conditional) {
-    return (
+  } else if (conditional) {
+    content = (
       <ForecastMakerConditional
         post={post}
         conditional={conditional}
@@ -56,10 +73,8 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
         onPredictionSubmit={onPredictionSubmit}
       />
     );
-  }
-
-  if (question) {
-    return (
+  } else if (question) {
+    content = (
       <QuestionForecastMaker
         question={question}
         canPredict={canPredict}
@@ -71,7 +86,14 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
     );
   }
 
-  return null;
+  if (!content) return null;
+
+  return (
+    <>
+      {content}
+      {infoDrawers}
+    </>
+  );
 };
 
 export default ForecastMaker;

--- a/front_end/src/components/forecast_maker/index.tsx
+++ b/front_end/src/components/forecast_maker/index.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { FC, ReactNode } from "react";
+import { FC } from "react";
 
 import PredictionStatusMessage from "@/components/forecast_maker/prediction_status_message";
-import MarkdownEditor from "@/components/markdown_editor";
-import SectionToggle from "@/components/ui/section_toggle";
 import { useAuth } from "@/contexts/auth_context";
-import { usePostTextSections } from "@/hooks/use_post_text_sections";
 import { PostWithForecasts } from "@/types/post";
 import {
   canPredictQuestion,
@@ -26,7 +23,6 @@ type Props = {
 const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
   const t = useTranslations();
   const { user } = useAuth();
-  const sections = usePostTextSections(post, { excludeFinePrint: true });
 
   const { group_of_questions: groupOfQuestions, conditional, question } = post;
   const canPredict = canPredictQuestion(post, user);
@@ -35,23 +31,8 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
 
   const predictionMessage = <PredictionStatusMessage post={post} />;
 
-  const infoDrawers = sections.length ? (
-    <div className="flex flex-col gap-2">
-      {sections.map((section) => (
-        <SectionToggle
-          key={section.title}
-          title={section.title}
-          variant="light"
-        >
-          <MarkdownEditor withCodeBlocks markdown={section.markdown} />
-        </SectionToggle>
-      ))}
-    </div>
-  ) : null;
-
-  let content: ReactNode = null;
   if (groupOfQuestions) {
-    content = (
+    return (
       <ForecastMakerGroup
         post={post}
         questions={groupOfQuestions.questions}
@@ -62,8 +43,10 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
         onPredictionSubmit={onPredictionSubmit}
       />
     );
-  } else if (conditional) {
-    content = (
+  }
+
+  if (conditional) {
+    return (
       <ForecastMakerConditional
         post={post}
         conditional={conditional}
@@ -73,8 +56,10 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
         onPredictionSubmit={onPredictionSubmit}
       />
     );
-  } else if (question) {
-    content = (
+  }
+
+  if (question) {
+    return (
       <QuestionForecastMaker
         question={question}
         canPredict={canPredict}
@@ -86,14 +71,7 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
     );
   }
 
-  if (!content) return null;
-
-  return (
-    <>
-      {content}
-      {infoDrawers}
-    </>
-  );
+  return null;
 };
 
 export default ForecastMaker;

--- a/front_end/src/contexts/continuous_chart_cursor_context.tsx
+++ b/front_end/src/contexts/continuous_chart_cursor_context.tsx
@@ -15,6 +15,8 @@ import { NumericAggregateForecast } from "@/types/question";
 type CursorContextValue = {
   activeForecast: NumericAggregateForecast | null;
   setActiveForecast: (f: NumericAggregateForecast | null) => void;
+  activeUserForecastValues: number[] | null;
+  setActiveUserForecastValues: (v: number[] | null) => void;
 };
 
 const ContinuousChartCursorContext = createContext<CursorContextValue | null>(
@@ -26,13 +28,27 @@ export const ContinuousChartCursorProvider: FC<{ children: ReactNode }> = ({
 }) => {
   const [activeForecast, setActiveForecast] =
     useState<NumericAggregateForecast | null>(null);
+  const [activeUserForecastValues, setActiveUserForecastValues] = useState<
+    number[] | null
+  >(null);
+
   const stableSet = useCallback(
     (f: NumericAggregateForecast | null) => setActiveForecast(f),
     []
   );
+  const stableSetUser = useCallback(
+    (v: number[] | null) => setActiveUserForecastValues(v),
+    []
+  );
+
   const value = useMemo(
-    () => ({ activeForecast, setActiveForecast: stableSet }),
-    [activeForecast, stableSet]
+    () => ({
+      activeForecast,
+      setActiveForecast: stableSet,
+      activeUserForecastValues,
+      setActiveUserForecastValues: stableSetUser,
+    }),
+    [activeForecast, stableSet, activeUserForecastValues, stableSetUser]
   );
   return (
     <ContinuousChartCursorContext.Provider value={value}>

--- a/front_end/src/hooks/use_post_text_sections.ts
+++ b/front_end/src/hooks/use_post_text_sections.ts
@@ -1,0 +1,63 @@
+import { useTranslations } from "next-intl";
+
+import { PostWithForecasts } from "@/types/post";
+
+export type PostTextSection = { title: string; markdown: string };
+
+export function usePostTextSections(
+  post: PostWithForecasts,
+  { excludeFinePrint = false } = {}
+): PostTextSection[] {
+  const t = useTranslations();
+
+  if (post.conditional) {
+    const { condition, condition_child } = post.conditional;
+    const sections: PostTextSection[] = [];
+    if (condition.resolution_criteria)
+      sections.push({
+        title: t("parentResolutionCriteria"),
+        markdown: condition.resolution_criteria,
+      });
+    if (!excludeFinePrint && condition.fine_print)
+      sections.push({ title: t("finePrint"), markdown: condition.fine_print });
+    if (condition.description)
+      sections.push({
+        title: t("parentBackgroundInfo"),
+        markdown: condition.description,
+      });
+    if (condition_child.resolution_criteria)
+      sections.push({
+        title: t("childResolutionCriteria"),
+        markdown: condition_child.resolution_criteria,
+      });
+    if (!excludeFinePrint && condition_child.fine_print)
+      sections.push({
+        title: t("finePrint"),
+        markdown: condition_child.fine_print,
+      });
+    if (condition_child.description)
+      sections.push({
+        title: t("childBackgroundInfo"),
+        markdown: condition_child.description,
+      });
+    return sections;
+  }
+
+  const resolution =
+    post.group_of_questions?.resolution_criteria ??
+    post.question?.resolution_criteria ??
+    "";
+  const finePrint =
+    post.group_of_questions?.fine_print ?? post.question?.fine_print ?? "";
+  const description =
+    post.group_of_questions?.description ?? post.question?.description ?? "";
+
+  const sections: PostTextSection[] = [];
+  if (resolution)
+    sections.push({ title: t("resolutionCriteria"), markdown: resolution });
+  if (!excludeFinePrint && finePrint)
+    sections.push({ title: t("finePrint"), markdown: finePrint });
+  if (description)
+    sections.push({ title: t("backgroundInfo"), markdown: description });
+  return sections;
+}


### PR DESCRIPTION
### Summary

This PR overlays the user's prediction on the timeline cursor distribution chart, fixes a mobile touch crash loop, and fixes the movement badge overlapping the binary gauge.

**Implemented:**

- **User prediction overlay** (`QuestionHeaderCPStatus`): mini distribution chart now shows user forecast in orange alongside community distribution on timeline hover, for both desktop side panel and mobile title-row mini chart
- **Cursor context extension** (`ContinuousChartCursorContext`): context now carries active user forecast values alongside community forecast, looked up via `findLast` over forecast history; mobile reads from context to stay in sync with desktop
- **Mobile touch infinite loop fix** (`numeric_chart`): `wrapPortal` helper skips `VictoryPortal` on touch devices, breaking the `addChild → setState` re-render cycle triggered by each touch-move producing a new JSX reference
- **Movement badge overlap fix** (`binary_cp_bar`): removed extra bottom margin on the large gauge variant that caused the movement chip to overlap the scaled-up arc
- **Info drawers** (`forecast_maker/index.tsx`): renders collapsible `SectionToggle` drawers below the prediction form using existing `SectionToggle` + `MarkdownEditor` components; handles all question types
- **Shared hook** (`use_post_text_sections.ts`): extracted section-building logic from `question_info.tsx` into a reusable hook; both the Question Info tab and the forecast maker now share one source of truth

### Demo videos

- Movement badge 

https://github.com/user-attachments/assets/862f2a2f-ae81-4c4d-a2da-879166278b52

- Mini distribution chart shows user forecast

https://github.com/user-attachments/assets/465d155c-4634-43aa-aa5e-69d50a5660d1

- Mobile touch infinite loop fix

https://github.com/user-attachments/assets/ce4302bf-13c2-467a-a895-bfbb95d092dd

- Resolution Criteria and Background Info drawers underneath prediction input for Forecaster View

https://github.com/user-attachments/assets/5259ece1-7084-4a0e-98dd-45e37a2ff4ca

