### PR TITLE
Improve async server component error boundary observability

### DIFF
--- a/front_end/src/components/server_component_error_boundary.tsx
+++ b/front_end/src/components/server_component_error_boundary.tsx
@@ -7,7 +7,7 @@ import RefreshButton from "./refresh_button";
 export default function WithServerComponentErrorBoundary<P extends object>(
   Component: FC<P>
 ): FC<P> {
-  const WrappedComponent = (async (props: P) => {
+  async function WrappedComponent(props: P) {
     try {
       return await Component(props);
     } catch (error: unknown) {
@@ -45,7 +45,11 @@ export default function WithServerComponentErrorBoundary<P extends object>(
         </div>
       );
     }
-  }) as unknown as FC<P>;
+  }
 
-  return WrappedComponent;
+  WrappedComponent.displayName = `WithServerComponentErrorBoundary(${
+    Component.displayName || Component.name || "Unknown"
+  })`;
+
+  return WrappedComponent as unknown as FC<P>;
 }


### PR DESCRIPTION
### Summary

Improve debuggability of the "An unknown Component is an async Client Component" error on `/questions/` by adding a name and `displayName` to the wrapped component in `WithServerComponentErrorBoundary`.

https://metaculus.sentry.io/issues/7506504062/?alert_rule_id=16645909&alert_type=issue&environment=prod&project=4507883273125888

Implemented:

- **Problem**: `WithServerComponentErrorBoundary` returned an anonymous async arrow function `(async (props) => {...}) as unknown as FC<P>` – in production builds the minifier strips the inferred variable name, leaving `Function.name === ""`. When this error occurs in Sentry it reports "unknown Component", making it impossible to identify which of the 18 wrapped components triggered it
- **Improvement** (`server_component_error_boundary.tsx`): replaced the anonymous IIFE with a named `async function WrappedComponent` declaration (name survives minification) and added `displayName = WithServerComponentErrorBoundary(${Component.name})` so that if the error recurs, Sentry reports the exact wrapped component name (e.g. `WithServerComponentErrorBoundary(AwaitedPostsFeed)`) instead of "unknown"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal error boundary component structure for improved code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4782?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->