### PR TITLE
Mailgun sender domain partial rollout

### DIFF
--- a/authentication/services.py
+++ b/authentication/services.py
@@ -8,7 +8,7 @@ from rest_framework_simplejwt.exceptions import AuthenticationFailed
 
 from authentication.jwt_session import SessionRefreshToken
 from users.models import User
-from utils.email import send_email_with_template
+from utils.email import send_account_email_with_template
 from utils.frontend import (
     build_frontend_account_activation_url,
     build_frontend_password_reset_url,
@@ -34,7 +34,7 @@ def generate_password_reset_link(user: User) -> str:
 def send_activation_email(user: User, redirect_url: str | None):
     activation_link = generate_account_activation_link(user, redirect_url)
 
-    send_email_with_template(
+    send_account_email_with_template(
         user.email,
         "Activate Your Metaculus Account",
         "emails/activation_email.html",
@@ -45,14 +45,13 @@ def send_activation_email(user: User, redirect_url: str | None):
             "redirect_url": redirect_url,
             "public_app_url": settings.PUBLIC_APP_URL,
         },
-        from_email=settings.EMAIL_HOST_USER,
     )
 
 
 def send_password_reset_email(user: User):
     reset_link = generate_password_reset_link(user)
 
-    send_email_with_template(
+    send_account_email_with_template(
         user.email,
         "Metaculus Password Reset Request",
         "emails/password_reset.html",
@@ -60,7 +59,6 @@ def send_password_reset_email(user: User):
             "username": user.username,
             "reset_link": reset_link,
         },
-        from_email=settings.EMAIL_HOST_USER,
     )
 
 
@@ -127,7 +125,7 @@ class SignupInviteService:
         invite_token = self._generate_token(email)
         signup_link = build_frontend_account_signup_invitation_url(email, invite_token)
 
-        send_email_with_template(
+        send_account_email_with_template(
             email,
             "Metaculus Signup Invitation",
             "emails/signup_invite.html",
@@ -137,7 +135,6 @@ class SignupInviteService:
                 "invited_by": invited_by.username,
                 "app_name": get_frontend_host(),
             },
-            from_email=settings.EMAIL_HOST_USER,
         )
 
 

--- a/comments/services/notifications.py
+++ b/comments/services/notifications.py
@@ -8,10 +8,9 @@ from notifications.constants import MailingTags
 from notifications.services import send_comment_mention_notification
 from notifications.utils import generate_email_comment_preview_text
 from users.models import User
-from utils.email import send_email_with_template
+from utils.email import send_notification_email_with_template
 from utils.frontend import build_frontend_url, build_post_url
 from ..utils import comment_extract_user_mentions, get_mention_for_user
-from django.conf import settings
 
 
 def notify_mentioned_users(comment: Comment):
@@ -84,7 +83,7 @@ def notify_weekly_top_comments_subscribers(
         if not emails_batch:
             break
 
-        send_email_with_template(
+        send_notification_email_with_template(
             to=emails_batch,
             subject="Last week’s top Metaculus comments",
             template_name="emails/weekly_top_comments.html",
@@ -94,6 +93,5 @@ def notify_weekly_top_comments_subscribers(
                 "other_usernames": other_usernames,
             },
             use_async=False,
-            from_email=settings.EMAIL_NOTIFICATIONS_USER,
         )
         start += batch_size

--- a/metaculus_web/settings.py
+++ b/metaculus_web/settings.py
@@ -305,10 +305,6 @@ EMAIL_ACCOUNTS_SENDER = os.environ.get(
     "EMAIL_ACCOUNTS_SENDER",
     f"Metaculus Accounts <accounts@{MAILGUN_DOMAIN}>",
 )
-# TODO: deprecate as well
-EMAIL_SENDER_NO_REPLY = os.environ.get(
-    "EMAIL_SENDER_NO_REPLY", f"Metaculus NoReply <no-reply@{MAILGUN_DOMAIN}>"
-)
 EMAIL_FEEDBACK = os.environ.get("EMAIL_FEEDBACK", "feedback@metaculus.com")
 EMAIL_SUPPORT = os.environ.get("EMAIL_SUPPORT", "support@metaculus.com")
 # TODO: reconsider after release

--- a/metaculus_web/settings.py
+++ b/metaculus_web/settings.py
@@ -286,10 +286,26 @@ EMAIL_BACKEND = os.environ.get("EMAIL_BACKEND", "anymail.backends.mailgun.EmailB
 EMAIL_HOST_USER = os.environ.get(
     "EMAIL_HOST_USER", f"Metaculus Accounts <accounts@{MAILGUN_DOMAIN}>"
 )
+# TODO: deprecate after 100% rollout
+# Legacy notification sender. Deprecated: kept as the warm-up "from" side and a
+# fallback while the notification stream migrates to EMAIL_NOTIFICATIONS_SENDER;
+# remove once that migration completes.
 EMAIL_NOTIFICATIONS_USER = os.environ.get(
     "EMAIL_NOTIFICATIONS_USER",
     f"Metaculus Notifications <notifications@{MAILGUN_DOMAIN}>",
 )
+# Active per-stream senders. Defaults stay on MAILGUN_DOMAIN so standalone
+# instances are unaffected; point these at dedicated domains in production to
+# drive the sending-domain warm-up (the ramp lives in utils/email.py).
+EMAIL_NOTIFICATIONS_SENDER = os.environ.get(
+    "EMAIL_NOTIFICATIONS_SENDER",
+    f"Metaculus Notifications <notifications@{MAILGUN_DOMAIN}>",
+)
+EMAIL_ACCOUNTS_SENDER = os.environ.get(
+    "EMAIL_ACCOUNTS_SENDER",
+    f"Metaculus Accounts <accounts@{MAILGUN_DOMAIN}>",
+)
+# TODO: deprecate as well
 EMAIL_SENDER_NO_REPLY = os.environ.get(
     "EMAIL_SENDER_NO_REPLY", f"Metaculus NoReply <no-reply@{MAILGUN_DOMAIN}>"
 )

--- a/misc/views.py
+++ b/misc/views.py
@@ -34,7 +34,7 @@ def contact_api_view(request: Request):
     EmailMessage(
         subject=serializer.data["subject"] or "Contact Form",
         body=serializer.data["message"],
-        from_email=settings.EMAIL_SENDER_NO_REPLY,
+        from_email=settings.EMAIL_ACCOUNTS_SENDER,
         to=[settings.EMAIL_FEEDBACK],
         reply_to=[serializer.data["email"]],
     ).send()
@@ -57,7 +57,7 @@ def contact_service_api_view(request: Request):
             f"Interested in: {serializer.data.get('service')}\n"
             f"Message: {serializer.data.get('message')}\n"
         ),
-        from_email=settings.EMAIL_SENDER_NO_REPLY,
+        from_email=settings.EMAIL_ACCOUNTS_SENDER,
         to=[settings.EMAIL_SUPPORT],
         reply_to=[serializer.data["email"]],
     ).send()

--- a/notifications/services.py
+++ b/notifications/services.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, asdict
 from datetime import datetime, timezone as dt_timezone, timedelta
 
 from dateutil.parser import parse as date_parse
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from comments.constants import CommentReportType
@@ -21,7 +20,7 @@ from projects.permissions import ObjectPermission
 from questions.models import Question, UserForecastNotification
 from users.models import User
 from utils.dtypes import dataclass_from_dict
-from utils.email import send_email_with_template
+from utils.email import send_notification_email_with_template
 from utils.formatters import abbreviated_number, format_value_unit
 from utils.frontend import build_post_comment_url, build_post_url, build_news_url
 
@@ -265,13 +264,12 @@ class NotificationTypeBase:
         recipient = notifications[0].recipient
         context = cls.get_email_context_group(notifications)
 
-        return send_email_with_template(
+        return send_notification_email_with_template(
             recipient.email,
             cls.generate_subject_group(recipient),
             cls.email_template,
             context=context,
             use_async=False,
-            from_email=settings.EMAIL_NOTIFICATIONS_USER,
         )
 
 
@@ -727,7 +725,7 @@ def send_comment_mention_notification(recipient, comment: Comment, mention: str)
         comment.text, mention, max_chars=1024
     )[0]
 
-    return send_email_with_template(
+    return send_notification_email_with_template(
         recipient.email,
         _(
             f"{comment.author.username} mentioned {mention_label} on “{comment.on_post.title}”"
@@ -748,7 +746,6 @@ def send_comment_mention_notification(recipient, comment: Comment, mention: str)
             },
         },
         use_async=False,
-        from_email=settings.EMAIL_NOTIFICATIONS_USER,
     )
 
 
@@ -759,7 +756,7 @@ def send_comment_report_notification_to_staff(
         ObjectPermission.CURATOR
     )
 
-    return send_email_with_template(
+    return send_notification_email_with_template(
         [x.email for x in recipients],
         _(
             f"Comment report: {comment.author.username} - "
@@ -781,7 +778,6 @@ def send_comment_report_notification_to_staff(
                 "reason": reason,
             },
         },
-        from_email=settings.EMAIL_NOTIFICATIONS_USER,
     )
 
 
@@ -793,7 +789,7 @@ def send_key_factor_report_notification_to_staff(
 
     recipients = post.default_project.get_users_for_permission(ObjectPermission.CURATOR)
 
-    return send_email_with_template(
+    return send_notification_email_with_template(
         [x.email for x in recipients],
         _(
             f"Key Factor report: {comment.author.username} - "
@@ -812,7 +808,6 @@ def send_key_factor_report_notification_to_staff(
                 "reason": reason,
             },
         },
-        from_email=settings.EMAIL_NOTIFICATIONS_USER,
     )
 
 
@@ -821,7 +816,7 @@ def send_forecast_autowidrawal_notification(
     posts_data: list[dict],
     account_settings_url: str,
 ):
-    send_email_with_template(
+    send_notification_email_with_template(
         to=user.email,
         subject=_(
             f"{len(posts_data)} of your predictions will auto-withdraw soon unless updated"
@@ -835,7 +830,6 @@ def send_forecast_autowidrawal_notification(
             "number_of_posts": len(posts_data),
         },
         use_async=False,
-        from_email=settings.EMAIL_NOTIFICATIONS_USER,
     )
 
     return True
@@ -848,7 +842,7 @@ def send_weekly_top_comments_notification(
     other_usernames: str,
     account_settings_url: str,
 ):
-    send_email_with_template(
+    send_notification_email_with_template(
         to=recipients,
         subject=_("Last week’s top Metaculus comments"),
         template_name="emails/weekly_top_comments.html",
@@ -876,7 +870,7 @@ def send_news_category_notebook_publish_notification(user: User, post: Post):
         post.notebook.markdown, max_words=100
     )
 
-    return send_email_with_template(
+    return send_notification_email_with_template(
         to=user.email,
         subject=f"[Metaculus News] {post.title}",
         template_name="emails/subscribed_news_notebook_published.html",
@@ -891,7 +885,6 @@ def send_news_category_notebook_publish_notification(user: User, post: Post):
             },
         },
         use_async=False,
-        from_email=settings.EMAIL_NOTIFICATIONS_USER,
     )
 
 

--- a/questions/tasks.py
+++ b/questions/tasks.py
@@ -2,7 +2,6 @@ import logging
 from datetime import datetime, timedelta, timezone as dt_timezone
 
 import dramatiq
-from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone
 
@@ -27,7 +26,7 @@ from scoring.constants import ScoreTypes
 from scoring.utils import score_question
 from users.models import User
 from utils.dramatiq import concurrency_retries, task_concurrent_limit
-from utils.email import send_email_with_template
+from utils.email import send_notification_email_with_template
 from utils.frontend import build_frontend_account_settings_url, build_post_url
 
 
@@ -322,7 +321,7 @@ def multiple_choice_delete_option_notifications(
         .order_by("id")
     )
     # send out an immediate email
-    send_email_with_template(
+    send_notification_email_with_template(
         to=[forecaster.email for forecaster in forecasters],
         subject=f"Multiple choice option{'s' if len(removed_options) > 1 else ''} "
         f"removed for {post.title}",
@@ -339,7 +338,6 @@ def multiple_choice_delete_option_notifications(
             },
         },
         use_async=False,
-        from_email=settings.EMAIL_NOTIFICATIONS_USER,
     )
 
 
@@ -420,7 +418,7 @@ def multiple_choice_add_option_notifications(
         .order_by("id")
     )
     # send out an immediate email
-    send_email_with_template(
+    send_notification_email_with_template(
         to=[forecaster.email for forecaster in forecasters],
         subject=f"Multiple choice option{'s' if len(added_options) > 1 else ''} "
         f"added for {post.title}",
@@ -437,7 +435,6 @@ def multiple_choice_add_option_notifications(
             },
         },
         use_async=False,
-        from_email=settings.EMAIL_NOTIFICATIONS_USER,
     )
 
     # schedule a followup email for 1 day before grace period

--- a/tests/unit/test_comments/test_services.py
+++ b/tests/unit/test_comments/test_services.py
@@ -116,7 +116,7 @@ def test_notify_mentioned_users(
     factory_forecast(author=user_forecaster, question=question_binary)
 
     mock_send_email_with_template = mocker.patch(
-        "notifications.services.send_email_with_template"
+        "notifications.services.send_notification_email_with_template"
     )
 
     notify_mentioned_users(

--- a/users/services/common.py
+++ b/users/services/common.py
@@ -28,7 +28,7 @@ from projects.permissions import ObjectPermission
 from users.models import User, UserCampaignRegistration
 from users.serializers import UserPrivateSerializer
 from utils.cache import cached_singleton
-from utils.email import send_email_with_template
+from utils.email import send_account_email_with_template
 from utils.frontend import build_frontend_email_change_url
 
 
@@ -271,7 +271,7 @@ def send_email_change_confirmation_email(user: User, new_email: str):
     confirmation_token = generate_email_change_token(user, new_email)
     reset_link = build_frontend_email_change_url(confirmation_token)
 
-    send_email_with_template(
+    send_account_email_with_template(
         user.email,
         "Metaculus Account Email Change",
         "emails/change_email_confirm.html",
@@ -280,7 +280,6 @@ def send_email_change_confirmation_email(user: User, new_email: str):
             "new_email": new_email,
             "reset_link": reset_link,
         },
-        from_email=settings.EMAIL_HOST_USER,
     )
 
 

--- a/users/services/spam_detection.py
+++ b/users/services/spam_detection.py
@@ -13,7 +13,7 @@ from misc.tasks import send_email_async
 from posts.models import Post
 from users.models import User, UserSpamActivity
 from users.serializers import UserUpdateProfileSerializer
-from utils.email import send_email_with_template
+from utils.email import send_notification_email_with_template
 from utils.openai import generate_text_async, run_spam_analysis
 
 logger = logging.getLogger(__name__)
@@ -253,7 +253,7 @@ def send_suspected_spam_to_admins_email(
     content_url: str,
     content_text: str,
 ) -> None:
-    send_email_with_template(
+    send_notification_email_with_template(
         to_emails,
         f"Suspected spam {content_type} from user {author.username}",
         "emails/suspected_spam_to_admins.html",
@@ -263,7 +263,6 @@ def send_suspected_spam_to_admins_email(
             "content_url": content_url,
             "content_text": content_text,
         },
-        from_email=settings.EMAIL_NOTIFICATIONS_USER,
     )
 
 
@@ -274,7 +273,7 @@ def send_repeated_spam_to_admins_email(
     content_url: str,
     content_text: str,
 ) -> None:
-    send_email_with_template(
+    send_notification_email_with_template(
         to_emails,
         f"Repeated spam {content_type} from user {author.username}",
         "emails/repeated_spam_to_admins.html",
@@ -284,5 +283,4 @@ def send_repeated_spam_to_admins_email(
             "content_url": content_url,
             "content_text": content_text,
         },
-        from_email=settings.EMAIL_NOTIFICATIONS_USER,
     )

--- a/utils/email.py
+++ b/utils/email.py
@@ -16,8 +16,7 @@ NOTIFICATIONS_DOMAIN_RAMP_PCT = 10
 ACCOUNTS_DOMAIN_RAMP_PCT = 0
 # @metaculus.com staff dogfood the new domain at these splits, independent of
 # the public ramp above, so the team sees the new domain early.
-NOTIFICATIONS_INTERNAL_RAMP_PCT = 50
-ACCOUNTS_INTERNAL_RAMP_PCT = 0
+INTERNAL_RAMP_PCT = 50
 
 
 def resolve_warmup_sender(
@@ -26,7 +25,6 @@ def resolve_warmup_sender(
     legacy_sender: str,
     new_sender: str,
     ramp_pct: int,
-    internal_ramp_pct: int,
 ) -> str:
     """
     Picks a stream's "From" address for a recipient during a sending-domain
@@ -36,7 +34,7 @@ def resolve_warmup_sender(
     domain independently of the public ramp.
     """
     recipient = recipient.strip().lower()
-    pct = internal_ramp_pct if recipient.endswith("@metaculus.com") else ramp_pct
+    pct = INTERNAL_RAMP_PCT if recipient.endswith("@metaculus.com") else ramp_pct
 
     digest = hashlib.md5(f"notifications-warmup:{recipient}".encode()).hexdigest()
     bucket = int(digest, 16) % 100
@@ -50,7 +48,6 @@ def resolve_notification_sender(recipient: str) -> str:
         legacy_sender=settings.EMAIL_NOTIFICATIONS_USER,
         new_sender=settings.EMAIL_NOTIFICATIONS_SENDER,
         ramp_pct=NOTIFICATIONS_DOMAIN_RAMP_PCT,
-        internal_ramp_pct=NOTIFICATIONS_INTERNAL_RAMP_PCT,
     )
 
 
@@ -60,7 +57,6 @@ def resolve_account_sender(recipient: str) -> str:
         legacy_sender=settings.EMAIL_HOST_USER,
         new_sender=settings.EMAIL_ACCOUNTS_SENDER,
         ramp_pct=ACCOUNTS_DOMAIN_RAMP_PCT,
-        internal_ramp_pct=ACCOUNTS_INTERNAL_RAMP_PCT,
     )
 
 

--- a/utils/email.py
+++ b/utils/email.py
@@ -1,4 +1,6 @@
+import hashlib
 import logging
+from collections import defaultdict
 
 from django.conf import settings
 from django.template.loader import render_to_string
@@ -7,6 +9,59 @@ from django.utils.html import strip_tags
 from misc.tasks import send_email_async
 
 logger = logging.getLogger(__name__)
+
+# Sending-domain warm-up ramp, per stream: the percentage (0-100) of recipients
+# routed to the new domain. Advance the warm-up by bumping these in code.
+NOTIFICATIONS_DOMAIN_RAMP_PCT = 10
+ACCOUNTS_DOMAIN_RAMP_PCT = 0
+# @metaculus.com staff dogfood the new domain at these splits, independent of
+# the public ramp above, so the team sees the new domain early.
+NOTIFICATIONS_INTERNAL_RAMP_PCT = 50
+ACCOUNTS_INTERNAL_RAMP_PCT = 0
+
+
+def resolve_warmup_sender(
+    recipient: str,
+    *,
+    legacy_sender: str,
+    new_sender: str,
+    ramp_pct: int,
+    internal_ramp_pct: int,
+) -> str:
+    """
+    Picks a stream's "From" address for a recipient during a sending-domain
+    warm-up, shifting traffic onto new_sender as ramp_pct grows. A recipient's
+    bucket is stable, so the assignment never flip-flops. Internal
+    @metaculus.com addresses use internal_ramp_pct so staff can dogfood the new
+    domain independently of the public ramp.
+    """
+    recipient = recipient.strip().lower()
+    pct = internal_ramp_pct if recipient.endswith("@metaculus.com") else ramp_pct
+
+    digest = hashlib.md5(f"notifications-warmup:{recipient}".encode()).hexdigest()
+    bucket = int(digest, 16) % 100
+
+    return new_sender if bucket < pct else legacy_sender
+
+
+def resolve_notification_sender(recipient: str) -> str:
+    return resolve_warmup_sender(
+        recipient,
+        legacy_sender=settings.EMAIL_NOTIFICATIONS_USER,
+        new_sender=settings.EMAIL_NOTIFICATIONS_SENDER,
+        ramp_pct=NOTIFICATIONS_DOMAIN_RAMP_PCT,
+        internal_ramp_pct=NOTIFICATIONS_INTERNAL_RAMP_PCT,
+    )
+
+
+def resolve_account_sender(recipient: str) -> str:
+    return resolve_warmup_sender(
+        recipient,
+        legacy_sender=settings.EMAIL_HOST_USER,
+        new_sender=settings.EMAIL_ACCOUNTS_SENDER,
+        ramp_pct=ACCOUNTS_DOMAIN_RAMP_PCT,
+        internal_ramp_pct=ACCOUNTS_INTERNAL_RAMP_PCT,
+    )
 
 
 def send_email_with_template(
@@ -44,3 +99,52 @@ def send_email_with_template(
             send_email_async(**kwargs)
         except Exception:
             logger.exception("Failed to send email")
+
+
+def _send_stream_email(to, subject, template_name, context, use_async, resolver):
+    """
+    Sends a stream email, routing each recipient to its warm-up sending domain
+    via `resolver`. Recipients are grouped by resolved sender so a single call
+    spanning both domains still produces correctly-attributed messages.
+    """
+    to = [to] if isinstance(to, str) else list(to)
+
+    by_sender: dict[str, list[str]] = defaultdict(list)
+    for recipient in to:
+        by_sender[resolver(recipient)].append(recipient)
+
+    for sender, recipients in by_sender.items():
+        send_email_with_template(
+            recipients,
+            subject,
+            template_name,
+            context=context,
+            use_async=use_async,
+            from_email=sender,
+        )
+
+
+def send_notification_email_with_template(
+    to: list[str] | str,
+    subject: str,
+    template_name: str,
+    context: dict = None,
+    use_async: bool = True,
+):
+    """Sends a notification-stream email."""
+    _send_stream_email(
+        to, subject, template_name, context, use_async, resolve_notification_sender
+    )
+
+
+def send_account_email_with_template(
+    to: list[str] | str,
+    subject: str,
+    template_name: str,
+    context: dict = None,
+    use_async: bool = True,
+):
+    """Sends an account-stream (transactional) email."""
+    _send_stream_email(
+        to, subject, template_name, context, use_async, resolve_account_sender
+    )

--- a/utils/tasks.py
+++ b/utils/tasks.py
@@ -7,6 +7,7 @@ from django.core.mail import EmailMessage
 
 from questions.types import AggregationMethod
 from utils.dramatiq import task_concurrent_limit
+from utils.email import resolve_account_sender
 from utils.translation import (
     update_translations_for_model,
     detect_and_update_content_language,
@@ -65,7 +66,7 @@ def email_all_data_for_questions_task(
         email = EmailMessage(
             subject="Your Metaculus Data",
             body="Attached is your Metaculus data.",
-            from_email=settings.EMAIL_SENDER_NO_REPLY,
+            from_email=resolve_account_sender(email_address),
             to=[email_address],
         )
         email.attach(filename or "metaculus_data.zip", data, "application/zip")
@@ -76,7 +77,7 @@ def email_all_data_for_questions_task(
             subject="Error generating Metaculus data",
             body="Error generating Metaculus data. Please contact an administrator "
             f"for assistance.\nError: {e}",
-            from_email=settings.EMAIL_SENDER_NO_REPLY,
+            from_email=resolve_account_sender(email_address),
             to=[email_address],
         )
         email.send()
@@ -134,7 +135,7 @@ def email_data_task(
         email = EmailMessage(
             subject="Your Metaculus Data",
             body="Attached is your Metaculus data.",
-            from_email=settings.EMAIL_SENDER_NO_REPLY,
+            from_email=resolve_account_sender(user_email),
             to=[user_email],
         )
         email.attach(filename, data, "application/zip")
@@ -145,7 +146,7 @@ def email_data_task(
             subject="Error generating Metaculus data",
             body="Error generating Metaculus data. Please contact an administrator "
             f"for assistance.\nError: {e}",
-            from_email=settings.EMAIL_SENDER_NO_REPLY,
+            from_email=resolve_account_sender(user_email),
             to=[user_email],
         )
         email.send()
@@ -169,7 +170,7 @@ def email_user_their_data_task(user_id: int):
         email = EmailMessage(
             subject="Your User Data",
             body="Attached is your User Data on Metaculus.",
-            from_email=settings.EMAIL_SENDER_NO_REPLY,
+            from_email=resolve_account_sender(user_email),
             to=[user_email],
         )
         email.attach("user_data.zip", data, "application/zip")
@@ -180,7 +181,7 @@ def email_user_their_data_task(user_id: int):
             subject="Error generating Metaculus data",
             body="Error generating Metaculus data. Please contact an administrator "
             f"for assistance.\nError: {e}",
-            from_email=settings.EMAIL_SENDER_NO_REPLY,
+            from_email=resolve_account_sender(user_email),
             to=[user_email],
         )
         email.send()


### PR DESCRIPTION
Gradual warm-up for moving our email onto dedicated sending domains (`notifications.*`, `accounts.*`).
  
Each recipient is hash-bucketed by a ramp % (configured in code), so traffic shifts slowly and stickily; `@metaculus.com` emails get a 50/50 split.

- Added EMAIL_NOTIFICATIONS_SENDER / EMAIL_ACCOUNTS_SENDER
- Made EMAIL_NOTIFICATIONS_USER legacy
- Dropped EMAIL_SENDER_NO_REPLY. 
- All send sites moved to the new stream wrappers

part of #4436 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gradual email-sender migration to improve delivery and attribution; recipient-facing emails may come from updated sender addresses.

* **Chores**
  * Centralized helpers now route notification and account emails through the new sender-resolution flow.
  * Contact and service emails now use the updated account sender setting.
  * Removed legacy sender config and added distinct notification/account sender settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->