### PR TITLE
Fix: Multiple Choice fixes for hidden / deleted states

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
@@ -15,6 +15,7 @@ type Props = {
   questionType: QuestionType;
   onChoiceChange: (choice: string, checked: boolean) => void;
   onChoiceHighlight: (choice: string, highlighted: boolean) => void;
+  hideCP?: boolean;
 };
 
 function isResolvedNo(item: ChoiceItem, questionType: QuestionType): boolean {
@@ -55,6 +56,7 @@ const CompactLegendBar: FC<Props> = ({
   questionType,
   onChoiceChange,
   onChoiceHighlight,
+  hideCP,
 }) => {
   const t = useTranslations();
   const [showAll, setShowAll] = useState(false);
@@ -148,9 +150,11 @@ const CompactLegendBar: FC<Props> = ({
                 <span className="max-w-[300px] truncate text-sm font-medium leading-4 text-gray-800 dark:text-gray-800-dark md:text-base md:leading-5">
                   {item.label || item.choice}
                 </span>
-                <span className="shrink-0 text-sm tabular-nums leading-4 text-gray-600 dark:text-gray-600-dark md:text-base md:leading-6">
-                  {resolvedYes ? `(${t("Yes")})` : pct}
-                </span>
+                {(resolvedYes || (!item.isDeleted && !hideCP)) && (
+                  <span className="shrink-0 text-sm tabular-nums leading-4 text-gray-600 dark:text-gray-600-dark md:text-base md:leading-6">
+                    {resolvedYes ? `(${t("Yes")})` : pct}
+                  </span>
+                )}
               </>
             )}
           </div>

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
@@ -279,6 +279,7 @@ const MultiChoicesChartView: FC<Props> = ({
                     questionType={QuestionType.MultipleChoice}
                     onChoiceChange={handleChoiceChange}
                     onChoiceHighlight={handleChoiceHighlight}
+                    hideCP={hideCP}
                   />
                 </div>
               ) : undefined
@@ -299,6 +300,7 @@ const MultiChoicesChartView: FC<Props> = ({
                     questionType={QuestionType.MultipleChoice}
                     onChoiceChange={handleChoiceChange}
                     onChoiceHighlight={handleChoiceHighlight}
+                    hideCP={hideCP}
                   />
                 </div>
               ) : undefined
@@ -326,6 +328,7 @@ const MultiChoicesChartView: FC<Props> = ({
                     questionType={questionType ?? QuestionType.Binary}
                     onChoiceChange={handleChoiceChange}
                     onChoiceHighlight={handleChoiceHighlight}
+                    hideCP={hideCP}
                   />
                 </div>
               ) : undefined

--- a/front_end/src/types/choices.ts
+++ b/front_end/src/types/choices.ts
@@ -9,6 +9,7 @@ export type ChoiceItem = {
   id?: number;
   choice: string; // multiple choice option or subquestion label
   label?: string; // label to display if different from "choice"
+  isDeleted?: boolean;
   color: ThemeColor;
   highlighted: boolean;
   active: boolean;

--- a/front_end/src/utils/questions/choices.ts
+++ b/front_end/src/utils/questions/choices.ts
@@ -172,6 +172,7 @@ export function generateChoiceItemsFromMultipleChoiceForecast(
         : isUpcoming
           ? choice + " (" + t("Upcoming") + ")"
           : choice,
+      isDeleted,
       color: MULTIPLE_CHOICE_COLOR_SCALE[index] ?? METAC_COLORS.gray["400"],
       highlighted: false,
       active: true,


### PR DESCRIPTION
Resolves #4818

### Summary

Deleted options in multiple choice questions were still displaying forecast percentages, and CP values were still visible in the legend even when CP was hidden by the user.

Implemented changes:

- **Deleted options**: tracked `isDeleted` flag on `ChoiceItem` and suppressed the forecast percentage in the legend for deleted options
- **Hidden CP**: wired the `hideCP` flag through all three chart render paths so percentages are hidden in the legend when CP is hidden


### Demo videos

#### Before

https://github.com/user-attachments/assets/15f26787-88dd-4151-b835-d6aad550611a

#### After

https://github.com/user-attachments/assets/769afd68-f17d-4f7b-9499-fb46df152211


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional control to hide forecast/CP values in legend items for cleaner chart visualization.
  * Enhanced choice item tracking with deletion state management to properly display deleted options in multiple-choice questions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->