### PR TITLE
Fix sidebar tile charts zoomed in

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/similar_question_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/similar_question_card.tsx
@@ -45,7 +45,7 @@ const SimilarQuestionCard: FC<Props> = ({ post, variant = "forecaster" }) => {
   return (
     <div
       className={cn(
-        "flex flex-col gap-3 rounded border border-blue-400 bg-blue-100 dark:border-blue-400-dark dark:bg-blue-100-dark",
+        "flex flex-col gap-3 rounded border border-blue-400 bg-blue-100 @container dark:border-blue-400-dark dark:bg-blue-100-dark",
         isForecaster ? "px-5 py-4" : "px-6 pb-6 pt-5"
       )}
     >

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/similar_question_prediction_chip.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/similar_question_prediction_chip.tsx
@@ -73,6 +73,7 @@ const SimilarPredictionChip: FC<Props> = ({ post, variant }) => {
           hideCP={hideCP}
           canPredict={false}
           showChart={false}
+          forFeedPage
         />
       </div>
     );
@@ -88,6 +89,7 @@ const SimilarPredictionChip: FC<Props> = ({ post, variant }) => {
           hideCP={hideCP}
           canPredict={false}
           showChart={true}
+          forFeedPage
         />
       </div>
     );

--- a/front_end/src/components/post_card/question_tile/index.tsx
+++ b/front_end/src/components/post_card/question_tile/index.tsx
@@ -86,6 +86,7 @@ const QuestionTile: FC<Props> = ({
           canPredict={canPredict}
           showChart={showChart}
           minimalistic={minimalistic}
+          forFeedPage={forFeedPage}
         />
       );
     case QuestionType.MultipleChoice: {

--- a/front_end/src/components/post_card/question_tile/question_continuous_tile.tsx
+++ b/front_end/src/components/post_card/question_tile/question_continuous_tile.tsx
@@ -40,6 +40,7 @@ type Props = {
   canPredict?: boolean;
   showChart?: boolean;
   minimalistic?: boolean;
+  forFeedPage?: boolean;
 };
 
 const QuestionContinuousTile: FC<Props> = ({
@@ -49,6 +50,7 @@ const QuestionContinuousTile: FC<Props> = ({
   canPredict,
   showChart = true,
   minimalistic = false,
+  forFeedPage = false,
 }) => {
   const { onReaffirm } = useCardReaffirmContext();
 
@@ -171,7 +173,7 @@ const QuestionContinuousTile: FC<Props> = ({
               tickFontSize={9}
               questionStatus={question.status}
               forecastAvailability={forecastAvailability}
-              forFeedPage
+              forFeedPage={forFeedPage}
             />
           </div>
         )}

--- a/posts/views.py
+++ b/posts/views.py
@@ -578,6 +578,7 @@ def post_similar_posts_api_view(request: Request, pk):
         posts,
         with_cp=True,
         group_cutoff=1,
+        include_cp_history=True,
         current_user=request.user if request.user.is_authenticated else None,
     )
 


### PR DESCRIPTION
Resolves #4793

### Summary

Fix similar questions sidebar tile charts appearing as flat zoomed-in lines instead of matching the feed.

- **`similar_question_card.tsx`**: add `@container` so container queries fire correctly inside the card
- **`similar_question_prediction_chip.tsx`** + **`question_continuous_tile.tsx`**: wire `forFeedPage` prop through to `NumericTimeline` for correct tick count and chart behavior
- **`posts/views.py`**: hardcode `include_cp_history=True` in the similar posts endpoint — unlike the feed which always had full history via `include_cp_history: true` in `getPostsWithCP`, this endpoint never had it wired up, returning only the latest forecast point and causing the flat line

### Screenshots

#### Before

<img width="345" height="934" alt="image (9)" src="https://github.com/user-attachments/assets/642c2392-fab1-432c-aa50-4bdc6107d9e0" />


#### After

<img width="341" height="935" alt="image (10)" src="https://github.com/user-attachments/assets/4cf54705-d228-4f99-bf65-0a249c78d29d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Similar posts API now includes copilot history data in responses.
  * Enhanced rendering support for similar questions in feed layouts.

* **UI/Visual Updates**
  * Improved responsive styling for similar question cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->