### PR TITLE
Fix question page redesign QA fixes

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page_component.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page_component.tsx
@@ -75,7 +75,7 @@ const IndividualQuestionPage: FC<{
                 )}
               >
                 <div className="flex gap-4">
-                  <div className="relative w-full">
+                  <div className="relative w-full min-w-0">
                     {isCommunityQuestion && defaultProject && (
                       <div className="absolute z-0 -mt-[34px] hidden w-full sm:block">
                         <CommunityDisclaimer

--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_feed.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_feed.tsx
@@ -181,7 +181,9 @@ const KeyFactorsFeed: FC<Props> = ({ post, truncateText, hideOverlay }) => {
               {t("noKeyFactorsP2")}
             </span>
           </div>
-          {canAddKeyFactor && <AddKeyFactorsButton post={post} as="div" />}
+          {(canAddKeyFactor || (!user && !isClosed)) && (
+            <AddKeyFactorsButton post={post} as="div" />
+          )}
         </div>
         {addModal}
       </>

--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_feed.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_feed.tsx
@@ -224,9 +224,7 @@ const KeyFactorsFeed: FC<Props> = ({ post, truncateText, hideOverlay }) => {
               <KeyFactorsGridPlaceholder
                 key={`placeholder-${i}`}
                 className={i < 2 - totalItemCount ? "" : "hidden md:flex"}
-                onClick={
-                  i === 0 && canAddKeyFactor ? handleAddClick : undefined
-                }
+                onClick={i === 0 && !isClosed ? handleAddClick : undefined}
               />
             ))}
         </div>

--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_grid_placeholder.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_grid_placeholder.tsx
@@ -15,24 +15,29 @@ type Props = {
 const KeyFactorsGridPlaceholder: FC<Props> = ({ className, onClick }) => {
   const t = useTranslations();
 
-  return (
-    <div
-      className={cn(
-        "flex min-h-[100px] items-center justify-center overflow-hidden rounded-xl bg-[#e8eeee] dark:bg-blue-300-dark",
-        "border border-transparent p-5 opacity-50 transition-opacity hover:opacity-100",
-        onClick &&
-          "cursor-pointer hover:border-blue-500 dark:hover:border-blue-500-dark",
-        className
-      )}
-      onClick={onClick}
-    >
-      <div className="flex flex-col items-center gap-3 text-blue-700 dark:text-blue-700-dark">
-        <FontAwesomeIcon icon={faPlus} className="size-[22px]" />
-        <span className="whitespace-nowrap text-base capitalize leading-5">
-          {t("addKeyFactor")}
-        </span>
-      </div>
+  const sharedClassName = cn(
+    "flex min-h-[100px] items-center justify-center overflow-hidden rounded-xl bg-[#e8eeee] dark:bg-blue-300-dark",
+    "border border-transparent p-5 opacity-50 transition-opacity hover:opacity-100",
+    onClick &&
+      "cursor-pointer hover:border-blue-500 dark:hover:border-blue-500-dark",
+    className
+  );
+
+  const content = (
+    <div className="flex flex-col items-center gap-3 text-blue-700 dark:text-blue-700-dark">
+      <FontAwesomeIcon icon={faPlus} className="size-[22px]" />
+      <span className="whitespace-nowrap text-base capitalize leading-5">
+        {t("addKeyFactor")}
+      </span>
     </div>
+  );
+
+  return onClick ? (
+    <button type="button" className={sharedClassName} onClick={onClick}>
+      {content}
+    </button>
+  ) : (
+    <div className={sharedClassName}>{content}</div>
   );
 };
 

--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_grid_placeholder.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_grid_placeholder.tsx
@@ -18,21 +18,20 @@ const KeyFactorsGridPlaceholder: FC<Props> = ({ className, onClick }) => {
   return (
     <div
       className={cn(
-        "group flex min-h-[100px] items-center justify-center overflow-hidden rounded-xl bg-[#e8eeee] dark:bg-blue-300-dark",
+        "flex min-h-[100px] items-center justify-center overflow-hidden rounded-xl bg-[#e8eeee] dark:bg-blue-300-dark",
+        "border border-transparent p-5 opacity-50 transition-opacity hover:opacity-100",
         onClick &&
-          "cursor-pointer border border-transparent p-5 hover:border-blue-500 dark:hover:border-blue-500-dark",
+          "cursor-pointer hover:border-blue-500 dark:hover:border-blue-500-dark",
         className
       )}
       onClick={onClick}
     >
-      {onClick && (
-        <div className="flex flex-col items-center gap-3 text-blue-700 opacity-0 transition-opacity group-hover:opacity-100 dark:text-blue-700-dark">
-          <FontAwesomeIcon icon={faPlus} className="size-[22px]" />
-          <span className="whitespace-nowrap text-base capitalize leading-5">
-            {t("addKeyFactor")}
-          </span>
-        </div>
-      )}
+      <div className="flex flex-col items-center gap-3 text-blue-700 dark:text-blue-700-dark">
+        <FontAwesomeIcon icon={faPlus} className="size-[22px]" />
+        <span className="whitespace-nowrap text-base capitalize leading-5">
+          {t("addKeyFactor")}
+        </span>
+      </div>
     </div>
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
@@ -13,27 +13,33 @@ const MOBILE_MAX_ITEMS = 5;
 
 type Props = {
   items: ChoiceItem[];
-  questionType: QuestionType.MultipleChoice | QuestionType.Binary;
+  questionType: QuestionType;
   onChoiceChange: (choice: string, checked: boolean) => void;
   onChoiceHighlight: (choice: string, highlighted: boolean) => void;
 };
 
 function isResolvedNo(item: ChoiceItem, questionType: QuestionType): boolean {
   if (questionType === QuestionType.Binary) return item.resolution === "no";
-  return (
-    item.resolution !== null &&
-    !isUnsuccessfullyResolved(item.resolution) &&
-    item.choice.toLowerCase() !== String(item.resolution).toLowerCase()
-  );
+  if (questionType === QuestionType.MultipleChoice) {
+    return (
+      item.resolution !== null &&
+      !isUnsuccessfullyResolved(item.resolution) &&
+      item.choice.toLowerCase() !== String(item.resolution).toLowerCase()
+    );
+  }
+  return false;
 }
 
 function isResolvedYes(item: ChoiceItem, questionType: QuestionType): boolean {
   if (questionType === QuestionType.Binary) return item.resolution === "yes";
-  return (
-    item.resolution !== null &&
-    !isUnsuccessfullyResolved(item.resolution) &&
-    item.choice.toLowerCase() === String(item.resolution).toLowerCase()
-  );
+  if (questionType === QuestionType.MultipleChoice) {
+    return (
+      item.resolution !== null &&
+      !isUnsuccessfullyResolved(item.resolution) &&
+      item.choice.toLowerCase() === String(item.resolution).toLowerCase()
+    );
+  }
+  return false;
 }
 
 function getLastAggregationValue(item: ChoiceItem): number | null {

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
@@ -27,6 +27,15 @@ function isResolvedNo(item: ChoiceItem, questionType: QuestionType): boolean {
   );
 }
 
+function isResolvedYes(item: ChoiceItem, questionType: QuestionType): boolean {
+  if (questionType === QuestionType.Binary) return item.resolution === "yes";
+  return (
+    item.resolution !== null &&
+    !isUnsuccessfullyResolved(item.resolution) &&
+    item.choice.toLowerCase() === String(item.resolution).toLowerCase()
+  );
+}
+
 function getLastAggregationValue(item: ChoiceItem): number | null {
   const values = item.aggregationValues;
   for (let i = values.length - 1; i >= 0; i--) {
@@ -55,7 +64,10 @@ const CompactLegendBar: FC<Props> = ({
   let hiddenCount: number;
 
   if (showAll) {
-    visibleItems = items;
+    const resolvedNoItems = items.filter((item) =>
+      isResolvedNo(item, questionType)
+    );
+    visibleItems = [...normalItems, ...resolvedNoItems];
     hiddenCount = 0;
   } else if (!isMd) {
     // Mobile: show up to MOBILE_MAX_ITEMS normal items only; resolved-NO always hidden
@@ -72,6 +84,7 @@ const CompactLegendBar: FC<Props> = ({
     <div className="flex flex-wrap gap-x-3 gap-y-1.5">
       {visibleItems.map((item) => {
         const resolvedNo = isResolvedNo(item, questionType);
+        const resolvedYes = isResolvedYes(item, questionType);
         const pct = getForecastPctDisplayValue(getLastAggregationValue(item));
 
         return (
@@ -81,9 +94,11 @@ const CompactLegendBar: FC<Props> = ({
               "flex items-center gap-1 rounded px-1.5 py-0.5",
               resolvedNo
                 ? "cursor-default"
-                : "cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-200-dark",
-              item.highlighted && "bg-gray-200 dark:bg-gray-200-dark"
+                : "cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-200-dark"
             )}
+            onClick={() =>
+              !resolvedNo && onChoiceChange(item.choice, !item.active)
+            }
             onMouseEnter={() =>
               !resolvedNo && onChoiceHighlight(item.choice, true)
             }
@@ -94,7 +109,7 @@ const CompactLegendBar: FC<Props> = ({
             {resolvedNo ? (
               <>
                 <span className="size-3 shrink-0 rounded-full bg-gray-300 dark:bg-gray-300-dark" />
-                <span className="max-w-[120px] truncate text-sm font-medium leading-4 text-gray-400 line-through dark:text-gray-400-dark md:text-base md:leading-5">
+                <span className="max-w-[300px] truncate text-sm font-medium leading-4 text-gray-400 line-through dark:text-gray-400-dark md:text-base md:leading-5">
                   {item.label || item.choice}
                 </span>
               </>
@@ -114,7 +129,6 @@ const CompactLegendBar: FC<Props> = ({
                         }
                       : undefined
                   }
-                  onClick={() => onChoiceChange(item.choice, !item.active)}
                   onKeyDown={(e) => {
                     if (e.key === " " || e.key === "Enter") {
                       e.preventDefault();
@@ -135,11 +149,11 @@ const CompactLegendBar: FC<Props> = ({
                     </svg>
                   )}
                 </span>
-                <span className="max-w-[120px] truncate text-sm font-medium leading-4 text-gray-800 dark:text-gray-800-dark md:text-base md:leading-5">
+                <span className="max-w-[300px] truncate text-sm font-medium leading-4 text-gray-800 dark:text-gray-800-dark md:text-base md:leading-5">
                   {item.label || item.choice}
                 </span>
                 <span className="shrink-0 text-sm tabular-nums leading-4 text-gray-600 dark:text-gray-600-dark md:text-base md:leading-6">
-                  {pct}
+                  {resolvedYes ? `(${t("Yes")})` : pct}
                 </span>
               </>
             )}

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
@@ -17,7 +17,6 @@ import { ForecastAvailability, QuestionType, Scaling } from "@/types/question";
 import cn from "@/utils/core/cn";
 import { buildChoicesWithOthers } from "@/utils/questions/choices";
 
-import ChoicesLegend from "./choices_legend";
 import CompactLegendBar from "./compact_legend_bar";
 
 type Props = {
@@ -107,26 +106,9 @@ const MultiChoicesChartView: FC<Props> = ({
 
   const isMC = questionType === QuestionType.MultipleChoice;
 
-  const legendContainerRef = useRef<HTMLDivElement>(null);
-  const [normalizedChartHeight, setNormalizedChartHeight] =
-    useState(chartHeight);
-  useEffect(() => {
-    if (!chartHeight) return;
-    if (!legendContainerRef.current) {
-      setNormalizedChartHeight(chartHeight);
-      return;
-    }
-    setNormalizedChartHeight(
-      chartHeight -
-        (legendContainerRef.current?.clientHeight ?? 0) -
-        (legendContainerRef.current.offsetHeight ?? 0)
-    );
-  }, [chartHeight]);
-
   const maxPrimary = embedMode
     ? 2
     : getEffectiveVisibleCount(choiceItems.length);
-  const showOthersToggle = isMC && choiceItems.length > maxPrimary;
 
   const normalizedInitRef = useRef(false);
   useEffect(() => {
@@ -141,25 +123,6 @@ const MultiChoicesChartView: FC<Props> = ({
     if (changed) onChoiceItemsUpdate(updated);
     normalizedInitRef.current = true;
   }, [choiceItems, maxPrimary, onChoiceItemsUpdate]);
-  const computeOthersVisible = useCallback(
-    (items: ChoiceItem[]) => {
-      if (!isMC || items.length <= maxPrimary) return false;
-      const left = items.slice(0, maxPrimary);
-      const right = items.slice(maxPrimary);
-      const dropdown = [...left.filter((c) => !c.active), ...right];
-      if (dropdown.length === 0) return false;
-      return dropdown.every((c) => c.active);
-    },
-    [isMC, maxPrimary]
-  );
-  const [othersVisible, setOthersVisible] = useState<boolean>(() =>
-    computeOthersVisible(choiceItems)
-  );
-  useEffect(() => {
-    if (!showOthersToggle) return;
-    const next = computeOthersVisible(choiceItems);
-    if (next !== othersVisible) setOthersVisible(next);
-  }, [showOthersToggle, choiceItems, computeOthersVisible, othersVisible]);
 
   const {
     isActive: isTooltipActive,
@@ -216,20 +179,6 @@ const MultiChoicesChartView: FC<Props> = ({
     [choiceItems, onChoiceItemsUpdate]
   );
 
-  const toggleSelectAll = useCallback(
-    (isAllSelected: boolean) => {
-      const nextActive = !isAllSelected;
-      onChoiceItemsUpdate(
-        choiceItems.map((item) => ({
-          ...item,
-          active: nextActive,
-          highlighted: false,
-        }))
-      );
-    },
-    [choiceItems, onChoiceItemsUpdate]
-  );
-
   const chartChoiceItems = useMemo(
     () => (isMC ? buildChoicesWithOthers(choiceItems) : choiceItems),
     [isMC, choiceItems]
@@ -273,7 +222,7 @@ const MultiChoicesChartView: FC<Props> = ({
     scaling,
     isClosed,
     extraTheme: chartTheme,
-    height: normalizedChartHeight,
+    height: chartHeight,
     withZoomPicker: true,
     defaultZoom: resolveDefaultZoom(defaultZoom, !!user),
     openTime,
@@ -370,11 +319,11 @@ const MultiChoicesChartView: FC<Props> = ({
             onTimelineMarkerEnter={onTimelineMarkerEnter}
             onTimelineMarkerLeave={onTimelineMarkerLeave}
             headerLeft={
-              withLegend && questionType === QuestionType.Binary ? (
+              withLegend ? (
                 <div {...legendEnterProps}>
                   <CompactLegendBar
                     items={choiceItems}
-                    questionType={QuestionType.Binary}
+                    questionType={questionType ?? QuestionType.Binary}
                     onChoiceChange={handleChoiceChange}
                     onChoiceHighlight={handleChoiceHighlight}
                   />
@@ -385,26 +334,6 @@ const MultiChoicesChartView: FC<Props> = ({
           />
         )}
       </div>
-
-      {withLegend && !isMC && questionType !== QuestionType.Binary && (
-        <div className="-ml-1 mt-3" ref={legendContainerRef}>
-          <ChoicesLegend
-            choices={choiceItems}
-            onChoiceChange={handleChoiceChange}
-            onChoiceHighlight={handleChoiceHighlight}
-            onToggleAll={toggleSelectAll}
-            othersToggle={showOthersToggle ? !timelineMode : undefined}
-            onOthersToggle={
-              showOthersToggle
-                ? (checked) => setTimelineMode(!checked)
-                : undefined
-            }
-            othersDisabled={
-              showOthersToggle ? totalActiveCount !== 1 : undefined
-            }
-          />
-        </div>
-      )}
 
       {isTooltipActive &&
         !isCursorOverLegend &&

--- a/front_end/src/app/(main)/questions/[id]/components/post_score_data/single_question_score_data.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/post_score_data/single_question_score_data.tsx
@@ -1,8 +1,6 @@
 import React, { FC } from "react";
 
 import ForecastMaker from "@/components/forecast_maker";
-import BackgroundInfo from "@/components/question/background_info";
-import ResolutionCriteria from "@/components/question/resolution_criteria";
 import { PostWithForecasts } from "@/types/post";
 import { QuestionType } from "@/types/question";
 import { isContinuousQuestion } from "@/utils/questions/helpers";
@@ -57,8 +55,6 @@ const SingleQuestionScoreData: FC<Props> = ({
       )}
       <ResolutionScoreCards post={post} />
       {isContinuousQuestion(question) && <ForecastMaker post={post} />}
-      <ResolutionCriteria post={post} defaultOpen />
-      <BackgroundInfo post={post} defaultOpen />
     </div>
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -14,6 +14,7 @@ import DetailedQuestionCard from "@/components/detailed_question_card/detailed_q
 import ForecastMaker from "@/components/forecast_maker";
 import MarkdownEditor from "@/components/markdown_editor";
 import CommunityDisclaimer from "@/components/post_card/community_disclaimer";
+import ResolutionCriteria from "@/components/question/resolution_criteria";
 import SectionToggle from "@/components/ui/section_toggle";
 import { ContinuousChartCursorProvider } from "@/contexts/continuous_chart_cursor_context";
 import { useHideCP } from "@/contexts/cp_context";
@@ -32,6 +33,7 @@ import { getQuestionForecastAvailability } from "@/utils/questions/forecastAvail
 import { sortGroupPredictionOptions } from "@/utils/questions/groupOrdering";
 import {
   checkGroupOfQuestionsPostType,
+  isConditionalPost,
   isContinuousQuestion,
   isGroupOfQuestionsPost,
   isMultipleChoicePost,
@@ -83,7 +85,10 @@ export const ForecasterShell: FC<
     };
   }, [postData.is_current_content_translated, locale, setBannerIsVisible]);
 
-  const sections = usePostTextSections(postData, { excludeFinePrint: true });
+  const sections = usePostTextSections(postData, {
+    excludeFinePrint: true,
+    excludeResolutionCriteria: true,
+  });
   const isResolved = postData.status === PostStatus.RESOLVED;
   const isGroup = isGroupOfQuestionsPost(postData);
   const showChartDivider =
@@ -145,6 +150,7 @@ export const ForecasterShell: FC<
               ))}
           </div>
           {(!isResolved || isGroup) && <ForecastMaker post={postData} />}
+          <ResolutionCriteria post={postData} defaultOpen />
           {sections.length > 0 && (
             <div className="flex flex-col gap-2">
               {sections.map((section) => (
@@ -270,7 +276,13 @@ export const ConsumerShell: FC<{
               {t("predictionClosedMessage")}
             </p>
           )}
-          {isBinarySingleQuestion && isQuestionPost(postData) ? (
+          {isConditionalPost(postData) ? (
+            <QuestionTimeline
+              postData={postData}
+              isConsumerView
+              className="mt-0 hidden sm:block"
+            />
+          ) : isBinarySingleQuestion && isQuestionPost(postData) ? (
             <div className="flex flex-col sm:flex-row sm:items-center sm:gap-0 md:gap-8">
               <div className="order-1 flex w-64 flex-col items-center justify-center gap-[18px] self-center sm:self-stretch">
                 {hideCP ? (

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
@@ -35,23 +35,27 @@ const MetaRow: FC<Props> = ({ post, className, variant }) => {
   const { ref, width } = useContainerSize<HTMLDivElement>();
 
   const projectsData = post.projects;
+  const defaultProject = projectsData?.default_project ?? null;
+  // default_project is shown first; the rest are deduped and go into "N more"
   const allProjects: Project[] = projectsData
     ? [
-        ...(projectsData.index ?? []),
-        ...(projectsData.tournament ?? []),
-        ...(projectsData.question_series ?? []),
-        ...(projectsData.community ?? []),
-        ...(projectsData.category ?? []),
-        ...(projectsData.leaderboard_tag ?? []),
+        ...(defaultProject ? [defaultProject] : []),
+        ...[
+          ...(projectsData.index ?? []),
+          ...(projectsData.tournament ?? []),
+          ...(projectsData.question_series ?? []),
+          ...(projectsData.community ?? []),
+          ...(projectsData.category ?? []),
+          ...(projectsData.leaderboard_tag ?? []),
+        ].filter((p) => p.id !== defaultProject?.id),
       ]
     : [];
 
   // Drop "forecasters" label first, then reduce visible chips
   const compactCounters = width > 0 && width < 600;
-  const maxVisibleChips = width > 0 && width < 500 ? 1 : 2;
 
-  const visibleChips = allProjects.slice(0, maxVisibleChips);
-  const hiddenChips = allProjects.slice(maxVisibleChips);
+  const visibleChips = allProjects.slice(0, 1);
+  const hiddenChips = allProjects.slice(1);
 
   return (
     <div className={cn("px-4 lg:px-8", className)}>

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
@@ -40,15 +40,16 @@ const MetaRow: FC<Props> = ({ post, className, variant }) => {
   const allProjects: Project[] = projectsData
     ? [
         ...(defaultProject ? [defaultProject] : []),
-        ...[
-          ...(projectsData.index ?? []),
-          ...(projectsData.tournament ?? []),
-          ...(projectsData.question_series ?? []),
-          ...(projectsData.community ?? []),
-          ...(projectsData.category ?? []),
-          ...(projectsData.leaderboard_tag ?? []),
-        ].filter((p) => p.id !== defaultProject?.id),
-      ]
+        ...(projectsData.index ?? []),
+        ...(projectsData.tournament ?? []),
+        ...(projectsData.question_series ?? []),
+        ...(projectsData.community ?? []),
+        ...(projectsData.category ?? []),
+        ...(projectsData.leaderboard_tag ?? []),
+      ].filter(
+        (project, index, arr) =>
+          arr.findIndex((candidate) => candidate.id === project.id) === index
+      )
     : [];
 
   // Drop "forecasters" label first, then reduce visible chips

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tab_bar.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tab_bar.tsx
@@ -3,11 +3,13 @@
 import { useTranslations } from "next-intl";
 import { FC, useEffect } from "react";
 
+import useCoherenceLinksContext from "@/app/(main)/components/coherence_links_provider";
 import { Tabs, TabsList, TabsTab } from "@/components/ui/tabs";
 import { useBreakpoint } from "@/hooks/tailwind";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import cn from "@/utils/core/cn";
 
+import { isDisplayableQuestionLink } from "../key_factors/utils";
 import { shouldPostShowUserScores } from "../post_score_data/utils";
 import { useQuestionLayout } from "../question_layout/question_layout_context";
 import { hasTimeline } from "../question_view/consumer_question_view/timeline";
@@ -49,7 +51,11 @@ const QuestionPageShellTabBar: FC<Props> = ({ post, variant, className }) => {
 
   const isSm = useBreakpoint("sm");
   const commentCount = post.comment_count ?? 0;
-  const keyFactorsCount = post.key_factors?.length ?? 0;
+  const { aggregateCoherenceLinks } = useCoherenceLinksContext();
+  const questionLinksCount = aggregateCoherenceLinks.data.filter(
+    isDisplayableQuestionLink
+  ).length;
+  const keyFactorsCount = (post.key_factors?.length ?? 0) + questionLinksCount;
   const hasScores = shouldPostShowUserScores(post);
   const hasSimilarQuestionsTab =
     !isSm && post.curation_status === PostStatus.APPROVED;

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_group_chart.tsx
@@ -22,13 +22,22 @@ const ConsumerGroupChart: FC<Props> = ({
   chartHeight,
   visibleQuestions,
 }) => {
-  const { hoveredChoiceName, setHoveredChoiceName } = useListChartExpanded();
+  const { hoveredChoiceName, setHoveredChoiceName, chartAreaHeight } =
+    useListChartExpanded();
   const { open_time, actual_close_time, scheduled_close_time, status } = post;
   const refCloseTime = actual_close_time ?? scheduled_close_time;
 
   const groupTimelineProps = visibleQuestions
     ? { questions: visibleQuestions }
     : { group: post.group_of_questions };
+
+  // GroupChart renders a ~44px header (title + zoom picker) above the SVG div.
+  // Subtract it so header + SVG together fit within chartAreaHeight.
+  const CHART_HEADER_HEIGHT = 44;
+  const effectiveChartHeight =
+    chartAreaHeight > 0
+      ? Math.max(80, chartAreaHeight - CHART_HEADER_HEIGHT)
+      : chartHeight;
 
   return (
     <div onMouseLeave={() => setHoveredChoiceName(null)}>
@@ -41,7 +50,7 @@ const ConsumerGroupChart: FC<Props> = ({
         withLegend={false}
         withHighlightArea={false}
         externalHighlightedChoice={hoveredChoiceName}
-        chartHeight={chartHeight}
+        chartHeight={effectiveChartHeight}
       />
     </div>
   );

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
@@ -2,18 +2,21 @@
 
 import { createContext, ReactNode, useContext, useMemo, useState } from "react";
 
+import useContainerSize from "@/hooks/use_container_size";
 import cn from "@/utils/core/cn";
 
 type ListChartExpandedContextType = {
   setIsExpanded: (value: boolean) => void;
   hoveredChoiceName: string | null;
   setHoveredChoiceName: (name: string | null) => void;
+  chartAreaHeight: number;
 };
 
 const ListChartExpandedContext = createContext<ListChartExpandedContextType>({
   setIsExpanded: () => {},
   hoveredChoiceName: null,
   setHoveredChoiceName: () => {},
+  chartAreaHeight: 0,
 });
 
 export const useListChartExpanded = () => useContext(ListChartExpandedContext);
@@ -44,10 +47,19 @@ const ConsumerListChartShell: React.FC<Props> = ({
     null
   );
 
+  const { ref: listColumnRef, height: listColumnHeight } =
+    useContainerSize<HTMLDivElement>();
+  const chartAreaHeight = Math.max(0, listColumnHeight - 40);
+
   // Memoize so isExpanded changes don't re-render context consumers (e.g. the chart).
   const contextValue = useMemo(
-    () => ({ setIsExpanded, hoveredChoiceName, setHoveredChoiceName }),
-    [hoveredChoiceName, setHoveredChoiceName, setIsExpanded]
+    () => ({
+      setIsExpanded,
+      hoveredChoiceName,
+      setHoveredChoiceName,
+      chartAreaHeight,
+    }),
+    [hoveredChoiceName, chartAreaHeight, setHoveredChoiceName, setIsExpanded]
   );
 
   return (
@@ -62,8 +74,9 @@ const ConsumerListChartShell: React.FC<Props> = ({
         onMouseLeave={() => setHoveredChoiceName(null)}
       >
         <div
+          ref={listColumnRef}
           className={cn(
-            "order-1 sm:w-80 sm:shrink-0",
+            "order-1 sm:w-80 sm:shrink-0 sm:self-start lg:w-64 xl:w-80",
             reduceInnerPadding ? "sm:py-5 sm:pl-5" : "sm:p-5",
             hideListOnMobile ? "hidden sm:block" : "",
             stretchListContent && "sm:flex sm:flex-col"
@@ -73,12 +86,15 @@ const ConsumerListChartShell: React.FC<Props> = ({
         </div>
         <div
           className={cn(
-            "relative order-2 hidden flex-1 sm:flex sm:flex-col",
+            "relative order-2 hidden flex-1 overflow-hidden sm:flex sm:flex-col",
             reduceInnerPadding ? "sm:py-5" : "sm:p-5",
             !hideDivider &&
               "sm:before:absolute sm:before:bottom-0 sm:before:left-0 sm:before:w-px sm:before:bg-gray-400/40 sm:before:content-[''] dark:sm:before:bg-gray-400-dark/40",
             !hideDivider && (isExpanded ? "sm:before:top-2" : "sm:before:top-0")
           )}
+          style={
+            listColumnHeight > 0 ? { height: listColumnHeight } : undefined
+          }
         >
           {chartContent}
         </div>

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { createContext, ReactNode, useContext, useMemo, useState } from "react";
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import useContainerSize from "@/hooks/use_container_size";
 import cn from "@/utils/core/cn";
@@ -42,14 +51,34 @@ const ConsumerListChartShell: React.FC<Props> = ({
   reduceInnerPadding = false,
   className,
 }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpandedRaw] = useState(false);
+  const [frozenHeight, setFrozenHeight] = useState(0);
   const [hoveredChoiceName, setHoveredChoiceName] = useState<string | null>(
     null
   );
 
   const { ref: listColumnRef, height: listColumnHeight } =
     useContainerSize<HTMLDivElement>();
-  const chartAreaHeight = Math.max(0, listColumnHeight - 40);
+
+  // Keep a ref to the live height so the stable setIsExpanded callback can
+  // snapshot it at click time without needing it as a dependency.
+  const liveHeightRef = useRef(0);
+  useLayoutEffect(() => {
+    liveHeightRef.current = listColumnHeight;
+  }, [listColumnHeight]);
+
+  // Stable wrapper: snapshots the current height when expanding so the chart
+  // area doesn't jump if a reflow occurs while the overlay is open.
+  const setIsExpanded = useCallback((value: boolean) => {
+    if (value) {
+      setFrozenHeight(liveHeightRef.current);
+    }
+    setIsExpandedRaw(value);
+  }, []);
+
+  const effectiveHeight =
+    isExpanded && frozenHeight > 0 ? frozenHeight : listColumnHeight;
+  const chartAreaHeight = Math.max(0, effectiveHeight - 40);
 
   // Memoize so isExpanded changes don't re-render context consumers (e.g. the chart).
   const contextValue = useMemo(
@@ -92,9 +121,7 @@ const ConsumerListChartShell: React.FC<Props> = ({
               "sm:before:absolute sm:before:bottom-0 sm:before:left-0 sm:before:w-px sm:before:bg-gray-400/40 sm:before:content-[''] dark:sm:before:bg-gray-400-dark/40",
             !hideDivider && (isExpanded ? "sm:before:top-2" : "sm:before:top-0")
           )}
-          style={
-            listColumnHeight > 0 ? { height: listColumnHeight } : undefined
-          }
+          style={effectiveHeight > 0 ? { height: effectiveHeight } : undefined}
         >
           {chartContent}
         </div>

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/fan_graph_chart_panel.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/fan_graph_chart_panel.tsx
@@ -11,6 +11,7 @@ import { QuestionWithNumericForecasts } from "@/types/question";
 import cn from "@/utils/core/cn";
 
 import ConsumerGroupChart from "./consumer_group_chart";
+import { useListChartExpanded } from "./consumer_list_chart_shell";
 
 type ChartView = "fan" | "timeline";
 
@@ -29,6 +30,7 @@ const FanGraphChartPanel: FC<Props> = ({
 }) => {
   const t = useTranslations();
   const { hideCP } = useHideCP();
+  const { chartAreaHeight } = useListChartExpanded();
   const isConsumer = variant === "consumer";
   const [activeView, setActiveView] = useState<ChartView>(
     isConsumer ? "timeline" : "fan"
@@ -65,6 +67,14 @@ const FanGraphChartPanel: FC<Props> = ({
     </div>
   );
 
+  // Fan view toggle is in-flow (h-6 + mb-2 ≈ 32px); subtract from available height.
+  const fanChartHeight =
+    chartAreaHeight > 0
+      ? Math.max(100, chartAreaHeight - 32)
+      : isCompact
+        ? 150
+        : undefined;
+
   return (
     <div className="grid grid-cols-1 grid-rows-1">
       <div
@@ -78,7 +88,7 @@ const FanGraphChartPanel: FC<Props> = ({
           group={post.group_of_questions}
           hideCP={hideCP}
           withTooltip
-          height={isCompact ? 150 : undefined}
+          height={fanChartHeight}
         />
       </div>
       <div

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/timeline/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/timeline/index.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import ConditionalTimeline from "@/components/conditional_timeline";
 import NumericForecastCard from "@/components/consumer_post_card/group_forecast_card/numeric_forecast_card";
 import DetailedGroupCard from "@/components/detailed_question_card/detailed_group_card";
 import DetailedQuestionCard from "@/components/detailed_question_card/detailed_question_card";
@@ -11,9 +14,12 @@ import { QuestionType } from "@/types/question";
 import cn from "@/utils/core/cn";
 import {
   checkGroupOfQuestionsPostType,
+  isConditionalPost,
   isGroupOfQuestionsPost,
   isQuestionPost,
 } from "@/utils/questions/helpers";
+
+import { useListChartExpanded } from "../consumer_list_chart_shell";
 
 type Props = {
   postData: PostWithForecasts;
@@ -32,10 +38,25 @@ const QuestionTimeline: React.FC<Props> = ({
   isConsumerView = true,
   preselectedGroupQuestionId,
 }) => {
+  const { chartAreaHeight } = useListChartExpanded();
   const isFanGraph =
     postData.group_of_questions?.graph_type ===
     GroupOfQuestionsGraphType.FanGraph;
-  const wrapperClass = cn(isFanGraph ? "mb-8" : "mt-8", className);
+  const inShell = chartAreaHeight > 0;
+
+  const wrapperClass = cn(
+    inShell ? "" : isFanGraph ? "mb-8" : "mt-8",
+    className
+  );
+  const embedHeight = inShell ? Math.max(80, chartAreaHeight - 44) : undefined;
+
+  if (isConditionalPost(postData)) {
+    return (
+      <div className={cn("mt-8", className)}>
+        <ConditionalTimeline post={postData} />
+      </div>
+    );
+  }
 
   if (isQuestionPost(postData)) {
     if (postData.question.status !== QuestionStatus.UPCOMING) {
@@ -46,6 +67,7 @@ const QuestionTimeline: React.FC<Props> = ({
             hideTitle={hideTitle}
             isConsumerView={isConsumerView}
             keyFactors={keyFactors}
+            embedChartHeight={embedHeight}
           />
         </div>
       );
@@ -88,6 +110,7 @@ const QuestionTimeline: React.FC<Props> = ({
             post={postData}
             preselectedQuestionId={preselectedGroupQuestionId}
             withLegend={!isConsumerView}
+            embedChartHeight={embedHeight}
           />
         )}
       </div>
@@ -98,6 +121,9 @@ const QuestionTimeline: React.FC<Props> = ({
 };
 
 export function hasTimeline(postData: PostWithForecasts): boolean {
+  if (isConditionalPost(postData)) {
+    return true;
+  }
   if (isQuestionPost(postData)) {
     return postData.question.status !== QuestionStatus.UPCOMING;
   }

--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
@@ -7,7 +7,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslations } from "next-intl";
 import { FC, PropsWithChildren } from "react";
 
-import { METAC_COLORS } from "@/constants/colors";
 import cn from "@/utils/core/cn";
 
 type Props = {
@@ -31,7 +30,6 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
   children,
 }) => {
   const t = useTranslations();
-  const showExpandRow = !expanded && otherItemsCount > 0;
 
   const isMinimal = buttonVariant === "minimal";
 
@@ -48,7 +46,7 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
     <div
       className={cn(
         "flex w-full flex-col",
-        !expanded && (compact ? "gap-1 md:gap-2" : "gap-2"),
+        compact ? "gap-1 md:gap-2" : "gap-2",
         className
       )}
     >
@@ -63,11 +61,8 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
             {children}
           </div>
           <div
-            className="pointer-events-none absolute bottom-0 left-0 right-0 z-10 h-8"
-            style={{
-              opacity: 0.99,
-              background: `linear-gradient(180deg, transparent 0%, ${METAC_COLORS.gray[0].DEFAULT} 67.31%)`,
-            }}
+            className="pointer-events-none absolute bottom-0 left-0 right-0 z-10 h-8 bg-gradient-to-b from-transparent to-gray-0 dark:to-gray-0-dark"
+            style={{ opacity: 0.99 }}
           />
         </div>
       ) : (
@@ -91,9 +86,14 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
         </button>
       )}
 
-      {showExpandRow &&
+      {otherItemsCount > 0 &&
         (isMinimal ? (
-          <div className={toggleButtonClassName}>
+          <div
+            className={cn(
+              toggleButtonClassName,
+              expanded && "pointer-events-none invisible"
+            )}
+          >
             <FontAwesomeIcon
               icon={faEllipsis}
               className="h-3 w-3 opacity-[0.45] sm:h-4 sm:w-4"
@@ -103,9 +103,13 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
         ) : (
           <button
             type="button"
-            onClick={onExpand}
+            onClick={expanded ? undefined : onExpand}
             aria-pressed={false}
-            className={toggleButtonClassName}
+            className={cn(
+              toggleButtonClassName,
+              expanded && "pointer-events-none invisible"
+            )}
+            disabled={expanded}
           >
             <FontAwesomeIcon icon={faChevronDown} className="h-4 w-4" />
             {t("otherWithCount", { count: otherItemsCount })}

--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
@@ -7,6 +7,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslations } from "next-intl";
 import { FC, PropsWithChildren } from "react";
 
+import { METAC_COLORS } from "@/constants/colors";
 import cn from "@/utils/core/cn";
 
 type Props = {
@@ -47,11 +48,48 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
     <div
       className={cn(
         "flex w-full flex-col",
-        compact ? "gap-1 md:gap-2" : "gap-2",
+        !expanded && (compact ? "gap-1 md:gap-2" : "gap-2"),
         className
       )}
     >
-      {children}
+      {expanded ? (
+        <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div
+            className={cn(
+              "flex flex-1 flex-col overflow-y-auto no-scrollbar",
+              compact ? "gap-1 md:gap-2" : "gap-2"
+            )}
+          >
+            {children}
+          </div>
+          <div
+            className="pointer-events-none absolute bottom-0 left-0 right-0 z-10 h-8"
+            style={{
+              opacity: 0.99,
+              background: `linear-gradient(180deg, transparent 0%, ${METAC_COLORS.gray[0].DEFAULT} 67.31%)`,
+            }}
+          />
+        </div>
+      ) : (
+        children
+      )}
+
+      {expanded && onCollapse && (
+        <button
+          type="button"
+          onClick={onCollapse}
+          aria-pressed={true}
+          className={cn(toggleButtonClassName, "shrink-0")}
+        >
+          <FontAwesomeIcon
+            icon={isMinimal ? faEllipsis : faChevronUp}
+            className={cn(
+              isMinimal ? "h-3 w-3 opacity-[0.45] sm:h-4 sm:w-4" : "h-4 w-4"
+            )}
+          />
+          {t("collapse")}
+        </button>
+      )}
 
       {showExpandRow &&
         (isMinimal ? (
@@ -73,23 +111,6 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
             {t("otherWithCount", { count: otherItemsCount })}
           </button>
         ))}
-
-      {expanded && onCollapse && (
-        <button
-          type="button"
-          onClick={onCollapse}
-          aria-pressed={true}
-          className={toggleButtonClassName}
-        >
-          <FontAwesomeIcon
-            icon={isMinimal ? faEllipsis : faChevronUp}
-            className={cn(
-              isMinimal ? "h-3 w-3 opacity-[0.45] sm:h-4 sm:w-4" : "h-4 w-4"
-            )}
-          />
-          {t("collapse")}
-        </button>
-      )}
     </div>
   );
 };

--- a/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
@@ -6,6 +6,7 @@ import { FC, useState } from "react";
 
 import { useListChartExpanded } from "@/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell";
 import { getEffectiveVisibleCount } from "@/constants/questions";
+import { useOverlayMaxHeight } from "@/hooks/use_overlay_max_height";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import { QuestionType, Scaling } from "@/types/question";
 import cn from "@/utils/core/cn";
@@ -41,6 +42,7 @@ const NumericForecastCard: FC<Props> = ({
   const t = useTranslations();
   const [expanded, setExpanded] = useState(false);
   const { setIsExpanded, setHoveredChoiceName } = useListChartExpanded();
+  const { containerRef, overlayMaxHeight } = useOverlayMaxHeight(expanded);
 
   if (!isGroupOfQuestionsPost(post)) {
     return null;
@@ -167,6 +169,7 @@ const NumericForecastCard: FC<Props> = ({
 
   return (
     <div
+      ref={containerRef}
       className={cn("relative", effectiveFillHeight && "flex flex-1 flex-col")}
     >
       <ForecastCardWrapper
@@ -182,9 +185,11 @@ const NumericForecastCard: FC<Props> = ({
       >
         {renderBars(collapsedChoices, effectiveFillHeight)}
       </ForecastCardWrapper>
-
       {expanded && (
-        <div className="absolute -left-[21px] -top-[21px] z-20 w-[calc(100%+42px)] rounded-lg border border-gray-400/40 bg-gray-0 p-5 dark:border-gray-400-dark/40 dark:bg-gray-0-dark">
+        <div
+          className="absolute -left-[21px] -top-[21px] z-20 flex w-[calc(100%+42px)] flex-col overflow-hidden rounded-lg border border-gray-400/40 bg-gray-0 p-5 dark:border-gray-400-dark/40 dark:bg-gray-0-dark"
+          style={{ maxHeight: overlayMaxHeight }}
+        >
           <ForecastCardWrapper
             otherItemsCount={0}
             expanded={true}
@@ -194,6 +199,7 @@ const NumericForecastCard: FC<Props> = ({
             }}
             compact={compact}
             buttonVariant={buttonVariant}
+            className="min-h-0 flex-1"
           >
             {renderBars(sortedChoices, false, visibleChoicesCount)}
           </ForecastCardWrapper>

--- a/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
@@ -186,24 +186,33 @@ const NumericForecastCard: FC<Props> = ({
         {renderBars(collapsedChoices, effectiveFillHeight)}
       </ForecastCardWrapper>
       {expanded && (
-        <div
-          className="absolute -left-[21px] -top-[21px] z-20 flex w-[calc(100%+42px)] flex-col overflow-hidden rounded-lg border border-gray-400/40 bg-gray-0 p-5 dark:border-gray-400-dark/40 dark:bg-gray-0-dark"
-          style={{ maxHeight: overlayMaxHeight }}
-        >
-          <ForecastCardWrapper
-            otherItemsCount={0}
-            expanded={true}
-            onCollapse={() => {
+        <>
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => {
               setExpanded(false);
               setIsExpanded(false);
             }}
-            compact={compact}
-            buttonVariant={buttonVariant}
-            className="min-h-0 flex-1"
+          />
+          <div
+            className="absolute -left-[21px] -top-[21px] z-20 flex w-[calc(100%+42px)] flex-col overflow-hidden rounded-lg border border-gray-400/40 bg-gray-0 p-5 dark:border-gray-400-dark/40 dark:bg-gray-0-dark"
+            style={{ maxHeight: overlayMaxHeight }}
           >
-            {renderBars(sortedChoices, false, visibleChoicesCount)}
-          </ForecastCardWrapper>
-        </div>
+            <ForecastCardWrapper
+              otherItemsCount={0}
+              expanded={true}
+              onCollapse={() => {
+                setExpanded(false);
+                setIsExpanded(false);
+              }}
+              compact={compact}
+              buttonVariant={buttonVariant}
+              className="min-h-0 flex-1"
+            >
+              {renderBars(sortedChoices, false, visibleChoicesCount)}
+            </ForecastCardWrapper>
+          </div>
+        </>
       )}
     </div>
   );

--- a/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
@@ -133,24 +133,33 @@ const PercentageForecastCard: FC<Props> = ({
         {renderBars(collapsedChoices, effectiveFillHeight)}
       </ForecastCardWrapper>
       {expanded && (
-        <div
-          className="absolute -left-[21px] -top-[21px] z-20 flex w-[calc(100%+42px)] flex-col overflow-hidden rounded-lg border border-gray-400/40 bg-gray-0 p-5 dark:border-gray-400-dark/40 dark:bg-gray-0-dark"
-          style={{ maxHeight: overlayMaxHeight }}
-        >
-          <ForecastCardWrapper
-            otherItemsCount={0}
-            expanded={true}
-            onCollapse={() => {
+        <>
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => {
               setExpanded(false);
               setIsExpanded(false);
             }}
-            compact={compact}
-            buttonVariant={buttonVariant}
-            className="min-h-0 flex-1"
+          />
+          <div
+            className="absolute -left-[21px] -top-[21px] z-20 flex w-[calc(100%+42px)] flex-col overflow-hidden rounded-lg border border-gray-400/40 bg-gray-0 p-5 dark:border-gray-400-dark/40 dark:bg-gray-0-dark"
+            style={{ maxHeight: overlayMaxHeight }}
           >
-            {renderBars(allChoices)}
-          </ForecastCardWrapper>
-        </div>
+            <ForecastCardWrapper
+              otherItemsCount={0}
+              expanded={true}
+              onCollapse={() => {
+                setExpanded(false);
+                setIsExpanded(false);
+              }}
+              compact={compact}
+              buttonVariant={buttonVariant}
+              className="min-h-0 flex-1"
+            >
+              {renderBars(allChoices)}
+            </ForecastCardWrapper>
+          </div>
+        </>
       )}
     </div>
   );

--- a/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
@@ -5,6 +5,7 @@ import { FC, useMemo, useState } from "react";
 
 import { useListChartExpanded } from "@/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell";
 import { getEffectiveVisibleCount } from "@/constants/questions";
+import { useOverlayMaxHeight } from "@/hooks/use_overlay_max_height";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import { QuestionType } from "@/types/question";
 import cn from "@/utils/core/cn";
@@ -40,6 +41,7 @@ const PercentageForecastCard: FC<Props> = ({
   const t = useTranslations();
   const [expanded, setExpanded] = useState(false);
   const { setIsExpanded } = useListChartExpanded();
+  const { containerRef, overlayMaxHeight } = useOverlayMaxHeight(expanded);
 
   const isMC = isMultipleChoicePost(post);
   const cpRevealTime = post.question?.cp_reveal_time;
@@ -114,6 +116,7 @@ const PercentageForecastCard: FC<Props> = ({
 
   return (
     <div
+      ref={containerRef}
       className={cn("relative", effectiveFillHeight && "flex flex-1 flex-col")}
     >
       <ForecastCardWrapper
@@ -130,7 +133,10 @@ const PercentageForecastCard: FC<Props> = ({
         {renderBars(collapsedChoices, effectiveFillHeight)}
       </ForecastCardWrapper>
       {expanded && (
-        <div className="absolute -left-[21px] -top-[21px] z-20 w-[calc(100%+42px)] rounded-lg border border-gray-400/40 bg-gray-0 p-5 dark:border-gray-400-dark/40 dark:bg-gray-0-dark">
+        <div
+          className="absolute -left-[21px] -top-[21px] z-20 flex w-[calc(100%+42px)] flex-col overflow-hidden rounded-lg border border-gray-400/40 bg-gray-0 p-5 dark:border-gray-400-dark/40 dark:bg-gray-0-dark"
+          style={{ maxHeight: overlayMaxHeight }}
+        >
           <ForecastCardWrapper
             otherItemsCount={0}
             expanded={true}
@@ -140,6 +146,7 @@ const PercentageForecastCard: FC<Props> = ({
             }}
             compact={compact}
             buttonVariant={buttonVariant}
+            className="min-h-0 flex-1"
           >
             {renderBars(allChoices)}
           </ForecastCardWrapper>

--- a/front_end/src/hooks/use_overlay_max_height.ts
+++ b/front_end/src/hooks/use_overlay_max_height.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef, useState } from "react";
+
+// 21px matches the -top-[21px] / -left-[21px] offset used on the overlay
+const OVERLAY_OFFSET = 21;
+const BOTTOM_MARGIN = 16;
+const MIN_HEIGHT = 200;
+
+export function useOverlayMaxHeight(expanded: boolean) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [overlayMaxHeight, setOverlayMaxHeight] = useState<number | undefined>(
+    undefined
+  );
+
+  useEffect(() => {
+    if (expanded && containerRef.current) {
+      const { top } = containerRef.current.getBoundingClientRect();
+      setOverlayMaxHeight(
+        Math.max(
+          window.innerHeight - (top - OVERLAY_OFFSET) - BOTTOM_MARGIN,
+          MIN_HEIGHT
+        )
+      );
+    }
+  }, [expanded]);
+
+  return { containerRef, overlayMaxHeight };
+}

--- a/front_end/src/hooks/use_overlay_max_height.ts
+++ b/front_end/src/hooks/use_overlay_max_height.ts
@@ -12,7 +12,10 @@ export function useOverlayMaxHeight(expanded: boolean) {
   );
 
   useEffect(() => {
-    if (expanded && containerRef.current) {
+    if (!expanded || !containerRef.current) return;
+
+    const recompute = () => {
+      if (!containerRef.current) return;
       const { top } = containerRef.current.getBoundingClientRect();
       setOverlayMaxHeight(
         Math.max(
@@ -20,7 +23,11 @@ export function useOverlayMaxHeight(expanded: boolean) {
           MIN_HEIGHT
         )
       );
-    }
+    };
+
+    recompute();
+    window.addEventListener("resize", recompute);
+    return () => window.removeEventListener("resize", recompute);
   }, [expanded]);
 
   return { containerRef, overlayMaxHeight };

--- a/front_end/src/hooks/use_post_text_sections.ts
+++ b/front_end/src/hooks/use_post_text_sections.ts
@@ -6,31 +6,38 @@ export type PostTextSection = { title: string; markdown: string };
 
 export function usePostTextSections(
   post: PostWithForecasts,
-  { excludeFinePrint = false } = {}
+  {
+    excludeFinePrint = false,
+    excludeResolutionCriteria = false,
+  }: { excludeFinePrint?: boolean; excludeResolutionCriteria?: boolean } = {}
 ): PostTextSection[] {
   const t = useTranslations();
 
   if (post.conditional) {
     const { condition, condition_child } = post.conditional;
     const sections: PostTextSection[] = [];
-    if (condition.resolution_criteria)
+    if (!excludeResolutionCriteria && condition.resolution_criteria)
       sections.push({
         title: t("parentResolutionCriteria"),
         markdown: condition.resolution_criteria,
       });
-    if (!excludeFinePrint && condition.fine_print)
+    if (!excludeResolutionCriteria && !excludeFinePrint && condition.fine_print)
       sections.push({ title: t("finePrint"), markdown: condition.fine_print });
     if (condition.description)
       sections.push({
         title: t("parentBackgroundInfo"),
         markdown: condition.description,
       });
-    if (condition_child.resolution_criteria)
+    if (!excludeResolutionCriteria && condition_child.resolution_criteria)
       sections.push({
         title: t("childResolutionCriteria"),
         markdown: condition_child.resolution_criteria,
       });
-    if (!excludeFinePrint && condition_child.fine_print)
+    if (
+      !excludeResolutionCriteria &&
+      !excludeFinePrint &&
+      condition_child.fine_print
+    )
       sections.push({
         title: t("finePrint"),
         markdown: condition_child.fine_print,
@@ -53,9 +60,9 @@ export function usePostTextSections(
     post.group_of_questions?.description ?? post.question?.description ?? "";
 
   const sections: PostTextSection[] = [];
-  if (resolution)
+  if (!excludeResolutionCriteria && resolution)
     sections.push({ title: t("resolutionCriteria"), markdown: resolution });
-  if (!excludeFinePrint && finePrint)
+  if (!excludeResolutionCriteria && !excludeFinePrint && finePrint)
     sections.push({ title: t("finePrint"), markdown: finePrint });
   if (description)
     sections.push({ title: t("backgroundInfo"), markdown: description });


### PR DESCRIPTION
### Summary

This PR addresses a batch of QA-reported issues on the question page redesign across forecaster and consumer views.

Implemented:

- **Meta row truncation** (`meta_row.tsx`): always shows `default_project` as the single visible chip; remaining projects collapsed under "{n} more…"
- **Conditional question timeline** (`question_page_shell`, `timeline/index.tsx`): forecaster and consumer shells now render `ConditionalTimeline` for conditional posts
- **Overlay height clamping** (`use_overlay_max_height.ts`, forecast cards): new hook caps expanded overlay to viewport bottom; content scrollable with fade gradient, collapse button always pinned visible
- **Chart height sync** (`consumer_list_chart_shell`, chart components): list column height propagated via context as `chartAreaHeight`; charts dynamically fill available space, scaling down between 1024–1280 px
- **Key factor count fix** (`tab_bar.tsx`): tab badge now includes `aggregateCoherenceLinks` count alongside `key_factors`
- **Resolution criteria drawer** (`question_page_shell`, `use_post_text_sections`): fine print stays inside the resolution criteria drawer in forecaster mode, matching prod behaviour
- **Key factor placeholder** (`key_factors_grid_placeholder`): 50% opacity by default, full opacity + border on hover; always shows "+ Add Key Factor"; triggers login modal for unauthenticated users
- **Chip fixes** (`compact_legend_bar`): max-width widened to 300 px; full chip click toggles visibility; resolved winner shows `(Yes)` instead of forecast %; `showAll` orders winner first
- **Hover stuck-state** (`compact_legend_bar`): removed `item.highlighted` from chip className, CSS `hover:` handles visual state, eliminating stuck-highlight race condition
- **Continuous group legend** (multiple_choices_chart_view): added compact legend bar above the chart for Numeric, Discrete, and Date group questions

### Demo videos

- Let’s update truncation to prioritize showing the main project fully, grouping the others under “more”

https://github.com/user-attachments/assets/90308081-ce8a-44b6-8625-cb8e296f1abc

- Forecast Timeline section in Conditional Question pages

<img width="1334" height="773" alt="image" src="https://github.com/user-attachments/assets/54d246c9-dc91-4b16-9860-194986055797" />

- The expandable section

https://github.com/user-attachments/assets/b84299f5-d9cd-4f04-b6d4-859726b10eaa

- Between 1024px and 1280px, the left pane scales down to make room for the right pane

https://github.com/user-attachments/assets/42a4d005-f8c3-443f-bedf-7179c0e93262

- Charts dynamically fill the available height of the container they’re in

https://github.com/user-attachments/assets/59ee7dac-b099-46f9-8a30-270641b28d16

- The key factor count displays the correct count

https://github.com/user-attachments/assets/576cbf08-d8c2-45c6-a53c-e151087e733d

- Updated the placeholder box for key factors

https://github.com/user-attachments/assets/b40d0e1d-51bc-4bf3-b692-e26f6da2ac1f

- Fine Print is part of the Resolution Criteria drawer in forecaster Mode

https://github.com/user-attachments/assets/f5d1ac91-835f-4678-9c19-147546a0f7d4

- Improved multiple-choice in forecaster UX & Hover Fixes

https://github.com/user-attachments/assets/2523acee-d4e5-414d-ad12-526e73ff6526

- Show winning option label instead

https://github.com/user-attachments/assets/ab205613-6cfd-4f35-8ec3-e09182b08c99

- Compact legend in Binary, MC, and Continuous groups (numeric, date, discrete), respectively

https://github.com/user-attachments/assets/8113ba70-e554-4bcb-9770-38d0518a7cc1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resolution Criteria section now displays on question pages
  * Conditional posts show timeline visualization
  * Key factors count includes linked questions

* **Bug Fixes & UI/UX Improvements**
  * Resolved YES/NO items now visually distinguished in charts
  * Project chips prioritize default project display
  * Expanded forecast cards become scrollable with improved height constraints
  * Key factor placeholder button interactions refined
  * Question page layout and height calculations improved across multiple components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->