### PR TITLE
fix: labor hub commentary misalignments (jobs order, workweek, tech sector)

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -34,8 +34,8 @@ export const JOBS_INSIGHTS = {
   "2035": {
     positive: (
       <>
-        By 2035, <strong>nurses</strong>, <strong>law enforcement</strong>, and{" "}
-        <strong>restaurant workers</strong> are expected to see the highest
+        By 2035, <strong>nurses</strong>, <strong>restaurant workers</strong>,
+        and <strong>law enforcement</strong> are expected to see the highest
         growth, driven by hands-on needs that cannot be easily automated.
       </>
     ),

--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -198,7 +198,7 @@ export default function LaborAutomationHubPage() {
               </span>
               , <strong>median wages are expected to grow.</strong> The workweek
               is also expected to become{" "}
-              <strong>about three hours shorter by 2035</strong> among all
+              <strong>about two hours shorter by 2035</strong> among all
               workers, while productivity grows.
             </ContentParagraph>
             <ContentParagraph>
@@ -755,7 +755,7 @@ export default function LaborAutomationHubPage() {
               forecasted to grow through 2027, largely unaffected by AI in this
               timeframe. Aerospace (employing 2%) is expected to see minor
               growth in the short-term, while technology (employing 10%) is
-              expected to see a marginal decline, largely consistent with
+              expected to see marginal growth, largely consistent with
               historical trends. These forecasts are short-term, leading to
               minimal predicted change.
             </ContentParagraph>

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-05-28">May 28</time>
+              Commentary last updated: <time dateTime="2026-05-29">May 29</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated commentary QA pass against live chart data found three forecast-data misalignments. All fixes are copy-only — no chart data, no component structure, no logic changed.

## Fixes

### 1 · Jobs Monitor — highest-growth occupation ordering
**Section:** Jobs Monitor (2035 commentary)
**Old:** "By 2035, nurses, **law enforcement**, and **restaurant workers** are expected to see the highest growth…"
**Data:** Restaurant Servers **+6.7%** > Law Enforcement **+6.5%** by 2035
**New:** "By 2035, nurses, **restaurant workers**, and **law enforcement** are expected to see the highest growth…"
**File:** `front_end/src/app/(main)/labor-hub/jobs_insights.tsx`

---

### 2 · Wages — workweek reduction magnitude
**Section:** Hours, Pay, and Financial Well-Being
**Old:** "The workweek is also expected to become **about three hours shorter by 2035**"
**Data:** 38.3 h (2025) → 36.1 h (2035) = **2.2 h decline**
**New:** "The workweek is also expected to become **about two hours shorter by 2035**"
**File:** `front_end/src/app/(main)/labor-hub/page.tsx`

---

### 3 · State-Level View — Washington technology sector direction
**Section:** State-Level View
**Old:** "technology (employing 10%) is expected to see a **marginal decline**"
**Data:** Technology Sector 2027 = **+0.1%** (marginal growth)
**New:** "technology (employing 10%) is expected to see **marginal growth**"
**File:** `front_end/src/app/(main)/labor-hub/page.tsx`

---

Commentary last updated date bumped to May 29.

https://claude.ai/code/session_01SvSWxpUpEN93GSrKK8JmZ3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvSWxpUpEN93GSrKK8JmZ3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Revised 2035 labor market projections on Labor Hub: workweek expected to be about two hours shorter (previously three), and technology sector forecast updated to marginal growth.
  * Reordered highlighted occupations in job insights narrative.
  * Updated commentary timestamp to May 29.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->