### PR TITLE
fix: labor hub commentary - state-level technology sector forecast description

### DIFF
--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -753,10 +753,11 @@ export default function LaborAutomationHubPage() {
             <ContentParagraph>
               The healthcare sector (employing 13% of Washington residents) is
               forecasted to grow through 2027, largely unaffected by AI in this
-              timeframe. Technology and aerospace (employing 10% and 2%
-              respectively) are expected to see minor growth in the short-term,
-              largely consistent with historical trends. These forecasts are
-              short-term, leading to minimal predicted change.
+              timeframe. Aerospace (employing 2% of Washington workers) is
+              expected to see minor growth in the short-term, while technology
+              (employing 10%) is expected to see a slight decline, both largely
+              consistent with historical trends. These forecasts are short-term,
+              leading to minimal predicted change.
             </ContentParagraph>
           </DualPaneSectionLeft>
           <DualPaneSectionRight className="lg:mt-16 print:mt-12">

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-05-23">May 23</time>
+              Commentary last updated: <time dateTime="2026-05-27">May 27</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Misalignment Fixed

### State-Level View

**Old commentary:**
> Technology and aerospace (employing 10% and 2% respectively) are expected to see minor growth in the short-term, largely consistent with historical trends.

**Chart/table data that contradicts it:**
- Aerospace Sector 2027: **+0.9%** (growth ✓)
- Technology Sector 2027: **−0.1%** (slight decline ✗ — contradicts "minor growth")

**What it now says:**
> Aerospace (employing 2% of Washington workers) is expected to see minor growth in the short-term, while technology (employing 10%) is expected to see a slight decline, both largely consistent with historical trends.

---

Also updated **Commentary last updated** date from May 23 → May 27.

---

*Automated commentary QA run: 2026-05-27*

https://claude.ai/code/session_01Lry5xMD2KG7FpM3bCYDr52

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lry5xMD2KG7FpM3bCYDr52)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sector expectations to distinguish between aerospace and technology short-term growth forecasts for Washington state.
  * Updated the "Commentary last updated" timestamp to May 27.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->