### PR TITLE
Question-page timeline follow-ups: continuous tooltip (#4822) + group/MC min-height (#4835)

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
@@ -98,6 +98,7 @@ const ConsumerListChartShell: React.FC<Props> = ({
           "flex flex-col sm:flex-row sm:items-stretch",
           !hideBorder &&
             "sm:rounded-lg sm:border sm:border-gray-400/40 dark:sm:border-gray-400-dark/40",
+          stretchListContent && "sm:min-h-[192px]",
           className
         )}
         onMouseLeave={() => setHoveredChoiceName(null)}
@@ -105,7 +106,8 @@ const ConsumerListChartShell: React.FC<Props> = ({
         <div
           ref={listColumnRef}
           className={cn(
-            "order-1 sm:w-80 sm:shrink-0 sm:self-start lg:w-64 xl:w-80",
+            "order-1 sm:w-80 sm:shrink-0 lg:w-64 xl:w-80",
+            !stretchListContent && "sm:self-start",
             reduceInnerPadding ? "sm:py-5 sm:pl-5" : "sm:p-5",
             hideListOnMobile ? "hidden sm:block" : "",
             stretchListContent && "sm:flex sm:flex-col"

--- a/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
@@ -95,6 +95,7 @@ const DetailedContinuousChartCard: FC<Props> = ({
   const [activeView, setActiveView] = useState<ChartView>("timeline");
 
   const isContinuous = isContinuousQuestion(question);
+  const userHasPrediction = !!question.my_forecasts?.history.length;
   const [shouldFetchFull, setShouldFetchFull] = useState(false);
   const { data: enrichedAggregation = null } = useFullAggregation(
     question.id,
@@ -354,7 +355,7 @@ const DetailedContinuousChartCard: FC<Props> = ({
       forecastAvailability={forecastAvailability}
       suppressEmptyOverlay
       cursorTooltip={
-        forecastAvailability?.isEmpty || isContinuous
+        forecastAvailability?.isEmpty || (isContinuous && !userHasPrediction)
           ? undefined
           : cursorTooltip
       }


### PR DESCRIPTION
Two post-launch follow-ups to the question-page / feed redesign, as two separate, individually-scoped commits.

## 1. Restore continuous-timeline hover tooltip for forecasters with a prediction (#4822)

The redesign removed the hover tooltip from continuous-question timelines, on the basis that the left panel now reacts to the cursor. But the left panel only ever shows the **community** value + distribution curves on hover — never the user's own **numeric** prediction value — so forecasters who had a prediction lost the ability to read it off the timeline.

Re-enables the existing full tooltip (community + my prediction + active forecasters) **only when the user has a prediction** (`my_forecasts.history.length`). The chart's existing `!isContinuousConsumerView` guard keeps this to **forecaster view only**; binary questions are unaffected. `continuous_chart_card.tsx` only (2 lines).

<img width="247" height="227" alt="image" src="https://github.com/user-attachments/assets/03533861-372f-4e3e-8989-b4799239230b" />


## 2. Min-height + equal-fill rows for group/MC consumer timeline (#4835)

In consumer views, a group or Multiple-Choice question with only 2-3 options rendered a tiny timeline: the bordered container had no height floor, and the chart column's height is derived from the (short) left option-column.

Adds a `sm:min-h-[192px]` floor to the shared `ConsumerListChartShell` container (gated on `stretchListContent`, so fan graphs / hidden-CP states are untouched) and makes the left column's `sm:self-start` conditional so it stretches to the floor via the existing `sm:items-stretch`. The cards' already-present `flex-1` fill mechanism then distributes the height equally across rows, and the chart grows with the taller measured height. `consumer_list_chart_shell.tsx` only — no new props, no card changes.

<img width="866" height="456" alt="image" src="https://github.com/user-attachments/assets/75d095d1-43ee-4940-a09f-7de68fc866d7" />


## Reviewer notes

- #4822 is **forecaster-view only** by design (consumer view intentionally stays tooltip-free); the floating tooltip co-exists with the on-axis value chip, as it did pre-redesign.
- #4835's floor is gated on `stretchListContent` (CP visible and not a fan graph), so fan / hidden-CP behavior is byte-identical. For ≥6 options the natural height already exceeds 192px (floor inert, expand button preserved). `192px` is a one-line tweak.
- The height coupling is one-way (a single `ResizeObserver` on the left column feeds the chart column), so the floor introduces no layout oscillation.

## Verification

- `tsc` clean; eslint clean on both changed files (no new problems).
- No translation-file changes needed.
- Manual: continuous question **with a prediction** in forecaster view → tooltip on hover (absent in consumer view / when no prediction); consumer-view **2 and 3 option** group + MC → taller container with rows filling equally; many-option / fan-graph / date group → unchanged.

Fixes #4822
Fixes #4835

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Enhanced layout styling for improved visual consistency when content stretching is enabled
  * Refined tooltip behavior based on user forecast data presence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->