### PR TITLE
Fix: Key factors carousel arrows hidden when scrolled to middle position

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_carousel.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/key_factors_carousel.tsx
@@ -29,13 +29,7 @@ function KeyFactorsCarousel<T>({
       items={items}
       showArrows={(state) => {
         if (!isDesktop) return false;
-        // Desktop arrows logic:
-        // - At start: right gradient + right arrow
-        // - Middle: gradients on both ends, but NO arrows
-        // - At end: left gradient + left arrow
-        return (
-          (state.canPrev && !state.canNext) || (!state.canPrev && state.canNext)
-        );
+        return state.canPrev || state.canNext;
       }}
       showGradients={(state) =>
         !isDesktop


### PR DESCRIPTION
Resolves #4819

### Summary

Carousel arrows disappeared when scrolled to a middle position due to XOR logic in `showArrows` — arrows only appeared at the edges, never both at once.

Implemented changes:

- **`KeyFactorsCarousel`**: fixed arrow visibility logic so each arrow shows whenever there is room to scroll in that direction.

### Demo video 

https://github.com/user-attachments/assets/71250972-a644-479b-a065-1ce6624b4530


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed carousel arrow visibility on desktop to display consistently whenever horizontal scrolling is available, regardless of scroll position. Previously, arrows would disappear in certain scroll states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->