### PR TITLE
Update Metaculus Data Needs Form links on API page

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -33,19 +33,19 @@ info:
     <h4>Bot Benchmarking Access Tier</h4>
     <p>
     An additional access tier is available for AI forecasting bot developers. This tier grants current Community Prediction, question text, and resolution access on a larger set of ~250 open questions and ~250 resolved questions, intended for training and evaluation purposes.
-    To request access, please fill out this form: <a href="https://docs.google.com/forms/d/e/1FAIpQLSeJhtZzHl5qMvBjbXbatyaqoS4IU7RE0GGw_vlhs6I9syqn1g/viewform?usp=dialog">Metaculus Data Needs Form</a>.
+    To request access, please fill out this form: <a href="https://docs.google.com/forms/d/e/1FAIpQLSeJhtZzHl5qMvBjbXbatyaqoS4IU7RE0GGw_vlhs6I9syqn1g/viewform?usp=pp_url&amp;entry.192763438=https://www.metaculus.com/api/">Metaculus Data Needs Form</a>.
     </p>
 
     <h4>Commercial API or Data Access</h4>
     <p>
     For commercial use inquiries, please submit our data request form with details about your data needs and intended use case. A member of our team will follow up soon.
-    <a href="https://docs.google.com/forms/d/e/1FAIpQLSeJhtZzHl5qMvBjbXbatyaqoS4IU7RE0GGw_vlhs6I9syqn1g/viewform?usp=dialog">Metaculus Data Needs Form</a>
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSeJhtZzHl5qMvBjbXbatyaqoS4IU7RE0GGw_vlhs6I9syqn1g/viewform?usp=pp_url&amp;entry.192763438=https://www.metaculus.com/api/">Metaculus Data Needs Form</a>
     </p>
 
     <h4>Non-commercial API or Data Access</h4>
     <p>
     If you want to make non-commercial use of Metaculus data (for academic or private research, hobbyist, etc.), please fill out our form &mdash; we generally support research efforts, and sometimes support exciting hobbyist projects.
-    <a href="https://docs.google.com/forms/d/e/1FAIpQLSeJhtZzHl5qMvBjbXbatyaqoS4IU7RE0GGw_vlhs6I9syqn1g/viewform?usp=dialog">Metaculus Data Needs Form</a>
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSeJhtZzHl5qMvBjbXbatyaqoS4IU7RE0GGw_vlhs6I9syqn1g/viewform?usp=pp_url&amp;entry.192763438=https://www.metaculus.com/api/">Metaculus Data Needs Form</a>
     </p>
 
     <h4>Questions or Feedback</h4>
@@ -2049,7 +2049,7 @@ paths:
         Downloads question data, forecast data, and optionally comments, scores, and key factors as a Zip file of CSVs.
         You must provide at least one of `post_id`, `question_id`, or `project_id` to specify the data to download.
 
-        **Note:** This is a restricted endpoint. To request access, please fill out the [Metaculus Data Needs Form](https://docs.google.com/forms/d/e/1FAIpQLSeJhtZzHl5qMvBjbXbatyaqoS4IU7RE0GGw_vlhs6I9syqn1g/viewform?usp=dialog). For questions or feedback, contact [api-requests@metaculus.com](mailto:api-requests@metaculus.com). Additionally, the `project_id` parameter is only accepted if your account has been whitelisted for that specific project, to prevent heavy data requests.
+        **Note:** This is a restricted endpoint. To request access, please fill out the [Metaculus Data Needs Form](https://docs.google.com/forms/d/e/1FAIpQLSeJhtZzHl5qMvBjbXbatyaqoS4IU7RE0GGw_vlhs6I9syqn1g/viewform?usp=pp_url&amp;entry.192763438=https://www.metaculus.com/api/). For questions or feedback, contact [api-requests@metaculus.com](mailto:api-requests@metaculus.com). Additionally, the `project_id` parameter is only accepted if your account has been whitelisted for that specific project, to prevent heavy data requests.
 
         This endpoint may time out for large data exports. If your download fails due to a timeout, use the `/api/data/email/` endpoint instead, which processes the export asynchronously.
       tags:
@@ -2146,7 +2146,7 @@ paths:
         Useful for large data exports that may time out with a direct download. Accepts the same parameters as `/api/data/download/`.
         You must provide at least one of `post_id`, `question_id`, or `project_id`.
 
-        **Note:** This is a restricted endpoint. To request access, please fill out the [Metaculus Data Needs Form](https://docs.google.com/forms/d/e/1FAIpQLSeJhtZzHl5qMvBjbXbatyaqoS4IU7RE0GGw_vlhs6I9syqn1g/viewform?usp=dialog). For questions or feedback, contact [api-requests@metaculus.com](mailto:api-requests@metaculus.com). Additionally, the `project_id` parameter is only accepted if your account has been whitelisted for that specific project.
+        **Note:** This is a restricted endpoint. To request access, please fill out the [Metaculus Data Needs Form](https://docs.google.com/forms/d/e/1FAIpQLSeJhtZzHl5qMvBjbXbatyaqoS4IU7RE0GGw_vlhs6I9syqn1g/viewform?usp=pp_url&amp;entry.192763438=https://www.metaculus.com/api/). For questions or feedback, contact [api-requests@metaculus.com](mailto:api-requests@metaculus.com). Additionally, the `project_id` parameter is only accepted if your account has been whitelisted for that specific project.
 
         The email attachment has a size limit of 25 MB. If your export exceeds this limit, try removing `include_comments` to reduce the file size.
       tags:


### PR DESCRIPTION
Updates all Metaculus Data Needs Form links in `docs/openapi.yml` (rendered on `/api/` via Swagger UI) to prefill the form's Page entry with `https://www.metaculus.com/api/`.

Closes #4799

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API endpoint documentation with clarified restricted access information
  * Added contact details for API access requests
  * Updated reference links in API access tier sections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Metaculus/metaculus/pull/4800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->