### PR TITLE
Remove Kelley Edelmann from about page

### DIFF
--- a/front_end/src/app/(main)/about/components/TeamBlock.tsx
+++ b/front_end/src/app/(main)/about/components/TeamBlock.tsx
@@ -331,13 +331,6 @@ const people: Person[] = [
       "Seth Killian was a graduate fellow at the UIUC Center for Advanced Study teaching philosophy when he was recruited by Capcom into game development. As a designer and founder, he helped revive the Street Fighter series with Street Fighter IV, co-founded the first team acquired by Riot Games, served as lead designer on Fortnite, and as Head of Game Design for Netflix. As a player and organizer, he played on the first US National Street Fighter team, hosted the first fighting game broadcast on ESPN, and co-founded the Evo Championship Series, which has grown to become the largest live gaming competition in the world.",
   },
   {
-    name: "Kelley Edelmann",
-    position: "Head of Consulting Services",
-    imgSrc: "https://cdn.metaculus.com/Kelley.webp",
-    introduction:
-      "Kelley leads Consulting Services at Metaculus, partnering with organizations to translate complex forecasting data into actionable insights that inform high-stakes decisions. She brings nearly two decades of consulting experience in the market research industry, most recently as a strategist at Ipsos. Kelley has led global engagements for Fortune 100 companies across technology, healthcare, and consumer packaged goods sectors, delivering insight that shapes C-suite strategy. Her experience spans B2B and B2C contexts worldwide, applying mixed methodologies with analytical rigor and human empathy to drive meaningful impact.",
-  },
-  {
     name: "Grace McLain",
     position: "Project Delivery Associate",
     imgSrc: "https://cdn.metaculus.com/Grace.webp",
@@ -379,7 +372,6 @@ const groups: Groups = {
     "John Bash",
     "Felipe Oliveira",
     "Cemre Inanc",
-    "Kelley Edelmann",
     "Grace McLain",
     "Jesse Damiani",
     "Carolin Ullrich",


### PR DESCRIPTION
## Summary
- Removes Kelley Edelmann from the team listing on the about page following her departure.
- Deletes the person object in the `people` array and the name reference in the `team` group in `TeamBlock.tsx`.

## Test plan
- [ ] Confirm Kelley no longer appears on `/about` in preview deploy
- [ ] Confirm no other team members are visually affected (order, layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated team member information displayed in the team modal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4798?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->