### PR TITLE
Set Neon role for PR previews

### DIFF
--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -250,6 +250,7 @@ jobs:
           project_id: ${{ secrets.NEON_PROJECT_ID }}
           branch: ${{ needs.setup.outputs.neon_branch }}
           cs_role_name: neondb_owner
+          cs_database: neondb
           parent: true
           api_key: ${{ secrets.NEON_API_KEY }}
 

--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -249,6 +249,7 @@ jobs:
         with:
           project_id: ${{ secrets.NEON_PROJECT_ID }}
           branch: ${{ needs.setup.outputs.neon_branch }}
+          cs_role_name: neondb_owner
           parent: true
           api_key: ${{ secrets.NEON_API_KEY }}
 
@@ -302,7 +303,7 @@ jobs:
           fi
 
           # Define app URLs (used for secrets and outputs)
-          APP_DOMAIN="${APP_NAME}-preview.mtcl.cc" 
+          APP_DOMAIN="${APP_NAME}-preview.mtcl.cc"
           PUBLIC_APP_URL="https://${APP_DOMAIN}"
 
           # Set all secrets and environment variables for the app


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD preview workflow updated to supply a role name for the database branch reset step.
  * Fly deployment step environment assignment cleaned up to remove an extraneous trailing whitespace in the app domain.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->