### PR TITLE
Fix Metaculus community tag and unify legend max items

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
@@ -2,14 +2,13 @@
 import { useTranslations } from "next-intl";
 import { FC, useState } from "react";
 
-import { useBreakpoint } from "@/hooks/tailwind";
 import { ChoiceItem } from "@/types/choices";
 import { QuestionType } from "@/types/question";
 import cn from "@/utils/core/cn";
 import { getForecastPctDisplayValue } from "@/utils/formatters/prediction";
 import { isUnsuccessfullyResolved } from "@/utils/questions/resolution";
 
-const MOBILE_MAX_ITEMS = 5;
+const MAX_ITEMS = 5;
 
 type Props = {
   items: ChoiceItem[];
@@ -58,12 +57,8 @@ const CompactLegendBar: FC<Props> = ({
   onChoiceHighlight,
 }) => {
   const t = useTranslations();
-  const isMd = useBreakpoint("md");
   const [showAll, setShowAll] = useState(false);
 
-  const resolvedNoCount = items.filter((item) =>
-    isResolvedNo(item, questionType)
-  ).length;
   const normalItems = items.filter((item) => !isResolvedNo(item, questionType));
 
   let visibleItems: ChoiceItem[];
@@ -75,15 +70,10 @@ const CompactLegendBar: FC<Props> = ({
     );
     visibleItems = [...normalItems, ...resolvedNoItems];
     hiddenCount = 0;
-  } else if (!isMd) {
-    // Mobile: show up to MOBILE_MAX_ITEMS normal items only; resolved-NO always hidden
-    const mobileVisible = normalItems.slice(0, MOBILE_MAX_ITEMS);
-    visibleItems = mobileVisible;
-    hiddenCount = items.length - mobileVisible.length;
   } else {
-    // Desktop: show all normal items; resolved-NO hidden
-    visibleItems = normalItems;
-    hiddenCount = resolvedNoCount;
+    const visible = normalItems.slice(0, MAX_ITEMS);
+    visibleItems = visible;
+    hiddenCount = items.length - visible.length;
   }
 
   return (

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
@@ -15,7 +15,7 @@ import Button from "@/components/ui/button";
 import Chip from "@/components/ui/chip";
 import useContainerSize from "@/hooks/use_container_size";
 import { PostWithForecasts } from "@/types/post";
-import { Project } from "@/types/projects";
+import { Project, TournamentType } from "@/types/projects";
 import { sendAnalyticsEvent } from "@/utils/analytics";
 import cn from "@/utils/core/cn";
 import { getPostLink, getProjectLink } from "@/utils/navigation";
@@ -48,6 +48,7 @@ const MetaRow: FC<Props> = ({ post, className, variant }) => {
         ...(projectsData.leaderboard_tag ?? []),
       ].filter(
         (project, index, arr) =>
+          project.type !== TournamentType.SiteMain &&
           arr.findIndex((candidate) => candidate.id === project.id) === index
       )
     : [];


### PR DESCRIPTION
Resolves #4788

### Summary

This PR fixes two issues related to the "Metaculus Community" tag, and unifies the visible items limit in the multiple choice chart legend

Implemented changes:

- **Metaculus Community tag (`meta_row.tsx`)**: filtered out `SiteMain` projects from the question chips list – the tag was not useful and clicking it led to a 404.
- **`CompactLegendBar`**: replaced the duplicate `MOBILE_MAX_ITEMS` / `DESKTOP_MAX_ITEMS` constants (both `5`) with a single `MAX_ITEMS` constant

### Demo video

https://github.com/user-attachments/assets/213f2aeb-ce56-4511-b0ce-300be8cab221



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Question metadata now correctly excludes specific project categories from display
* **Refactor**
  * Multiple choice charts simplified for consistent behavior, displaying a fixed number of choices initially with expanded options available on demand

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->