### PR TITLE
safeguard community-prediction endpoint return from failing on Nones

### DIFF
--- a/questions/views.py
+++ b/questions/views.py
@@ -309,7 +309,7 @@ def questions_community_predictions(request) -> Response:
         if agg:
             pmf = agg.get_pmf()
             pmf = [
-                v if not np.isnan(v) else None for v in pmf
+                None if (v is None or np.isnan(v)) else v for v in pmf
             ]  # Convert NaNs to None for JSON serialization
             results.append(
                 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a data serialization issue in community predictions where null and missing values were not being handled correctly in aggregated data. This improves data integrity and ensures consistency when storing, transmitting, and displaying aggregated predictions through the API, preventing formatting issues that could impact prediction accuracy and reliability across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->