### PR TITLE
Fix prevent labels overflow in top comments question preview card

### DIFF
--- a/front_end/src/app/(main)/questions/components/forecaster_counter.tsx
+++ b/front_end/src/app/(main)/questions/components/forecaster_counter.tsx
@@ -37,7 +37,7 @@ const ForecastersCounter: FC<Props> = ({
   return (
     <div
       className={cn(
-        "flex flex-row items-center gap-1.5 truncate px-1.5 text-justify text-sm font-normal leading-4 text-gray-700 dark:text-gray-700-dark md:gap-2",
+        "flex min-w-0 flex-row items-center gap-1.5 truncate px-1.5 text-justify text-sm font-normal leading-4 text-gray-700 dark:text-gray-700-dark md:gap-2",
         className
       )}
     >

--- a/front_end/src/components/comment_feed/comment_post_preview/compact_comment_post_card.tsx
+++ b/front_end/src/components/comment_feed/comment_post_preview/compact_comment_post_card.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/utils/questions/helpers";
 
 const VISIBLE_CHOICES_COUNT = 3;
+const COMPACT_STATS_THRESHOLD = 1000;
 
 type Props = {
   post: PostWithForecasts;
@@ -35,6 +36,10 @@ const CompactCommentPostCard: FC<Props> = ({ post, className }) => {
   const t = useTranslations();
   const locale = useLocale();
 
+  const compactStats =
+    (post.comment_count ?? 0) >= COMPACT_STATS_THRESHOLD &&
+    (post.nr_forecasters ?? 0) >= COMPACT_STATS_THRESHOLD;
+
   return (
     <div
       className={cn(
@@ -42,16 +47,23 @@ const CompactCommentPostCard: FC<Props> = ({ post, className }) => {
         className
       )}
     >
-      <div className="flex items-center gap-2">
+      <div
+        className={cn(
+          "flex flex-wrap items-center gap-2",
+          compactStats && "justify-center"
+        )}
+      >
         <CommentStatus
           totalCount={post.comment_count ?? 0}
           unreadCount={0}
           url={getPostLink(post)}
           variant="gray"
+          compact={compactStats}
           className="pl-0 md:pl-0"
         />
         <ForecastersCounter
           forecasters={post.nr_forecasters}
+          compact={compactStats}
           className="px-0 md:px-0"
         />
       </div>

--- a/front_end/src/components/weekly_top_comments_feed/components/highlighted_comment_card.tsx
+++ b/front_end/src/components/weekly_top_comments_feed/components/highlighted_comment_card.tsx
@@ -130,7 +130,7 @@ const HighlightedCommentCard: FC<Props> = ({
         {comment.on_post_data && (
           <div
             className={cn(
-              "hidden items-start rounded-l border border-blue-500 dark:border-blue-500-dark md:flex md:w-[280px] md:shrink-0",
+              "hidden items-start overflow-hidden rounded-l border border-blue-500 dark:border-blue-500-dark md:flex md:w-[325px] md:shrink-0",
               placement === 1
                 ? "border-r-yellow-500 dark:border-r-yellow-500/40"
                 : "border-r-blue-400 dark:border-r-blue-400-dark"
@@ -140,6 +140,7 @@ const HighlightedCommentCard: FC<Props> = ({
               post={post}
               postTitle={comment.on_post_data.title}
               postId={comment.on_post_data.id}
+              className="w-full"
             />
           </div>
         )}


### PR DESCRIPTION
Resolves #4789 

### Summary

Stats labels ("N comments", "N forecasters") in the top comments question preview card could overflow and shift the layout when counts were large.

Implemented changes:

- **`highlighted_comment_card`**: widened left column to 325px, added `overflow-hidden` to strictly clip content within bounds, and passed `w-full` to `CommentPostPreview` so the card fills its parent instead of sizing to content.
- **`compact_comment_post_card`**: added `flex-wrap` to the stats row so labels fall to the next line instead of overflowing; when both comment and forecaster counts are ≥ 1000, both labels switch to compact mode (icon + number only) and center-align to keep the row tidy.
- **`forecaster_counter`**: added `min-w-0` to the root div so the existing `truncate` class can correctly clip the element when used inside a flex row.

### Demo video

https://github.com/user-attachments/assets/4434ca2d-ec66-44f5-b481-e56f8f6a36a0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout and spacing in comment card displays
  * Enhanced visual presentation of forecaster counters and comment statistics
  * Optimized responsive design for comment preview areas with better width management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4796?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->