### PR TITLE
Fix: similar questions sidebar tiles not showing user forecasts

### DIFF
--- a/front_end/src/services/api/posts/posts.shared.ts
+++ b/front_end/src/services/api/posts/posts.shared.ts
@@ -197,8 +197,7 @@ class PostsApi extends ApiService {
 
   async getSimilarPosts(postId: number): Promise<PostWithForecasts[]> {
     return await this.get<PostWithForecasts[]>(
-      `/posts/${postId}/similar-posts/`,
-      { next: { revalidate: 1800 } }
+      `/posts/${postId}/similar-posts/`
     );
   }
 

--- a/posts/views.py
+++ b/posts/views.py
@@ -580,6 +580,7 @@ def post_similar_posts_api_view(request: Request, pk):
         group_cutoff=1,
         include_cp_history=True,
         current_user=request.user if request.user.is_authenticated else None,
+        include_user_forecasts=True,
     )
 
     return Response(posts)


### PR DESCRIPTION
Resolves #4792

### Summary

Sidebar similar question tiles were not displaying the user's own forecast ("Me: X%"), even though the main feed tiles showed them correctly.

Implemented changes:

- **`posts/views.py`**: `post_similar_posts_api_view` was calling `serialize_post_many()` without `include_user_forecasts=True`, so `my_forecasts` was never included in the similar posts API response.

- **`posts.shared.ts`**: `getSimilarPosts` used `next: { revalidate: 1800 }`, which triggers a security guard in the server fetcher that intentionally strips the auth token from cached requests to prevent leaking user-specific data across a shared cache. Without the auth token, the backend treats the request as unauthenticated and skips user forecast data regardless of the backend fix. Removing `revalidate` makes the request dynamic and auth-bearing — the backend's own 24h Redis cache for `get_similar_posts()` ensures performance is not impacted.

### Screenshots

#### Before

<img width="327" height="928" alt="image (11)" src="https://github.com/user-attachments/assets/35edc203-796d-48ef-b9e7-35cfac7e6a70" />


#### After

<img width="340" height="941" alt="image (12)" src="https://github.com/user-attachments/assets/f81154fd-9dc6-4ac9-b5a9-038824520be1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Similar posts recommendations now include personalized user forecast data, providing users with additional forecasting context alongside related content suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->