### PR TITLE
Job compute movement: deadlock fix

### DIFF
--- a/misc/management/commands/cron.py
+++ b/misc/management/commands/cron.py
@@ -93,7 +93,9 @@ class Command(BaseCommand):
         #
         scheduler.add_job(
             close_old_connections(job_compute_movement.send),
-            trigger=CronTrigger.from_crontab("0 * * * *"),  # Every Hour
+            trigger=CronTrigger.from_crontab(
+                "7 * * * *"
+            ),  # Every hour at :07 (offset from :00/:15/:30/:45 hotness job to avoid posts_post deadlocks)
             id="posts_job_compute_movement",
             max_instances=1,
             replace_existing=True,


### PR DESCRIPTION
Changed `job_compute_movement` to not overlap with hotness job

Fixes https://metaculus.sentry.io/issues/6844039171/?environment=prod&project=4507883238129664&query=is%3Aunresolved&referrer=issue-stream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the execution schedule for a background maintenance job to optimize system performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->