### PR TITLE
fix: labor hub commentary — correct degrees forecast description

### DIFF
--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -453,11 +453,12 @@ export default function LaborAutomationHubPage() {
               <strong>more than doubled</strong> in 2035 compared to 2025.
             </ContentParagraph>
             <ContentParagraph>
-              The number of degrees awarded overall and for STEM and humanities
-              is expected to see only minor change due to the long gestation
-              time, while trade schools and community colleges are expected to
-              see significant growth in degrees and certificates awarded by
-              2035.
+              The number of degrees awarded for STEM is expected to see only
+              minor change due to the long gestation time, while overall 4-year
+              degrees are expected to decline 3.7% and humanities degrees are
+              expected to decline 7.1% by 2035. Trade schools and community
+              colleges are expected to see significant growth in degrees and
+              certificates awarded by 2035.
             </ContentParagraph>
           </DualPaneSectionLeft>
           <DualPaneSectionRight className="lg:mt-24 print:mt-12">

--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -455,10 +455,10 @@ export default function LaborAutomationHubPage() {
             <ContentParagraph>
               The number of degrees awarded for STEM is expected to see only
               minor change due to the long gestation time, while overall 4-year
-              degrees are expected to decline 3.7% and humanities degrees are
-              expected to decline 7.1% by 2035. Trade schools and community
-              colleges are expected to see significant growth in degrees and
-              certificates awarded by 2035.
+              degrees are expected to see a modest decline and humanities
+              degrees are expected to see a more substantial decline by 2035.
+              Trade schools and community colleges are expected to see
+              significant growth in degrees and certificates awarded by 2035.
             </ContentParagraph>
           </DualPaneSectionLeft>
           <DualPaneSectionRight className="lg:mt-24 print:mt-12">

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-02">Jun 2</time>
+              Commentary last updated: <time dateTime="2026-06-03">Jun 3</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- **Section:** Graduates — "Impact on the Next Generation of Workers"
- **Old text:** "The number of degrees awarded overall and for STEM and humanities is expected to see only minor change due to the long gestation time, while trade schools and community colleges are expected to see significant growth in degrees and certificates awarded by 2035."
- **New text:** "The number of degrees awarded for STEM is expected to see only minor change due to the long gestation time, while overall 4-year degrees are expected to decline 3.7% and humanities degrees are expected to decline 7.1% by 2035. Trade schools and community colleges are expected to see significant growth in degrees and certificates awarded by 2035."

## What was wrong

The commentary described all three degree types (overall 4-year, STEM, humanities) as seeing "only minor change," but the chart data shows:
- STEM 4-year: **-0.7%** by 2035 ✓ minor
- Overall 4-year: **-3.7%** by 2035 — moderate, not "minor"
- Humanities 4-year: **-7.1%** by 2035 — significant decline, clearly not "minor"

## Test plan

- [ ] Verify the updated text appears correctly on `/labor-hub` under the Graduates section
- [ ] Confirm the "Commentary last updated" date shows Jun 3

https://claude.ai/code/session_01YZqdWQP8NjgGyw36Nw8CvN

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZqdWQP8NjgGyw36Nw8CvN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised Graduates section with clearer 2035 forecasts: STEM degrees change only slightly, overall 4‑year degrees decline ~3.7%, humanities decline ~7.1%, and trade schools/community colleges expected notable growth in degrees and certificates.
  * Updated Labor Hub commentary timestamp to reflect the latest revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->