### PR TITLE
Fix: Hide "CP is hidden: Reveal Temporarily" section when question is in hidden period

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/histogram_drawer.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/histogram_drawer.tsx
@@ -7,6 +7,7 @@ import SectionToggle from "@/components/ui/section_toggle";
 import { useHideCP } from "@/contexts/cp_context";
 import useContainerSize from "@/hooks/use_container_size";
 import { PostWithForecasts } from "@/types/post";
+import { getQuestionForecastAvailability } from "@/utils/questions/forecastAvailability";
 
 import RevealCPButton from "./reveal_cp_button";
 
@@ -28,6 +29,7 @@ const HistogramDrawer: React.FC<Props> = ({ post }) => {
 
   if (post.question?.type === "binary") {
     const question = post.question;
+    const forecastAvailability = getQuestionForecastAvailability(question);
 
     const histogram =
       question.aggregations[
@@ -50,7 +52,7 @@ const HistogramDrawer: React.FC<Props> = ({ post }) => {
     return (
       <div ref={chartContainerRef}>
         <SectionToggle title={t("histogram")} defaultOpen>
-          {hideCP ? (
+          {hideCP && !forecastAvailability.cpRevealsOn ? (
             <RevealCPButton />
           ) : (
             <Histogram
@@ -107,7 +109,11 @@ const HistogramDrawer: React.FC<Props> = ({ post }) => {
     return (
       <div ref={chartContainerRef}>
         <SectionToggle title={t("histogram")}>
-          {hideCP ? (
+          {hideCP &&
+          !getQuestionForecastAvailability(post.conditional.question_yes)
+            .cpRevealsOn &&
+          !getQuestionForecastAvailability(post.conditional.question_no)
+            .cpRevealsOn ? (
             <RevealCPButton />
           ) : (
             <>

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -219,6 +219,11 @@ export const ConsumerShell: FC<{
       ? getQuestionForecastAvailability(postData.question)
       : null;
 
+  const mcForecastAvailability =
+    isMultipleChoice && isQuestionPost(postData)
+      ? getQuestionForecastAvailability(postData.question)
+      : null;
+
   const showClosedMessageMultipleChoice =
     isMultipleChoicePost(postData) &&
     postData.question.status === QuestionStatus.CLOSED;
@@ -285,12 +290,12 @@ export const ConsumerShell: FC<{
           ) : isBinarySingleQuestion && isQuestionPost(postData) ? (
             <div className="flex flex-col sm:flex-row sm:items-center sm:gap-0 md:gap-8">
               <div className="order-1 flex w-64 flex-col items-center justify-center gap-[18px] self-center sm:self-stretch">
-                {hideCP ? (
-                  <RevealCPButton />
-                ) : binaryForecastAvailability?.cpRevealsOn ? (
+                {binaryForecastAvailability?.cpRevealsOn ? (
                   <UpcomingCP
                     cpRevealsOn={binaryForecastAvailability.cpRevealsOn}
                   />
+                ) : hideCP ? (
+                  <RevealCPButton />
                 ) : (
                   <QuestionHeaderCPStatus
                     question={postData.question}
@@ -338,7 +343,7 @@ export const ConsumerShell: FC<{
                 hideBorder={false}
                 reduceInnerPadding={!!isDateGroup}
                 listContent={
-                  hideCP ? (
+                  hideCP && !mcForecastAvailability?.cpRevealsOn ? (
                     <RevealCPButton />
                   ) : isFanGraph && fanGraphQuestions ? (
                     <ConsumerTimeSeriesPane

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/title_row.tsx
@@ -11,6 +11,7 @@ import { useHideCP } from "@/contexts/cp_context";
 import { PostWithForecasts } from "@/types/post";
 import { QuestionType, QuestionWithForecasts } from "@/types/question";
 import cn from "@/utils/core/cn";
+import { getQuestionForecastAvailability } from "@/utils/questions/forecastAvailability";
 import {
   isConditionalPost,
   isContinuousQuestion,
@@ -43,6 +44,9 @@ const TitleRow: FC<Props> = ({ post, variant, className }) => {
   if (variant === "forecaster" && isQuestionPost(post)) {
     const isMultipleChoice = post.question.type === QuestionType.MultipleChoice;
     const isContinuous = isContinuousQuestion(post.question);
+    const mcForecastAvailability = isMultipleChoice
+      ? getQuestionForecastAvailability(post.question)
+      : null;
 
     return (
       <div
@@ -63,7 +67,10 @@ const TitleRow: FC<Props> = ({ post, variant, className }) => {
             </QuestionTitle>
             <div className="shrink-0 self-center md:hidden">
               {isMultipleChoice ? (
-                hideCP && <RevealCPButton className="whitespace-nowrap" />
+                hideCP &&
+                !mcForecastAvailability?.cpRevealsOn && (
+                  <RevealCPButton className="whitespace-nowrap" />
+                )
               ) : (
                 <QuestionHeaderCPStatus
                   question={post.question as QuestionWithForecasts}
@@ -80,7 +87,9 @@ const TitleRow: FC<Props> = ({ post, variant, className }) => {
         </div>
         {!isContinuous && (
           <div className="hidden shrink-0 md:block">
-            {isMultipleChoice && hideCP ? (
+            {isMultipleChoice &&
+            hideCP &&
+            !mcForecastAvailability?.cpRevealsOn ? (
               <RevealCPButton className="whitespace-nowrap" />
             ) : (
               <QuestionHeaderCPStatus

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/prediction/single_question_prediction/continuous_question_prediction.tsx
@@ -64,7 +64,7 @@ const ContinuousQuestionPrediction: React.FC<Props> = ({
     return data;
   }, [cursorForecastValues, cursorUserForecastValues, question.status]);
 
-  if (hideCP) {
+  if (hideCP && !forecastAvailability.cpRevealsOn) {
     return (
       <div className="mx-auto mb-7 flex max-w-[340px] flex-col items-center justify-center gap-2.5">
         <RevealCPButton />

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
@@ -304,6 +304,17 @@ const QuestionHeaderCPStatus: FC<Props> = ({
       </div>
     );
   } else if (question.type === QuestionType.Binary) {
+    if (forecastAvailability.cpRevealsOn) {
+      return (
+        <div className="flex flex-col items-center justify-center">
+          <UpcomingCP
+            cpRevealsOn={forecastAvailability.cpRevealsOn}
+            className="whitespace-nowrap"
+          />
+        </div>
+      );
+    }
+
     if (hideCP) {
       if (isEmbed) {
         return null;
@@ -315,17 +326,6 @@ const QuestionHeaderCPStatus: FC<Props> = ({
           })}
         >
           <RevealCPButton />
-        </div>
-      );
-    }
-
-    if (forecastAvailability.cpRevealsOn) {
-      return (
-        <div className="flex flex-col items-center justify-center">
-          <UpcomingCP
-            cpRevealsOn={forecastAvailability.cpRevealsOn}
-            className="whitespace-nowrap"
-          />
         </div>
       );
     }

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
@@ -16,7 +16,6 @@ import {
 import MinifiedContinuousAreaChart from "@/components/charts/minified_continuous_area_chart";
 import BinaryCPBar from "@/components/consumer_post_card/binary_cp_bar";
 import QuestionResolutionChip from "@/components/consumer_post_card/question_resolution_chip";
-import UpcomingCP from "@/components/consumer_post_card/upcoming_cp";
 import QuestionCPMovement from "@/components/cp_movement";
 import ContinuousCPBar from "@/components/post_card/question_tile/continuous_cp_bar";
 import { useHideCP } from "@/contexts/cp_context";
@@ -185,19 +184,8 @@ const QuestionHeaderCPStatus: FC<Props> = ({
       );
     }
 
-    // CP reveals in the future — center the countdown, skip the mini chart
     if (forecastAvailability.cpRevealsOn) {
-      return (
-        <div
-          style={borderStyle}
-          className={cn(containerClassName, "items-center justify-center")}
-        >
-          <UpcomingCP
-            cpRevealsOn={forecastAvailability.cpRevealsOn}
-            className="whitespace-nowrap"
-          />
-        </div>
-      );
+      return null;
     }
 
     // CP hidden by user preference — center the reveal button, skip the mini chart
@@ -305,14 +293,7 @@ const QuestionHeaderCPStatus: FC<Props> = ({
     );
   } else if (question.type === QuestionType.Binary) {
     if (forecastAvailability.cpRevealsOn) {
-      return (
-        <div className="flex flex-col items-center justify-center">
-          <UpcomingCP
-            cpRevealsOn={forecastAvailability.cpRevealsOn}
-            className="whitespace-nowrap"
-          />
-        </div>
-      );
+      return null;
     }
 
     if (hideCP) {

--- a/front_end/src/components/conditional_tile/index.tsx
+++ b/front_end/src/components/conditional_tile/index.tsx
@@ -13,6 +13,7 @@ import { ConditionalPost, PostStatus } from "@/types/post";
 import { QuestionWithNumericForecasts } from "@/types/question";
 import { sendAnalyticsEvent } from "@/utils/analytics";
 import cn from "@/utils/core/cn";
+import { getQuestionForecastAvailability } from "@/utils/questions/forecastAvailability";
 import { isUnsuccessfullyResolved } from "@/utils/questions/resolution";
 
 import ConditionalCard from "./conditional_card";
@@ -167,7 +168,12 @@ const ConditionalTile: FC<Props> = ({
           </div>
         </div>
       </div>
-      {withCPRevealBtn && hideCP && <RevealCPButton />}
+      {withCPRevealBtn &&
+        hideCP &&
+        !(
+          getQuestionForecastAvailability(question_yes).cpRevealsOn &&
+          getQuestionForecastAvailability(question_no).cpRevealsOn
+        ) && <RevealCPButton />}
     </>
   );
 };

--- a/front_end/src/components/conditional_timeline.tsx
+++ b/front_end/src/components/conditional_timeline.tsx
@@ -8,6 +8,7 @@ import RevealCPButton from "@/app/(main)/questions/[id]/components/reveal_cp_but
 import { useHideCP } from "@/contexts/cp_context";
 import { ConditionalPost, PostConditional, PostStatus } from "@/types/post";
 import { QuestionWithNumericForecasts } from "@/types/question";
+import { getQuestionForecastAvailability } from "@/utils/questions/forecastAvailability";
 import { getPostDrivenTime } from "@/utils/questions/helpers";
 
 type Props = {
@@ -34,7 +35,12 @@ const ConditionalTimeline: FC<Props> = ({ post }) => {
         hideCP={hideCP}
         isClosed={status === PostStatus.CLOSED}
       />
-      {hideCP && <RevealCPButton className="mb-3" />}
+      {hideCP &&
+        !(
+          getQuestionForecastAvailability(conditional.question_yes)
+            .cpRevealsOn &&
+          getQuestionForecastAvailability(conditional.question_no).cpRevealsOn
+        ) && <RevealCPButton className="mb-3" />}
     </div>
   );
 };

--- a/front_end/src/components/consumer_post_card/upcoming_cp.tsx
+++ b/front_end/src/components/consumer_post_card/upcoming_cp.tsx
@@ -15,7 +15,7 @@ const UpcomingCP: FC<Props> = ({ cpRevealsOn, className }) => {
   const locale = useLocale();
   return (
     <div className={cn("w-full text-center", className)}>
-      <span>{t("cpRevealed")} </span>
+      <span className="block">{t("cpRevealed")}</span>
       <RelativeTime datetime={cpRevealsOn} lang={locale} className="leading-6">
         {intlFormatDistance(cpRevealsOn, new Date(), {
           locale,


### PR DESCRIPTION
Resolves #4820, #4821

### Summary

"Reveal Temporarily" button was appearing on questions still in their hidden period (`cp_reveal_time` in the future), even though the CP is hidden server-wide and clicking the button does nothing useful. The button is only meaningful when the user has personally hidden the CP via preferences. Additionally, the "Revealed in N days" label was incorrectly shown in the top-right question header during the hidden period — it is now suppressed there while remaining visible inside the timeline chart.


Implemented changes:

- **`question_page_shell/index.tsx`**: fixed check order in binary left panel (`cpRevealsOn` before `hideCP`); added `cpRevealsOn` guard to multiple choice list content panel.
- **`question_header_cp_status.tsx`**: fixed check order in binary branch of the forecaster CP chip.
- **`continuous_question_prediction.tsx`**: added `cpRevealsOn` guard for the consumer continuous view.
- **`title_row.tsx`**: added `cpRevealsOn` guard for multiple choice questions in the forecaster title row.
- **`conditional_timeline.tsx`** and **`conditional_tile/index.tsx`**: hide button only when both `question_yes` and `question_no` are in their hidden period.
- **`histogram_drawer.tsx`**: defense-in-depth guard (backend already clears histogram data during hidden period, but logic was still incorrect).
- **`upcoming_cp.tsx`**: made "Revealed" label a block element so the date wraps to the next line instead of overflowing on a single line.
- **`question_header_cp_status.tsx`** (second change): suppressed "Revealed in N days" label from the top-right header panel during the hidden period — the same countdown remains visible inside the timeline chart.

### Demo videos

#### Before

https://github.com/user-attachments/assets/26bb90bf-b80f-4e81-9d20-7b54220e366f

#### After 

- Forecaster view

https://github.com/user-attachments/assets/55819db6-9daa-4e3b-9bea-f1b9fcc4d18f

- Consumer view

https://github.com/user-attachments/assets/dbfb2dea-b1ab-40d9-8aec-f7229c9e87a9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved timing logic for when Creator Prediction (CP) reveal button appears. The button now intelligently shows or hides based on forecast availability, ensuring the UpcomingCP countdown displays at the appropriate time across binary, multiple-choice, and conditional questions.

* **Style**
  * Updated CP revealed message display formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->