### PR TITLE
fix: labor hub commentary — state-level tech direction & jobs monitor ordering

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -34,8 +34,8 @@ export const JOBS_INSIGHTS = {
   "2035": {
     positive: (
       <>
-        By 2035, <strong>nurses</strong>, <strong>law enforcement</strong>, and{" "}
-        <strong>restaurant workers</strong> are expected to see the highest
+        By 2035, <strong>nurses</strong>, <strong>restaurant workers</strong>,
+        and <strong>law enforcement</strong> are expected to see the highest
         growth, driven by hands-on needs that cannot be easily automated.
       </>
     ),

--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -755,7 +755,7 @@ export default function LaborAutomationHubPage() {
               forecasted to grow through 2027, largely unaffected by AI in this
               timeframe. Aerospace (employing 2%) is expected to see minor
               growth in the short-term, while technology (employing 10%) is
-              expected to see a marginal decline, largely consistent with
+              expected to see marginal growth, largely consistent with
               historical trends. These forecasts are short-term, leading to
               minimal predicted change.
             </ContentParagraph>

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-05-28">May 28</time>
+              Commentary last updated: <time dateTime="2026-06-02">Jun 2</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated commentary QA pass (2026-06-02) against live chart data found two forecast-data misalignments. Both fixes are copy-only — no chart data, no component structure, no logic changed.

Supersedes PR #4803 (closed), which was on a different branch and only addressed the jobs monitor ordering fix.

---

## Fix 1 — State-Level View: technology sector direction

**Section:** State-Level View

**Old:** "technology (employing 10%) is expected to see a marginal **decline**, largely consistent with historical trends"

**Chart data:** Technology Sector forecast for 2027 = **+0.5%** (growth, not decline)

**New:** "technology (employing 10%) is expected to see **marginal growth**, largely consistent with historical trends"

**File:** `front_end/src/app/(main)/labor-hub/page.tsx`

---

## Fix 2 — Jobs Monitor: highest-growth occupation ordering (2035)

**Section:** Jobs Monitor (2035 commentary)

**Old:** "By 2035, nurses, **law enforcement**, and **restaurant workers** are expected to see the highest growth"

**Chart data:** Restaurant Servers **+7.5%** > Law Enforcement **+6.8%** by 2035

**New:** "By 2035, nurses, **restaurant workers**, and **law enforcement** are expected to see the highest growth"

**File:** `front_end/src/app/(main)/labor-hub/jobs_insights.tsx`

---

Commentary last updated date bumped to Jun 2.

https://claude.ai/code/session_01RxbL7kXBVy7NG2T6qWDoWw

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxbL7kXBVy7NG2T6qWDoWw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed job insights content with revised information emphasis
  * Corrected Washington's technology sector forecast to reflect expected marginal growth
  * Updated commentary timestamp to June 2, 2026

<!-- end of auto-generated comment: release notes by coderabbit.ai -->