### PR TITLE
fix: labor hub commentary — jobs monitor 2035 occupation ordering

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -34,8 +34,8 @@ export const JOBS_INSIGHTS = {
   "2035": {
     positive: (
       <>
-        By 2035, <strong>nurses</strong>, <strong>law enforcement</strong>, and{" "}
-        <strong>restaurant workers</strong> are expected to see the highest
+        By 2035, <strong>nurses</strong>, <strong>restaurant workers</strong>,
+        and <strong>law enforcement</strong> are expected to see the highest
         growth, driven by hands-on needs that cannot be easily automated.
       </>
     ),

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-05-28">May 28</time>
+              Commentary last updated: <time dateTime="2026-06-01">Jun 1</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated commentary QA pass (2026-06-01) against live chart data found one forecast-data misalignment. Fix is copy-only — no chart data, no component structure, no logic changed.

Supersedes PR #4802 (closed), which was on a different branch. The two other fixes in that PR are no longer applicable: forecast values have shifted since 2026-05-31, making the "workweek hours" and "degrees characterization" fixes incorrect relative to current data.

## Fix

### Jobs Monitor — highest-growth occupation ordering (2035)

**Section:** Jobs Monitor (2035 commentary)

**Old:** "By 2035, nurses, **law enforcement**, and **restaurant workers** are expected to see the highest growth"

**Chart data:** Restaurant Servers **+8.1%** > Law Enforcement **+7.5%** by 2035

**New:** "By 2035, nurses, **restaurant workers**, and **law enforcement** are expected to see the highest growth"

**File:** `front_end/src/app/(main)/labor-hub/jobs_insights.tsx`

---

Commentary last updated date bumped to Jun 1.

https://claude.ai/code/session_01CbnWSAqYLZ4LsEuRmKqQaH

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbnWSAqYLZ4LsEuRmKqQaH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Content Updates**
  * Updated job market insights narrative for 2035 projections, reorganizing highlighted employment sectors including healthcare, food service, and law enforcement roles.
  * Refreshed the commentary last updated timestamp to June 1, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->