### PR TITLE
Feed N+1 query fix: get_last_aggregated_forecasts_for_questions

### DIFF
--- a/questions/services/forecasts.py
+++ b/questions/services/forecasts.py
@@ -406,12 +406,13 @@ def update_forecast_notification(
 def get_last_aggregated_forecasts_for_questions(
     questions: Iterable[Question], aggregated_forecast_qs: QuerySet[AggregateForecast]
 ):
+    # Return the most recent started forecast per (question, method), regardless of
+    # whether it is still live. Closed/resolved questions keep their final CP this way,
+    # and — crucially — this row is fully loaded, so serializing it with full=True does
+    # not trigger a deferred-field reload against the (heavy, deferred) CP history.
     return (
         aggregated_forecast_qs.filter(question__in=questions)
-        .filter(
-            (Q(end_time__isnull=True) | Q(end_time__gt=timezone.now())),
-            start_time__lte=timezone.now(),
-        )
+        .filter(start_time__lte=timezone.now())
         .order_by("question_id", "method", "-start_time")
         .distinct("question_id", "method")
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed forecast data retrieval to include final forecasts from closed and resolved questions. Previously, only active forecasts were returned, preventing access to complete historical data. Users can now view comprehensive forecast information for all question states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->