### PR TITLE
Fix: continuous chart bullet alignment

### DIFF
--- a/front_end/src/components/charts/continuous_area_chart.tsx
+++ b/front_end/src/components/charts/continuous_area_chart.tsx
@@ -496,6 +496,7 @@ const ContinuousAreaChart: FC<Props> = ({
   const CursorContainer = (
     <VictoryCursorContainer
       cursorLabel={"label"}
+      cursorLabelOffset={{ x: 0, y: 0 }}
       style={{
         strokeWidth: 0,
         touchAction: "pan-y",


### PR DESCRIPTION
Resolves #4833

### Summary

Cursor bullets on continuous forecast charts were rendering 5px to the right of the actual cursor position due to Victory's default `cursorLabelOffset: { x: 5, y: -10 }` – designed for text labels, not dot indicators. On steep/extremized distributions, even a small x-offset causes a large visible y-mismatch, making it impossible to tell what value you're forecasting.

Implemented changes:

- **`ContinuousAreaChart`**: added `cursorLabelOffset={{ x: 0, y: 0 }}` to `VictoryCursorContainer`, matching the pattern already used in `numeric_chart.tsx`, `multiple_choice_chart.tsx`, and `group_chart.tsx`.

### Demo videos

#### Before


https://github.com/user-attachments/assets/82867eed-d625-4ae1-b255-687e6248b1b4



#### After 


https://github.com/user-attachments/assets/fb96fbe2-d897-4ed4-aed3-c1b7856e29f5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted cursor label positioning behavior in area charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->