### PR TITLE
fix: labor hub commentary — correct weekly hours forecast (four → three hours)

### DIFF
--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -198,7 +198,7 @@ export default function LaborAutomationHubPage() {
               </span>
               , <strong>median wages are expected to grow.</strong> The workweek
               is also expected to become{" "}
-              <strong>about four hours shorter by 2035</strong> among all
+              <strong>about three hours shorter by 2035</strong> among all
               workers, while productivity grows.
             </ContentParagraph>
             <ContentParagraph>

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-05-16">May 16</time>
+              Commentary last updated: <time dateTime="2026-05-23">May 23</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated commentary QA run on https://www.metaculus.com/labor-hub detected one misalignment between chart forecast data and commentary text.

## Fixes

### Wages / Hours section

**Old text:** "The workweek is also expected to become **about four hours shorter by 2035** among all workers, while productivity grows."

**Chart data:**
- 2025 baseline (historical): 38.3 hours/week
- 2035 forecast: 35.2 hours/week
- Difference: **3.1 hours** (~3 hours shorter, not 4)

**New text:** "The workweek is also expected to become **about three hours shorter by 2035** among all workers, while productivity grows."

Also updated `Commentary last updated` date from May 16 → May 23.

## Test plan
- [ ] Verify the Wages section on `/labor-hub` reads "about three hours shorter by 2035"
- [ ] Verify commentary last updated shows "May 23"

https://claude.ai/code/session_014pA5vkGiu99jkEC5MwVBLY

---
_Generated by [Claude Code](https://claude.ai/code/session_014pA5vkGiu99jkEC5MwVBLY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated wages forecast narrative with revised workweek reduction estimate.
  * Updated commentary timestamp to May 23.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4775?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->