### PR TITLE
Fix tweet api cache bust

### DIFF
--- a/front_end/src/components/markdown_editor/embedded_twitter/index.tsx
+++ b/front_end/src/components/markdown_editor/embedded_twitter/index.tsx
@@ -9,7 +9,7 @@ const TweetEmbed: React.FC<{ id: string }> = ({ id }) => {
   return (
     <div className="tweet-embed" data-embed="tweet">
       <div className="tweet-embed-scroll">
-        <Tweet id={id} apiUrl={`/tweet/${id}`} />
+        <Tweet id={id} apiUrl={`/tweet/${id}?v=2`} />
       </div>
     </div>
   );


### PR DESCRIPTION
### Summary

Follow-up to #4766 

Force browsers to re-fetch tweet data after the entity-patching fix by busting the cached API URL.

Implemented:

- **Problem**: browsers had already cached `/tweet/{id}` responses (up to 24h `max-age` + 7-day `stale-while-revalidate`) containing the broken entity data from before the fix
- **Fix** (`apiUrl` in `embedded_twitter/index.tsx`): appended `?v=2` to the tweet API URL so all requests go to a new cache key, bypassing any stale cached responses from before the entity patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Twitter embed API integration to use the latest endpoint version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->