### PR TITLE
Feat: extend hover-mirror cursor sync to all consumer view question types

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/group_timeline.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/group_timeline.tsx
@@ -60,6 +60,8 @@ type Props = QuestionsDataProps & {
   onTimelineMarkerLeave?: (marker: GroupTimelineMarker) => void;
   withHighlightArea?: boolean;
   withHighlightEndpoint?: boolean;
+  onCursorChange?: (ts: number) => void;
+  hideTooltip?: boolean;
 };
 
 /**
@@ -92,6 +94,8 @@ const GroupTimeline: FC<Props> = ({
   externalHighlightedChoice,
   withHighlightArea,
   withHighlightEndpoint,
+  onCursorChange,
+  hideTooltip,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -186,8 +190,15 @@ const GroupTimeline: FC<Props> = ({
     [choiceItems, externalHighlightedChoice]
   );
 
-  const [cursorTimestamp, _tooltipDate, handleCursorChange] =
+  const [cursorTimestamp, _tooltipDate, _handleCursorChange] =
     useTimestampCursor(timestamps);
+  const handleCursorChange = useCallback(
+    (value: number, format: Parameters<typeof _handleCursorChange>[1]) => {
+      _handleCursorChange(value, format);
+      onCursorChange?.(value);
+    },
+    [_handleCursorChange, onCursorChange]
+  );
   const tooltipChoices = useMemo<ChoiceTooltipItem[]>(() => {
     return choiceItems
       .filter(({ active }) => active)
@@ -355,6 +366,7 @@ const GroupTimeline: FC<Props> = ({
       onTimelineMarkerLeave={onTimelineMarkerLeave}
       withHighlightArea={withHighlightArea}
       withHighlightEndpoint={withHighlightEndpoint}
+      hideTooltip={hideTooltip}
     />
   );
 };

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
@@ -51,6 +51,7 @@ type Props = {
   onTimelineMarkerLeave?: (marker: GroupTimelineMarker) => void;
   withHighlightArea?: boolean;
   withHighlightEndpoint?: boolean;
+  hideTooltip?: boolean;
 };
 
 const MultiChoicesChartView: FC<Props> = ({
@@ -86,6 +87,7 @@ const MultiChoicesChartView: FC<Props> = ({
   onTimelineMarkerLeave,
   withHighlightArea = true,
   withHighlightEndpoint = false,
+  hideTooltip = false,
 }) => {
   const { user } = useAuth();
   const isInteracted = useRef(false);
@@ -339,6 +341,7 @@ const MultiChoicesChartView: FC<Props> = ({
       </div>
 
       {isTooltipActive &&
+        !hideTooltip &&
         !isCursorOverLegend &&
         !hideCP &&
         !forecastAvailability?.cpRevealsOn &&

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -16,7 +16,10 @@ import MarkdownEditor from "@/components/markdown_editor";
 import CommunityDisclaimer from "@/components/post_card/community_disclaimer";
 import ResolutionCriteria from "@/components/question/resolution_criteria";
 import SectionToggle from "@/components/ui/section_toggle";
-import { ContinuousChartCursorProvider } from "@/contexts/continuous_chart_cursor_context";
+import {
+  ContinuousChartCursorProvider,
+  useContinuousChartCursor,
+} from "@/contexts/continuous_chart_cursor_context";
 import { useHideCP } from "@/contexts/cp_context";
 import { useContentTranslatedBannerContext } from "@/contexts/translations_banner_context";
 import { usePostTextSections } from "@/hooks/use_post_text_sections";
@@ -28,7 +31,11 @@ import {
   QuestionStatus,
 } from "@/types/post";
 import { TournamentType } from "@/types/projects";
-import { QuestionType, QuestionWithNumericForecasts } from "@/types/question";
+import {
+  QuestionType,
+  QuestionWithForecasts,
+  QuestionWithNumericForecasts,
+} from "@/types/question";
 import { getQuestionForecastAvailability } from "@/utils/questions/forecastAvailability";
 import { sortGroupPredictionOptions } from "@/utils/questions/groupOrdering";
 import {
@@ -177,6 +184,19 @@ export const ForecasterShell: FC<
   );
 };
 
+const BinaryCursorGauge: FC<{
+  question: QuestionWithForecasts;
+}> = ({ question }) => {
+  const cursorCtx = useContinuousChartCursor();
+  return (
+    <QuestionHeaderCPStatus
+      question={question}
+      size="lg"
+      cursorBinaryValue={cursorCtx?.activeBinaryValue}
+    />
+  );
+};
+
 export const ConsumerShell: FC<{
   postData: PostWithForecasts;
   preselectedGroupQuestionId?: number;
@@ -297,10 +317,7 @@ export const ConsumerShell: FC<{
                 ) : hideCP ? (
                   <RevealCPButton />
                 ) : (
-                  <QuestionHeaderCPStatus
-                    question={postData.question}
-                    size="lg"
-                  />
+                  <BinaryCursorGauge question={postData.question} />
                 )}
               </div>
               <QuestionTimeline

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_group_chart.tsx
@@ -22,8 +22,12 @@ const ConsumerGroupChart: FC<Props> = ({
   chartHeight,
   visibleQuestions,
 }) => {
-  const { hoveredChoiceName, setHoveredChoiceName, chartAreaHeight } =
-    useListChartExpanded();
+  const {
+    hoveredChoiceName,
+    setHoveredChoiceName,
+    chartAreaHeight,
+    setCursorTimestamp,
+  } = useListChartExpanded();
   const { open_time, actual_close_time, scheduled_close_time, status } = post;
   const refCloseTime = actual_close_time ?? scheduled_close_time;
 
@@ -51,6 +55,8 @@ const ConsumerGroupChart: FC<Props> = ({
         withHighlightArea={false}
         externalHighlightedChoice={hoveredChoiceName}
         chartHeight={effectiveChartHeight}
+        onCursorChange={setCursorTimestamp}
+        hideTooltip
       />
     </div>
   );

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
@@ -19,6 +19,8 @@ type ListChartExpandedContextType = {
   hoveredChoiceName: string | null;
   setHoveredChoiceName: (name: string | null) => void;
   chartAreaHeight: number;
+  cursorTimestamp: number | null;
+  setCursorTimestamp: (ts: number | null) => void;
 };
 
 const ListChartExpandedContext = createContext<ListChartExpandedContextType>({
@@ -26,6 +28,8 @@ const ListChartExpandedContext = createContext<ListChartExpandedContextType>({
   hoveredChoiceName: null,
   setHoveredChoiceName: () => {},
   chartAreaHeight: 0,
+  cursorTimestamp: null,
+  setCursorTimestamp: () => {},
 });
 
 export const useListChartExpanded = () => useContext(ListChartExpandedContext);
@@ -56,6 +60,7 @@ const ConsumerListChartShell: React.FC<Props> = ({
   const [hoveredChoiceName, setHoveredChoiceName] = useState<string | null>(
     null
   );
+  const [cursorTimestamp, setCursorTimestamp] = useState<number | null>(null);
 
   const { ref: listColumnRef, height: listColumnHeight } =
     useContainerSize<HTMLDivElement>();
@@ -87,8 +92,17 @@ const ConsumerListChartShell: React.FC<Props> = ({
       hoveredChoiceName,
       setHoveredChoiceName,
       chartAreaHeight,
+      cursorTimestamp,
+      setCursorTimestamp,
     }),
-    [hoveredChoiceName, chartAreaHeight, setHoveredChoiceName, setIsExpanded]
+    [
+      hoveredChoiceName,
+      chartAreaHeight,
+      setHoveredChoiceName,
+      setIsExpanded,
+      cursorTimestamp,
+      setCursorTimestamp,
+    ]
   );
 
   return (
@@ -101,7 +115,10 @@ const ConsumerListChartShell: React.FC<Props> = ({
           stretchListContent && "sm:min-h-[192px]",
           className
         )}
-        onMouseLeave={() => setHoveredChoiceName(null)}
+        onMouseLeave={() => {
+          setHoveredChoiceName(null);
+          setCursorTimestamp(null);
+        }}
       >
         <div
           ref={listColumnRef}

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/timeline/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/timeline/index.tsx
@@ -38,7 +38,7 @@ const QuestionTimeline: React.FC<Props> = ({
   isConsumerView = true,
   preselectedGroupQuestionId,
 }) => {
-  const { chartAreaHeight } = useListChartExpanded();
+  const { chartAreaHeight, setCursorTimestamp } = useListChartExpanded();
   const isFanGraph =
     postData.group_of_questions?.graph_type ===
     GroupOfQuestionsGraphType.FanGraph;
@@ -111,6 +111,8 @@ const QuestionTimeline: React.FC<Props> = ({
             preselectedQuestionId={preselectedGroupQuestionId}
             withLegend={!isConsumerView}
             embedChartHeight={embedHeight}
+            onCursorChange={isConsumerView ? setCursorTimestamp : undefined}
+            hideTooltip={isConsumerView}
           />
         )}
       </div>

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_cp_status.tsx
@@ -40,6 +40,7 @@ type Props = {
   chartTheme?: VictoryThemeDefinition;
   cursorForecast?: NumericAggregateForecast | null;
   cursorUserForecastValues?: number[] | null;
+  cursorBinaryValue?: number | null;
 };
 
 const QuestionHeaderCPStatus: FC<Props> = ({
@@ -50,6 +51,7 @@ const QuestionHeaderCPStatus: FC<Props> = ({
   chartTheme,
   cursorForecast,
   cursorUserForecastValues,
+  cursorBinaryValue,
 }) => {
   const locale = useLocale();
   const t = useTranslations();
@@ -327,6 +329,7 @@ const QuestionHeaderCPStatus: FC<Props> = ({
             question={question}
             size={size === "lg" ? "lg" : "sm"}
             colorOverride={colorOverride}
+            overrideValue={cursorBinaryValue}
           />
         )}
         {!hideCP && (

--- a/front_end/src/components/consumer_post_card/binary_cp_bar.tsx
+++ b/front_end/src/components/consumer_post_card/binary_cp_bar.tsx
@@ -17,6 +17,7 @@ type Props = {
   size?: "xs" | "sm" | "md" | "lg";
   className?: string;
   colorOverride?: string;
+  overrideValue?: number | null;
 };
 
 const BinaryCPBar: FC<Props> = ({
@@ -24,6 +25,7 @@ const BinaryCPBar: FC<Props> = ({
   size = "md",
   className,
   colorOverride,
+  overrideValue,
 }) => {
   const t = useTranslations();
   const { hideCP } = useHideCP();
@@ -31,8 +33,10 @@ const BinaryCPBar: FC<Props> = ({
   const isEmbed = useIsEmbedMode();
 
   const questionCP =
-    question.aggregations[question.default_aggregation_method]?.latest
-      ?.centers?.[0];
+    overrideValue != null
+      ? overrideValue
+      : question.aggregations[question.default_aggregation_method]?.latest
+          ?.centers?.[0];
 
   if (question.type !== QuestionType.Binary) {
     return null;

--- a/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
@@ -78,13 +78,20 @@ const NumericForecastCard: FC<Props> = ({
   const hiddenCount = Math.max(0, sortedChoices.length - visibleChoicesCount);
   const collapsedChoices = sortedChoices.slice(0, visibleChoicesCount);
 
-  // Anchor all sub-questions to the same timestamp; fall back to the first
-  // choice's last entry since history lengths differ per sub-question.
-  const refTimestamps = sortedChoices[0]?.aggregationTimestamps ?? [];
-  const refTs =
-    cursorTimestamp !== null
-      ? cursorTimestamp
-      : refTimestamps[refTimestamps.length - 1] ?? null;
+  // Anchor all sub-questions to the same timestamp. Use the global latest
+  // across all choices so resolved rows (sorted first) don't anchor to a
+  // stale timestamp and show outdated values on initial load.
+  const fallbackLatestTs = sortedChoices.reduce<number | null>(
+    (maxTs, choice) => {
+      const lastTs =
+        choice.aggregationTimestamps[choice.aggregationTimestamps.length - 1] ??
+        null;
+      if (lastTs === null) return maxTs;
+      return maxTs === null || lastTs > maxTs ? lastTs : maxTs;
+    },
+    null
+  );
+  const refTs = cursorTimestamp ?? fallbackLatestTs;
 
   // Returns the aggregation value for a sub-question at refTs using its own
   // timestamp array, since each sub-question may have a different history length.

--- a/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
@@ -9,6 +9,7 @@ import { getEffectiveVisibleCount } from "@/constants/questions";
 import { useOverlayMaxHeight } from "@/hooks/use_overlay_max_height";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import { QuestionType, Scaling } from "@/types/question";
+import { findPreviousTimestamp } from "@/utils/charts/cursor";
 import cn from "@/utils/core/cn";
 import { getPredictionDisplayValue } from "@/utils/formatters/prediction";
 import { scaleInternalLocation } from "@/utils/math";
@@ -41,7 +42,8 @@ const NumericForecastCard: FC<Props> = ({
   const locale = useLocale();
   const t = useTranslations();
   const [expanded, setExpanded] = useState(false);
-  const { setIsExpanded, setHoveredChoiceName } = useListChartExpanded();
+  const { setIsExpanded, setHoveredChoiceName, cursorTimestamp } =
+    useListChartExpanded();
   const { containerRef, overlayMaxHeight } = useOverlayMaxHeight(expanded);
 
   if (!isGroupOfQuestionsPost(post)) {
@@ -76,11 +78,33 @@ const NumericForecastCard: FC<Props> = ({
   const hiddenCount = Math.max(0, sortedChoices.length - visibleChoicesCount);
   const collapsedChoices = sortedChoices.slice(0, visibleChoicesCount);
 
+  // Anchor all sub-questions to the same timestamp; fall back to the first
+  // choice's last entry since history lengths differ per sub-question.
+  const refTimestamps = sortedChoices[0]?.aggregationTimestamps ?? [];
+  const refTs =
+    cursorTimestamp !== null
+      ? cursorTimestamp
+      : refTimestamps[refTimestamps.length - 1] ?? null;
+
+  // Returns the aggregation value for a sub-question at refTs using its own
+  // timestamp array, since each sub-question may have a different history length.
+  const getChoiceValue = (
+    aggregationValues: (number | null)[],
+    ownTimestamps: number[]
+  ): number | null => {
+    if (refTs === null || !ownTimestamps.length) {
+      return aggregationValues[aggregationValues.length - 1] ?? null;
+    }
+    const closestTs = findPreviousTimestamp(ownTimestamps, refTs);
+    const idx = ownTimestamps.indexOf(closestTs);
+    return idx >= 0 ? aggregationValues[idx] ?? null : null;
+  };
+
   const scaledValues = [...sortedChoices]
     .filter((choice) => isNil(choice.resolution))
-    .map(({ aggregationValues, scaling }) =>
+    .map(({ aggregationValues, aggregationTimestamps, scaling }) =>
       scaleInternalLocation(
-        aggregationValues[aggregationValues.length - 1] ?? 0,
+        getChoiceValue(aggregationValues, aggregationTimestamps) ?? 0,
         {
           range_min: scaling?.range_min ?? 0,
           range_max: scaling?.range_max ?? 1,
@@ -101,6 +125,7 @@ const NumericForecastCard: FC<Props> = ({
         {
           closeTime,
           aggregationValues,
+          aggregationTimestamps,
           scaling,
           resolution,
           id,
@@ -113,8 +138,10 @@ const NumericForecastCard: FC<Props> = ({
         index
       ) => {
         const isChoiceClosed = closeTime ? closeTime < Date.now() : false;
-        const rawChoiceValue =
-          aggregationValues[aggregationValues.length - 1] ?? null;
+        const rawChoiceValue = getChoiceValue(
+          aggregationValues,
+          aggregationTimestamps
+        );
         const normalizedScaling: Scaling = {
           range_min: scaling?.range_min ?? 0,
           range_max: scaling?.range_max ?? 1,

--- a/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
@@ -91,10 +91,16 @@ const PercentageForecastCard: FC<Props> = ({
   // Resolves each choice's value at the cursor (or last) timestamp using its
   // own timeline, since history lengths differ per sub-question.
   const displayChoices = useMemo(() => {
-    const refTimestamps = allChoices[0]?.aggregationTimestamps ?? [];
-    if (!refTimestamps.length) return allChoices;
-    const refTs =
-      cursorTimestamp ?? refTimestamps[refTimestamps.length - 1] ?? null;
+    const fallbackLatestTs = allChoices.reduce<number | null>(
+      (maxTs, choice) => {
+        const own = choice.aggregationTimestamps;
+        const lastTs = own[own.length - 1] ?? null;
+        if (lastTs === null) return maxTs;
+        return maxTs === null || lastTs > maxTs ? lastTs : maxTs;
+      },
+      null
+    );
+    const refTs = cursorTimestamp ?? fallbackLatestTs;
     if (refTs === null) return allChoices;
 
     return allChoices.map((choice) => {

--- a/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
@@ -8,6 +8,7 @@ import { getEffectiveVisibleCount } from "@/constants/questions";
 import { useOverlayMaxHeight } from "@/hooks/use_overlay_max_height";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import { QuestionType } from "@/types/question";
+import { findPreviousTimestamp } from "@/utils/charts/cursor";
 import cn from "@/utils/core/cn";
 import { getPredictionDisplayValue } from "@/utils/formatters/prediction";
 import {
@@ -40,7 +41,7 @@ const PercentageForecastCard: FC<Props> = ({
   const locale = useLocale();
   const t = useTranslations();
   const [expanded, setExpanded] = useState(false);
-  const { setIsExpanded } = useListChartExpanded();
+  const { setIsExpanded, cursorTimestamp } = useListChartExpanded();
   const { containerRef, overlayMaxHeight } = useOverlayMaxHeight(expanded);
 
   const isMC = isMultipleChoicePost(post);
@@ -87,12 +88,41 @@ const PercentageForecastCard: FC<Props> = ({
     });
   }, [post, visibleChoicesCount, locale, t, emptyLabel]);
 
+  // Resolves each choice's value at the cursor (or last) timestamp using its
+  // own timeline, since history lengths differ per sub-question.
+  const displayChoices = useMemo(() => {
+    const refTimestamps = allChoices[0]?.aggregationTimestamps ?? [];
+    if (!refTimestamps.length) return allChoices;
+    const refTs =
+      cursorTimestamp ?? refTimestamps[refTimestamps.length - 1] ?? null;
+    if (refTs === null) return allChoices;
+
+    return allChoices.map((choice) => {
+      const ownTimestamps = choice.aggregationTimestamps;
+      const closestTs = findPreviousTimestamp(ownTimestamps, refTs);
+      const ownIdx = ownTimestamps.indexOf(closestTs);
+      const rawVal =
+        ownIdx >= 0 ? choice.aggregationValues[ownIdx] ?? null : null;
+      const valueStr = getPredictionDisplayValue(rawVal, {
+        questionType: QuestionType.Binary,
+        scaling: choice.scaling,
+        actual_resolve_time: choice.actual_resolve_time ?? null,
+        emptyLabel,
+      });
+      const percent =
+        typeof valueStr === "string"
+          ? Number(valueStr.replace("%", "")) || 0
+          : 0;
+      return { ...choice, valueStr, percent };
+    });
+  }, [allChoices, cursorTimestamp, emptyLabel]);
+
   if (!isMC && !isGroupOfQuestionsPost(post)) return null;
 
   const isPostClosed = post.status === PostStatus.CLOSED;
 
-  const collapsedChoices = allChoices.slice(0, visibleChoicesCount);
-  const hiddenCount = Math.max(0, allChoices.length - visibleChoicesCount);
+  const collapsedChoices = displayChoices.slice(0, visibleChoicesCount);
+  const hiddenCount = Math.max(0, displayChoices.length - visibleChoicesCount);
 
   const renderBars = (choices: typeof allChoices, stretchBars = false) =>
     choices.map((choice) => (
@@ -156,7 +186,7 @@ const PercentageForecastCard: FC<Props> = ({
               buttonVariant={buttonVariant}
               className="min-h-0 flex-1"
             >
-              {renderBars(allChoices)}
+              {renderBars(displayChoices)}
             </ForecastCardWrapper>
           </div>
         </>

--- a/front_end/src/components/detailed_question_card/detailed_group_card/index.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_group_card/index.tsx
@@ -45,6 +45,8 @@ type Props = {
   chartTheme?: VictoryThemeDefinition;
   defaultZoom?: TimelineChartZoomOption;
   withLegend?: boolean;
+  onCursorChange?: (ts: number) => void;
+  hideTooltip?: boolean;
 };
 
 const DetailedGroupCard: FC<Props> = ({
@@ -58,6 +60,8 @@ const DetailedGroupCard: FC<Props> = ({
   chartTheme,
   defaultZoom,
   withLegend,
+  onCursorChange,
+  hideTooltip,
 }) => {
   const {
     open_time,
@@ -189,6 +193,8 @@ const DetailedGroupCard: FC<Props> = ({
           chartTheme={chartTheme}
           defaultZoom={defaultZoom}
           withLegend={withLegend}
+          onCursorChange={onCursorChange}
+          hideTooltip={hideTooltip}
         />
       );
     }

--- a/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
@@ -7,6 +7,7 @@ import {
   ReactNode,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useState,
 } from "react";
@@ -238,9 +239,25 @@ const DetailedContinuousChartCard: FC<Props> = ({
     ) as NumericAggregateForecast | null;
   }, [isCpHidden, cursorTimestamp, effectiveAggregation, question]);
 
+  // CP probability at the cursor position, pushed to context so the binary
+  // gauge on the left updates in sync with timeline hover.
+  const activeBinaryValue = useMemo<number | null>(() => {
+    if (!isBinary || !isConsumerView || isCpHidden || cursorTimestamp === null)
+      return null;
+    const forecast = getCursorForecast(cursorTimestamp, effectiveAggregation);
+    return forecast?.centers?.[0] ?? null;
+  }, [
+    isBinary,
+    isConsumerView,
+    isCpHidden,
+    cursorTimestamp,
+    effectiveAggregation,
+  ]);
+
   const cursorCtx = useContinuousChartCursor();
   const setCursorForecast = cursorCtx?.setActiveForecast;
   const setCursorUserForecast = cursorCtx?.setActiveUserForecastValues;
+  const setCursorBinaryValue = cursorCtx?.setActiveBinaryValue;
   useEffect(() => {
     if (
       !isContinuousQuestion(question) ||
@@ -261,6 +278,11 @@ const DetailedContinuousChartCard: FC<Props> = ({
     setCursorUserForecast,
     question,
   ]);
+  // Syncs the binary gauge to the cursor position on every cursor move
+  useLayoutEffect(() => {
+    if (!isBinary || !isConsumerView || !setCursorBinaryValue) return;
+    setCursorBinaryValue(activeBinaryValue);
+  }, [activeBinaryValue, isBinary, isConsumerView, setCursorBinaryValue]);
 
   const handleCursorChange = useCallback((value: number | null) => {
     setCursorTimestamp(value);
@@ -355,7 +377,9 @@ const DetailedContinuousChartCard: FC<Props> = ({
       forecastAvailability={forecastAvailability}
       suppressEmptyOverlay
       cursorTooltip={
-        forecastAvailability?.isEmpty || (isContinuous && !userHasPrediction)
+        forecastAvailability?.isEmpty ||
+        (isContinuous && !userHasPrediction) ||
+        (isConsumerView && isBinary)
           ? undefined
           : cursorTooltip
       }

--- a/front_end/src/components/detailed_question_card/detailed_question_card/multiple_choice_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/multiple_choice_chart_card.tsx
@@ -5,6 +5,7 @@ import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import { VictoryThemeDefinition } from "victory";
 
 import MultiChoicesChartView from "@/app/(main)/questions/[id]/components/multiple_choices_chart_view";
+import { useListChartExpanded } from "@/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell";
 import CPRevealTime from "@/components/cp_reveal_time";
 import { MultipleChoiceTile } from "@/components/post_card/multiple_choice_tile";
 import { getEffectiveVisibleCount } from "@/constants/questions";
@@ -50,6 +51,7 @@ const DetailedMultipleChoiceChartCard: FC<Props> = ({
 }) => {
   const t = useTranslations();
   const [isChartHovered, setIsChartHovered] = useState(false);
+  const { setCursorTimestamp: setCtxCursorTimestamp } = useListChartExpanded();
 
   const actualCloseTime = getPostDrivenTime(question.actual_close_time);
   const openTime = getPostDrivenTime(question.open_time);
@@ -94,8 +96,16 @@ const DetailedMultipleChoiceChartCard: FC<Props> = ({
     [choiceItems]
   );
 
-  const [cursorTimestamp, _tooltipDate, handleCursorChange] =
+  const [cursorTimestamp, _tooltipDate, _handleCursorChange] =
     useTimestampCursor(timestamps);
+  // In consumer view, pushes the cursor timestamp to the sidebar choice bars.
+  const handleCursorChange = useCallback(
+    (value: number, format: Parameters<typeof _handleCursorChange>[1]) => {
+      _handleCursorChange(value, format);
+      if (isConsumerView) setCtxCursorTimestamp(value);
+    },
+    [_handleCursorChange, isConsumerView, setCtxCursorTimestamp]
+  );
 
   const liveOptions = useMemo(() => {
     if (!question.options_history?.length || cursorTimestamp === null) {
@@ -311,6 +321,7 @@ const DetailedMultipleChoiceChartCard: FC<Props> = ({
       forecastAvailability={forecastAvailability}
       openTime={openTime}
       withLegend={!isConsumerView}
+      hideTooltip={isConsumerView}
     />
   );
 };

--- a/front_end/src/components/ui/dropdown_menu.tsx
+++ b/front_end/src/components/ui/dropdown_menu.tsx
@@ -15,6 +15,7 @@ import {
   MouseEventHandler,
   ReactElement,
   useEffect,
+  useRef,
   useState,
 } from "react";
 
@@ -63,21 +64,21 @@ function InnerMenuContent({
   className,
   onClose,
 }: DropdownMenuProps & { open: boolean }) {
-  const [prevItems, setPrevItems] = useState<MenuItemProps[]>(items);
+  const prevItemsRef = useRef<MenuItemProps[]>(items);
   const [activeItems, setActiveItems] = useState<MenuItemProps[]>(items);
 
   // Track prop change
   useEffect(() => {
-    setPrevItems(items);
+    prevItemsRef.current = items;
     setActiveItems(items);
   }, [items]);
 
   useEffect(() => {
     if (!open) {
-      setActiveItems(prevItems);
+      setActiveItems(prevItemsRef.current);
       if (onClose) onClose();
     }
-  }, [open, onClose, prevItems]);
+  }, [open, onClose]);
 
   return (
     <>

--- a/front_end/src/contexts/continuous_chart_cursor_context.tsx
+++ b/front_end/src/contexts/continuous_chart_cursor_context.tsx
@@ -17,6 +17,8 @@ type CursorContextValue = {
   setActiveForecast: (f: NumericAggregateForecast | null) => void;
   activeUserForecastValues: number[] | null;
   setActiveUserForecastValues: (v: number[] | null) => void;
+  activeBinaryValue: number | null;
+  setActiveBinaryValue: (v: number | null) => void;
 };
 
 const ContinuousChartCursorContext = createContext<CursorContextValue | null>(
@@ -31,6 +33,9 @@ export const ContinuousChartCursorProvider: FC<{ children: ReactNode }> = ({
   const [activeUserForecastValues, setActiveUserForecastValues] = useState<
     number[] | null
   >(null);
+  const [activeBinaryValue, setActiveBinaryValue] = useState<number | null>(
+    null
+  );
 
   const stableSet = useCallback(
     (f: NumericAggregateForecast | null) => setActiveForecast(f),
@@ -40,6 +45,10 @@ export const ContinuousChartCursorProvider: FC<{ children: ReactNode }> = ({
     (v: number[] | null) => setActiveUserForecastValues(v),
     []
   );
+  const stableSetBinary = useCallback(
+    (v: number | null) => setActiveBinaryValue(v),
+    []
+  );
 
   const value = useMemo(
     () => ({
@@ -47,8 +56,17 @@ export const ContinuousChartCursorProvider: FC<{ children: ReactNode }> = ({
       setActiveForecast: stableSet,
       activeUserForecastValues,
       setActiveUserForecastValues: stableSetUser,
+      activeBinaryValue,
+      setActiveBinaryValue: stableSetBinary,
     }),
-    [activeForecast, stableSet, activeUserForecastValues, stableSetUser]
+    [
+      activeForecast,
+      stableSet,
+      activeUserForecastValues,
+      stableSetUser,
+      activeBinaryValue,
+      stableSetBinary,
+    ]
   );
   return (
     <ContinuousChartCursorContext.Provider value={value}>


### PR DESCRIPTION
Resolves #4764

### Summary

In consumer view, hovering the forecast timeline only synced the mini-distribution on the left for continuous questions. All other question types showed stale values regardless of cursor position. Tooltip also duplicated information already visible in the sidebar.

Implemented changes:

- **`ContinuousChartCursorContext`**: added `activeBinaryValue` / `setActiveBinaryValue` to carry the binary CP value at cursor position
- **`DetailedContinuousChartCard`**: computes CP probability at cursor timestamp and pushes it to context via `useLayoutEffect` for same-frame gauge updates; suppresses floating tooltip in consumer binary view
- **`ConsumerListChartShell`**: added `cursorTimestamp` / `setCursorTimestamp` to `ListChartExpandedContext` so sidebar components can read the hovered timestamp; resets to `null` on mouse leave
- **`DetailedMultipleChoiceChartCard`**: pushes cursor timestamp to context in consumer view; hides floating tooltip
- **`GroupTimeline`**: added `onCursorChange` and `hideTooltip` props and wires them through to `MultiChoicesChartView`
- **`ConsumerGroupChart`**: forwards cursor timestamp to context and hides tooltip for continuous groups
- **`PercentageForecastCard`**: resolves each choice's display value at the cursor timestamp using per-choice history lookup (fixes wrong initial values when sub-questions have different history lengths)
- **`NumericForecastCard`**: same cursor-aware value resolution for numeric group sub-questions
- **`QuestionHeaderCPStatus`** / **`BinaryCPBar`**: accept `cursorBinaryValue` / `overrideValue` to display cursor-position CP instead of latest
- **`QuestionPageShell`**: extracted `BinaryCursorGauge` as an isolated context consumer so `ConsumerShell` no longer re-renders on every cursor move
- **`DropdownMenu`**: converted `prevItems` from state to ref to prevent a render loop triggered by the increased re-render frequency

### Demo video

https://github.com/user-attachments/assets/664338b5-02d9-45f0-bfb7-e4fc2ba3b421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chart cursor shares a timestamp and binary value across charts and headers, letting gauges and headers reflect cursor position.
  * Choice and numeric forecast displays now show values anchored to the chart cursor.

* **Improvements**
  * Optionally hide tooltips in consumer view to reduce clutter.
  * Better coordination of cursor state between list, group and continuous charts.

* **Bug Fixes**
  * Dropdown menu reliably restores previous items when closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->