### PR TITLE
Fix: Question is overlayed on Filter dropdown

### DIFF
--- a/front_end/src/components/popover_filter/index.tsx
+++ b/front_end/src/components/popover_filter/index.tsx
@@ -55,8 +55,10 @@ const Panel: FC<PropsWithChildren<PanelProps>> = ({
       portal={usePortal}
       {...(isLargeScreen && { anchor: "bottom end" as const })}
       className={cn(
-        "z-[100] box-border flex flex-col items-start overflow-hidden overflow-y-auto rounded border border-gray-300 bg-gray-0 p-5 shadow-lg shadow-[#0003] dark:border-gray-300-dark dark:bg-gray-0-dark",
+        "box-border flex flex-col items-start overflow-hidden overflow-y-auto rounded border border-gray-300 bg-gray-0 p-5 shadow-lg shadow-[#0003] dark:border-gray-300-dark dark:bg-gray-0-dark",
+        !useFullscreen && "z-[100]",
         !usePortal && "absolute right-0 top-10",
+        isLargeScreen && "max-h-[var(--anchor-max-height)]",
         useFullscreen &&
           "!fixed !inset-0 z-[1300] h-dvh !w-screen overflow-y-auto overscroll-contain px-5 pb-0 pt-5",
         className

--- a/front_end/src/components/popover_filter/index.tsx
+++ b/front_end/src/components/popover_filter/index.tsx
@@ -45,17 +45,20 @@ const Panel: FC<PropsWithChildren<PanelProps>> = ({
     };
   }, [fullScreenEnabled, isLargeScreen, open]);
 
-  const usePortal = fullScreenEnabled && !isLargeScreen;
+  const useFullscreen = fullScreenEnabled && !isLargeScreen;
+  // Desktop always uses portal (escapes chart stacking contexts).
+  // Mobile uses portal only for fullscreen overlay; otherwise keeps original absolute positioning.
+  const usePortal = isLargeScreen || useFullscreen;
 
   return (
     <PopoverPanel
       portal={usePortal}
+      {...(isLargeScreen && { anchor: "bottom end" as const })}
       className={cn(
-        "absolute right-0 top-10 z-[100] box-border flex flex-col items-start overflow-hidden overflow-y-auto rounded border border-gray-300 bg-gray-0 p-5 shadow-lg shadow-[#0003] dark:border-gray-300-dark dark:bg-gray-0-dark",
-        {
-          "max-sm:!fixed max-sm:!inset-0 max-sm:z-[1300] max-sm:h-dvh max-sm:w-screen max-sm:overflow-y-auto max-sm:overscroll-contain max-sm:px-5 max-sm:pb-0 max-sm:pt-5":
-            fullScreenEnabled,
-        },
+        "z-[100] box-border flex flex-col items-start overflow-hidden overflow-y-auto rounded border border-gray-300 bg-gray-0 p-5 shadow-lg shadow-[#0003] dark:border-gray-300-dark dark:bg-gray-0-dark",
+        !usePortal && "absolute right-0 top-10",
+        useFullscreen &&
+          "!fixed !inset-0 z-[1300] h-dvh !w-screen overflow-y-auto overscroll-contain px-5 pb-0 pt-5",
         className
       )}
     >

--- a/front_end/src/components/posts_filters.tsx
+++ b/front_end/src/components/posts_filters.tsx
@@ -41,6 +41,7 @@ import {
   POST_WITHDRAWN_FILTER,
 } from "@/constants/posts_feed";
 import { useFeedLayout } from "@/contexts/feed_layout_context";
+import { useBreakpoint } from "@/hooks/tailwind";
 import { QuestionOrder } from "@/types/question";
 import { sendAnalyticsEvent } from "@/utils/analytics";
 import cn from "@/utils/core/cn";
@@ -105,6 +106,7 @@ const PostsFilters: FC<Props> = ({
   hideMobileActions = false,
 }) => {
   const t = useTranslations();
+  const isLargeScreen = useBreakpoint("sm");
   const { layout, setLayout } = useFeedLayout();
   const actionRailRef = useRef<HTMLDivElement>(null);
   const [actionRailWidth, setActionRailWidth] = useState(0);
@@ -355,7 +357,8 @@ const PostsFilters: FC<Props> = ({
             options={dropdownSortOptions}
             value={order || defaultOrder}
             menuPosition="right"
-            renderInPortal={variant === "mobileActions"}
+            renderInPortal
+            menuFitContent={isLargeScreen}
             preventParentScroll={variant === "mobileActions"}
             label={
               dropdownSortOptions.find((o) => o.value === order)

--- a/front_end/src/components/ui/listbox.tsx
+++ b/front_end/src/components/ui/listbox.tsx
@@ -51,6 +51,7 @@ type Props<T> = {
   renderInPortal?: boolean;
   preventParentScroll?: boolean;
   menuMinWidthMatchesButton?: boolean;
+  menuFitContent?: boolean;
   onOpenChange?: (open: boolean) => void;
 } & (SingleSelectProps<T> | MultiSelectProps<T>);
 
@@ -68,6 +69,7 @@ const Listbox = <T extends string>(props: Props<T>) => {
     renderInPortal = false,
     preventParentScroll = false,
     menuMinWidthMatchesButton = true,
+    menuFitContent = false,
   } = props;
 
   const buttonRef = useRef<HTMLButtonElement | null>(null);
@@ -165,6 +167,7 @@ const Listbox = <T extends string>(props: Props<T>) => {
               renderInPortal
               preventParentScroll={preventParentScroll}
               menuMinWidthMatchesButton={menuMinWidthMatchesButton}
+              menuFitContent={menuFitContent}
               menuPosition={menuPosition}
               optionsClassName={optionsClassName}
               buttonRef={buttonRef}
@@ -192,6 +195,7 @@ type FloatingMenuProps<T> = {
   renderInPortal: boolean;
   preventParentScroll: boolean;
   menuMinWidthMatchesButton: boolean;
+  menuFitContent: boolean;
   menuPosition?: "left" | "right";
   optionsClassName?: string;
   buttonRef: React.RefObject<HTMLButtonElement | null>;
@@ -205,6 +209,7 @@ function FloatingMenu<T extends string>({
   renderInPortal,
   preventParentScroll,
   menuMinWidthMatchesButton,
+  menuFitContent,
   menuPosition = "right",
   optionsClassName,
   buttonRef,
@@ -241,6 +246,7 @@ function FloatingMenu<T extends string>({
     <ListboxOptions
       className={cn(
         "divide-y divide-gray-300 rounded border border-gray-300 bg-gray-0 shadow-lg outline-none dark:divide-gray-300-dark dark:border-gray-300-dark dark:bg-gray-0-dark",
+        menuFitContent && "no-scrollbar",
         optionsClassName
       )}
       style={
@@ -259,8 +265,10 @@ function FloatingMenu<T extends string>({
                 : undefined,
               minWidth: menuMinWidthMatchesButton ? rect?.width : undefined,
               maxWidth: "min(420px, 100vw - 16px)",
-              maxHeight: "min(320px, 50vh)",
-              overflowY: "auto",
+              ...(!menuFitContent && {
+                maxHeight: "min(320px, 50vh)",
+                overflowY: "auto" as const,
+              }),
               zIndex: 10000,
             }
       }


### PR DESCRIPTION
Resolves #4808

### Summary

This PR fixes the filter and sort dropdowns being overlaid by question cards on desktop, making it impossible to click options.

Implemented changes:

- **`PopoverPanel` (desktop)**: filter dropdown now always renders via a portal on desktop, escaping any stacking context created by chart or card ancestors. Mobile fullscreen path is unchanged.
- **Anchor positioning**: added `anchor="bottom end"` for portal-rendered panels so the dropdown aligns correctly relative to its trigger button without absolute positioning.
- **ClassName cleanup**: separated desktop positioning (`absolute right-0 top-10`) from mobile fullscreen styles — each is now applied only when its condition is active, removing reliance on `max-sm:` overrides.
- **`Listbox` (sort dropdown)**: now always renders via a portal, escaping the same stacking context issue. On large screens (`sm` breakpoint) renders at full height; on mobile keeps `maxHeight` with scrolling enabled.
- **Scrollbar**: suppressed scrollbar track on large-screen portal-rendered listboxes where full height makes it unnecessary.

### Demo videos

#### Before


https://github.com/user-attachments/assets/d8fff0e1-f693-4dd3-bae1-968297667bbe


#### After

https://github.com/user-attachments/assets/7f4c41a4-154d-48b7-9c93-54c4184ba505



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  - Enhanced filter component responsiveness with optimized display behavior for mobile and desktop screens
  - Improved filter menu rendering, sizing, and positioning across different viewport sizes
  - Refined dropdown portal behavior for better visual presentation on all devices
<!-- end of auto-generated comment: release notes by coderabbit.ai -->