### PR TITLE
Fix/time travel resolved questions

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
@@ -99,7 +99,7 @@ const QuestionHeaderCPStatus: FC<Props> = ({
     return data;
   }, [cursorForecastValues, cursorUserForecastValues, question.status]);
 
-  if (question.status === QuestionStatus.RESOLVED && question.resolution) {
+  if (question.status === QuestionStatus.RESOLVED && question.resolution && (!isContinuous || !cursorForecast)) {
     // Resolved/Annulled/Ambiguous
     const formatedResolution = formatResolution({
       resolution: question.resolution,

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
@@ -99,7 +99,11 @@ const QuestionHeaderCPStatus: FC<Props> = ({
     return data;
   }, [cursorForecastValues, cursorUserForecastValues, question.status]);
 
-  if (question.status === QuestionStatus.RESOLVED && question.resolution && (!isContinuous || !cursorForecast)) {
+  if (
+    question.status === QuestionStatus.RESOLVED &&
+    question.resolution &&
+    (!isContinuous || !cursorForecast)
+  ) {
     // Resolved/Annulled/Ambiguous
     const formatedResolution = formatResolution({
       resolution: question.resolution,

--- a/front_end/src/components/charts/numeric_chart.tsx
+++ b/front_end/src/components/charts/numeric_chart.tsx
@@ -22,7 +22,6 @@ import {
   VictoryLabel,
   VictoryLabelProps,
   VictoryLine,
-  VictoryPortal,
   VictoryScatter,
   VictoryThemeDefinition,
 } from "victory";
@@ -43,7 +42,6 @@ import {
   CHART_FONT_STYLE,
 } from "@/constants/chart_typography";
 import { METAC_COLORS } from "@/constants/colors";
-import { useBreakpoint } from "@/hooks/tailwind";
 import useAppTheme from "@/hooks/use_app_theme";
 import useChartTooltip from "@/hooks/use_chart_tooltip";
 import useContainerSize from "@/hooks/use_container_size";
@@ -71,11 +69,6 @@ import { resolveToCssColor } from "@/utils/resolve_color";
 import ForecastAvailabilityChartOverflow from "../post_card/chart_overflow";
 import ChartValueBox from "./primitives/chart_value_box";
 import ResolutionTooltip from "./primitives/resolution_tooltip";
-
-// VictoryPortal fixes SVG z-ordering but causes an infinite loop on mobile
-// (touch-move → new JSX ref → addChild → setState → re-render → repeat).
-const wrapPortal = (element: React.ReactElement, disabled: boolean) =>
-  disabled ? element : <VictoryPortal>{element}</VictoryPortal>;
 
 type ChartData = {
   line: Line;
@@ -161,7 +154,6 @@ const NumericChart: FC<Props> = ({
   const { theme, getThemeColor } = useAppTheme();
   const [isChartReady, setIsChartReady] = useState(false);
   const [zoom, setZoom] = useState(defaultZoom);
-  const isMobile = !useBreakpoint("md");
 
   const [isCursorActive, setIsCursorActive] = useState(false);
   const isContinuousConsumerView =
@@ -294,7 +286,7 @@ const NumericChart: FC<Props> = ({
           />
         )
       }
-      cursorLabelComponent={wrapPortal(
+      cursorLabelComponent={
         <ChartCursorLabel
           positionY={height - 10}
           {...(hasExternalTheme
@@ -302,9 +294,8 @@ const NumericChart: FC<Props> = ({
             : { fill: getThemeColor(METAC_COLORS.gray["700"]) })}
           style={CHART_FONT_STYLE.cursor}
           isActive={isCursorActive}
-        />,
-        isMobile
-      )}
+        />
+      }
       onCursorChange={(value: CursorCoordinatesPropType) => {
         if (typeof value === "number") {
           handleCursorChange(value);
@@ -729,7 +720,7 @@ const NumericChart: FC<Props> = ({
                         ? () => ""
                         : xScale.tickFormat
                   }
-                  tickLabelComponent={wrapPortal(
+                  tickLabelComponent={
                     <XTickLabel
                       chartWidth={chartWidth}
                       fontSize={tickLabelFontSize}
@@ -739,9 +730,8 @@ const NumericChart: FC<Props> = ({
                           fill: getThemeColor(METAC_COLORS.gray["700"]),
                         },
                       })}
-                    />,
-                    isMobile
-                  )}
+                    />
+                  }
                 />
 
                 {/* CP range */}
@@ -788,68 +778,58 @@ const NumericChart: FC<Props> = ({
                 ) : null}
 
                 {/* Prediction points */}
-                {wrapPortal(
-                  <VictoryScatter
-                    data={clampedPoints}
-                    dataComponent={
-                      <PredictionWithRange
-                        colorOverride={colorOverride ?? colorPalette.chip}
-                      />
-                    }
-                  />,
-                  isMobile
-                )}
+                <VictoryScatter
+                  data={clampedPoints}
+                  dataComponent={
+                    <PredictionWithRange
+                      colorOverride={colorOverride ?? colorPalette.chip}
+                    />
+                  }
+                />
 
                 {/* Resolution marker */}
                 {!!resolutionPoint &&
                 !isCursorActive &&
-                resolutionPlacement === "in"
-                  ? wrapPortal(
-                      <VictoryScatter
-                        data={resolutionPoint}
-                        size={() => 4}
-                        style={{
-                          data: {
-                            stroke: getThemeColor(METAC_COLORS.purple["800"]),
-                            fill: getThemeColor(METAC_COLORS.gray["0"]),
-                            strokeWidth: 2.5,
-                          },
-                        }}
-                      />,
-                      isMobile
-                    )
-                  : null}
+                resolutionPlacement === "in" ? (
+                  <VictoryScatter
+                    data={resolutionPoint}
+                    size={() => 4}
+                    style={{
+                      data: {
+                        stroke: getThemeColor(METAC_COLORS.purple["800"]),
+                        fill: getThemeColor(METAC_COLORS.gray["0"]),
+                        strokeWidth: 2.5,
+                      },
+                    }}
+                  />
+                ) : null}
 
                 {/* Cursor value chip / box */}
                 {resolutionClamped &&
                 resolutionPlacement &&
-                resolutionPlacement !== "in"
-                  ? wrapPortal(
-                      <VictoryScatter
-                        data={[
-                          {
-                            x: resolutionClamped.x,
-                            y: resolutionClamped.y,
-                            placement: resolutionPlacement,
-                            primary:
-                              colorOverride ?? METAC_COLORS.purple["800"],
-                            secondary: METAC_COLORS.purple["500"],
-                          },
-                        ]}
-                        dataComponent={
-                          <ResolutionDiamond
-                            isHovered={isDiamondActive}
-                            refProps={{
-                              ...getDiamondRefProps(),
-                              ref: diamondRefs.setReference,
-                              style: { pointerEvents: "visiblePainted" },
-                            }}
-                          />
-                        }
-                      />,
-                      isMobile
-                    )
-                  : null}
+                resolutionPlacement !== "in" ? (
+                  <VictoryScatter
+                    data={[
+                      {
+                        x: resolutionClamped.x,
+                        y: resolutionClamped.y,
+                        placement: resolutionPlacement,
+                        primary: colorOverride ?? METAC_COLORS.purple["800"],
+                        secondary: METAC_COLORS.purple["500"],
+                      },
+                    ]}
+                    dataComponent={
+                      <ResolutionDiamond
+                        isHovered={isDiamondActive}
+                        refProps={{
+                          ...getDiamondRefProps(),
+                          ref: diamondRefs.setReference,
+                          style: { pointerEvents: "visiblePainted" },
+                        }}
+                      />
+                    }
+                  />
+                ) : null}
 
                 {isCursorActive &&
                 !isNil(highlightedPoint) &&
@@ -874,7 +854,7 @@ const NumericChart: FC<Props> = ({
                 !(hideCursorValueLabel && isCursorActive) ? (
                   <VictoryScatter
                     data={[highlightedPoint]}
-                    dataComponent={wrapPortal(
+                    dataComponent={
                       useSimplifiedCursor ? (
                         <CursorChip
                           shouldRender={
@@ -896,9 +876,8 @@ const NumericChart: FC<Props> = ({
                           questionType={questionType}
                           colorOverride={colorOverride ?? colorPalette.chip}
                         />
-                      ),
-                      isMobile
-                    )}
+                      )
+                    }
                   />
                 ) : null}
               </VictoryChart>


### PR DESCRIPTION
### Summary

Fix prediction time travel on resolved continuous questions — the left panel now syncs to historical CP when hovering the timeline instead of always showing the static resolution chip. Also fixes a "Maximum update depth exceeded" crash that occurred on fast cursor movement in a resolved question.

Implemented changes:

- **`QuestionHeaderCPStatus`**: skip the resolved early-return when `cursorForecast` is active on a continuous question, letting it fall through to the existing display that already handles `overrideCenter`, `overrideBounds`, and `cursorAreaChartData`.
- **`NumericChart`**: remove all `VictoryPortal` / `wrapPortal` usage — the portal's `useEffect([props.children])` fired on every render (new JSX ref each time), triggering a "Maximum update depth exceeded" crash when hovering the timeline on resolved questions. Natural SVG paint order already ensures correct z-ordering, making the portal an unnecessary safety net.

### Demo videos

### Before

https://github.com/user-attachments/assets/a00e0f94-c25d-4a1b-94fc-cffb4c91c501

### After

https://github.com/user-attachments/assets/2d5c1233-02e8-4df8-b87b-1b8f0df13bdb



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resolved status display for continuous questions with active forecast cursors.

* **Refactoring**
  * Optimized chart overlay rendering for improved visual consistency and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->