### PR TITLE
Fix: Revealing CP on main question no longer reveals CP on sidebar similar questions

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/similar_question_prediction_chip.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/similar_question_prediction_chip.tsx
@@ -7,8 +7,8 @@ import GroupForecastCard from "@/components/consumer_post_card/group_forecast_ca
 import PercentageForecastCard from "@/components/consumer_post_card/group_forecast_card/percentage_forecast_card";
 import GroupOfQuestionsTile from "@/components/post_card/group_of_questions_tile";
 import QuestionTile from "@/components/post_card/question_tile";
-import { useHideCP } from "@/contexts/cp_context";
-import { PostWithForecasts } from "@/types/post";
+import { useAuth } from "@/contexts/auth_context";
+import { PostStatus, PostWithForecasts } from "@/types/post";
 import { QuestionType } from "@/types/question";
 import {
   checkGroupOfQuestionsPostType,
@@ -23,7 +23,10 @@ type Props = {
 };
 
 const SimilarPredictionChip: FC<Props> = ({ post, variant }) => {
-  const { hideCP } = useHideCP();
+  const { user } = useAuth();
+  const hideCP =
+    !!user?.hide_community_prediction &&
+    ![PostStatus.CLOSED, PostStatus.RESOLVED].includes(post.status);
 
   if (hideCP) {
     return null;


### PR DESCRIPTION
Resolves #4817 

### Summary

Revealing the CP on a question was also revealing it for all sidebar similar questions due to shared context state.

Implemented changes:

- **`SimilarPredictionChip`**: replaced `useHideCP()` context consumption with a local `hideCP` calculation derived directly from `user?.hide_community_prediction` and `post.status`. Sidebar questions now determine their own CP visibility independently, unaffected by the main question's `RevealCPButton`.

### Demo videos

#### Before

https://github.com/user-attachments/assets/b7aaf0a4-4ad5-464e-aad0-13cc0361f301

#### After

https://github.com/user-attachments/assets/6b498a59-c081-4997-b0df-d77e8d843b14



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated prediction chip visibility to respect user preferences for hiding community predictions.
  * Fixed prediction chip to only display when post status is closed or resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->