### PR TITLE
Fix react-tweet null/undefined entities

### DIFF
--- a/front_end/src/app/(api)/tweet/[id]/route.ts
+++ b/front_end/src/app/(api)/tweet/[id]/route.ts
@@ -1,8 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
+import type { TweetEntities } from "react-tweet/api";
 import { fetchTweet } from "react-tweet/api";
 
 const CACHE_MAX_AGE = 86400; // 24 hours
 const CACHE_STALE_WHILE_REVALIDATE = 604800; // 7 days
+
+// In some cases, the Twitter API omits entity arrays instead of returning [] for empty ones
+// react-tweet iterates them without a guard, so patch before sending to client.
+function fixEntities(entities: Partial<TweetEntities> | undefined) {
+  if (!entities) return;
+  entities.hashtags ??= [];
+  entities.urls ??= [];
+  entities.user_mentions ??= [];
+  entities.symbols ??= [];
+}
 
 export async function GET(
   _request: NextRequest,
@@ -20,6 +31,11 @@ export async function GET(
 
     if (result.notFound || result.tombstone) {
       return NextResponse.json({ data: null }, { status: 404 });
+    }
+
+    if (result.data) {
+      fixEntities(result.data.entities);
+      fixEntities(result.data.quoted_tweet?.entities);
     }
 
     return NextResponse.json(


### PR DESCRIPTION
### Summary

Fix a crash on question pages that embed tweets where the Twitter API omits entity arrays from the response.

https://metaculus.sentry.io/issues/7497830045/?alert_rule_id=16645909&alert_type=issue&environment=prod&project=4507883273125888

Implemented:

- **Root cause** (`/tweet/[id]/route.ts`): the Twitter API sometimes returns tweet `entities` objects without `hashtags`, `urls`, `user_mentions`, or `symbols` keys at all (rather than empty arrays); `react-tweet`'s `addEntities` iterates these fields unconditionally with `for...of`, throwing `TypeError: entities is not iterable` on `undefined`
- **Fix** (`fixEntities`): patches the four unguarded fields to `[]` in-place before the response is sent to the client; `media` is excluded as the library already guards it with an `if` check; also applied to `quoted_tweet.entities` for the same reason

### Demo video

https://github.com/user-attachments/assets/9385b3b9-f0af-44ec-8a7d-3b639c5ed598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where tweet entity arrays (hashtags, URLs, user mentions, symbols) could be missing or undefined when retrieving individual tweet details, preventing potential downstream processing errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->