### PR TITLE
Emails: accounts domain 10% rollout

### DIFF
--- a/utils/email.py
+++ b/utils/email.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 # Sending-domain warm-up ramp, per stream: the percentage (0-100) of recipients
 # routed to the new domain. Advance the warm-up by bumping these in code.
 NOTIFICATIONS_DOMAIN_RAMP_PCT = 10
-ACCOUNTS_DOMAIN_RAMP_PCT = 0
+ACCOUNTS_DOMAIN_RAMP_PCT = 10
 # @metaculus.com staff dogfood the new domain at these splits, independent of
 # the public ramp above, so the team sees the new domain early.
 INTERNAL_RAMP_PCT = 50


### PR DESCRIPTION
Since the warmup strategy with `notifications.metaculus.com` is going well (only 3% bounces across 3k deliveries), I suggest we start a 10% rollout of `accounts.metaculus.com` for account-related notifications

closes #4769 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated email routing configuration to adjust account recipient handling during the warm-up phase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4780?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->