### PR TITLE
Fix: UI polish and stale forecast

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
@@ -84,7 +84,7 @@ const CompactLegendBar: FC<Props> = ({
         const resolvedNo = isResolvedNo(item, questionType);
         const resolvedYes = isResolvedYes(item, questionType);
         const displayValue = getPredictionDisplayValue(
-          getLastAggregationValue(item),
+          item.latestValue ?? getLastAggregationValue(item),
           {
             questionType,
             scaling: item.scaling,

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell.tsx
@@ -134,7 +134,7 @@ const ConsumerListChartShell: React.FC<Props> = ({
         </div>
         <div
           className={cn(
-            "relative order-2 hidden flex-1 overflow-hidden sm:flex sm:flex-col",
+            "relative order-2 hidden flex-1 overflow-visible sm:flex sm:flex-col",
             reduceInnerPadding ? "sm:py-5" : "sm:p-5",
             !hideDivider &&
               "sm:before:absolute sm:before:bottom-0 sm:before:left-0 sm:before:w-px sm:before:bg-gray-400/40 sm:before:content-[''] dark:sm:before:bg-gray-400-dark/40",

--- a/front_end/src/components/consumer_post_card/consumer_question_tile/consumer_continuous_tile.tsx
+++ b/front_end/src/components/consumer_post_card/consumer_question_tile/consumer_continuous_tile.tsx
@@ -1,8 +1,9 @@
-import { useLocale } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { FC } from "react";
 
 import ContinuousCPBar from "@/components/consumer_post_card/consumer_question_tile/continuous_cp_bar";
 import QuestionContinuousResolutionChip from "@/components/consumer_post_card/question_continuous_resolution_chip";
+import { useHideCP } from "@/contexts/cp_context";
 import { QuestionStatus } from "@/types/post";
 import { ForecastAvailability, QuestionWithForecasts } from "@/types/question";
 import { getPredictionDisplayValue } from "@/utils/formatters/prediction";
@@ -22,6 +23,8 @@ const ConsumerContinuousTile: FC<Props> = ({
   overrideCenter,
 }) => {
   const locale = useLocale();
+  const t = useTranslations();
+  const { hideCP } = useHideCP();
 
   const latest =
     question.aggregations[question.default_aggregation_method]?.latest;
@@ -30,7 +33,7 @@ const ConsumerContinuousTile: FC<Props> = ({
     overrideCenter !== null && overrideCenter !== undefined
       ? overrideCenter
       : latest?.centers?.[0];
-  const communityPredictionDisplayValue =
+  const rawCommunityPredictionDisplayValue =
     effectiveCenter !== undefined
       ? getPredictionDisplayValue(effectiveCenter, {
           questionType: question.type,
@@ -39,6 +42,10 @@ const ConsumerContinuousTile: FC<Props> = ({
           unit: question.unit,
         })
       : null;
+  const communityPredictionDisplayValue =
+    hideCP && rawCommunityPredictionDisplayValue !== null
+      ? t("hidden")
+      : rawCommunityPredictionDisplayValue;
 
   // Resolved/Annulled/Ambiguous
   if (question.resolution) {

--- a/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/index.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/index.tsx
@@ -15,8 +15,8 @@ import {
 
 import NumericForecastCard from "@/components/consumer_post_card/group_forecast_card/numeric_forecast_card";
 import { darkTheme, lightTheme } from "@/constants/chart_theme";
-import { useHideCP } from "@/contexts/cp_context";
 import { METAC_COLORS } from "@/constants/colors";
+import { useHideCP } from "@/contexts/cp_context";
 import useAppTheme from "@/hooks/use_app_theme";
 import useContainerSize from "@/hooks/use_container_size";
 import { ChoiceItem } from "@/types/choices";

--- a/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/index.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/index.tsx
@@ -15,6 +15,7 @@ import {
 
 import NumericForecastCard from "@/components/consumer_post_card/group_forecast_card/numeric_forecast_card";
 import { darkTheme, lightTheme } from "@/constants/chart_theme";
+import { useHideCP } from "@/contexts/cp_context";
 import { METAC_COLORS } from "@/constants/colors";
 import useAppTheme from "@/hooks/use_app_theme";
 import useContainerSize from "@/hooks/use_container_size";
@@ -63,6 +64,7 @@ const DateForecastCard: FC<Props> = ({
   const { questions } = questionsGroup;
   const locale = useLocale();
   const t = useTranslations();
+  const { hideCP } = useHideCP();
   const { theme, getThemeColor } = useAppTheme();
   const chartTheme = theme === "dark" ? darkTheme : lightTheme;
   const {
@@ -82,7 +84,7 @@ const DateForecastCard: FC<Props> = ({
     choices,
     scaling
   );
-  if (points.length === 0) {
+  if (points.length === 0 || hideCP) {
     // Render empty state taken from the Numeric representation
     return <NumericForecastCard post={post} />;
   }

--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_card_wrapper.tsx
@@ -5,7 +5,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslations } from "next-intl";
-import { FC, PropsWithChildren } from "react";
+import { FC, PropsWithChildren, useEffect, useRef, useState } from "react";
 
 import cn from "@/utils/core/cn";
 
@@ -33,6 +33,33 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
 
   const isMinimal = buttonVariant === "minimal";
 
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollDown, setCanScrollDown] = useState(true);
+
+  // 4px threshold avoids a permanently visible gradient on sub-pixel scroll remainders
+  const checkScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const { scrollTop, clientHeight, scrollHeight } = el;
+    setCanScrollDown(scrollTop + clientHeight < scrollHeight - 4);
+  };
+
+  // Hide the bottom gradient when the expanded list has nothing left to scroll
+  useEffect(() => {
+    if (!expanded) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    const frameId = window.requestAnimationFrame(checkScroll);
+    const observer = new ResizeObserver(checkScroll);
+    observer.observe(el);
+    el.addEventListener("scroll", checkScroll, { passive: true });
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      observer.disconnect();
+      el.removeEventListener("scroll", checkScroll);
+    };
+  }, [expanded]);
+
   const toggleButtonClassName = cn(
     "flex w-full self-stretch items-center gap-2 rounded-lg px-[13px]",
     "font-medium leading-4",
@@ -53,6 +80,7 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
       {expanded ? (
         <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
           <div
+            ref={scrollRef}
             className={cn(
               "flex flex-1 flex-col overflow-y-auto no-scrollbar",
               compact ? "gap-1 md:gap-2" : "gap-2"
@@ -61,8 +89,10 @@ const ForecastCardWrapper: FC<PropsWithChildren<Props>> = ({
             {children}
           </div>
           <div
-            className="pointer-events-none absolute bottom-0 left-0 right-0 z-10 h-8 bg-gradient-to-b from-transparent to-gray-0 dark:to-gray-0-dark"
-            style={{ opacity: 0.99 }}
+            className={cn(
+              "pointer-events-none absolute bottom-0 left-0 right-0 z-10 h-8 bg-gradient-to-b from-transparent to-gray-0 transition-opacity dark:to-gray-0-dark",
+              canScrollDown ? "opacity-100" : "opacity-0"
+            )}
           />
         </div>
       ) : (

--- a/front_end/src/components/consumer_post_card/group_forecast_card/index.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/index.tsx
@@ -1,5 +1,6 @@
 import { FC } from "react";
 
+import { useHideCP } from "@/contexts/cp_context";
 import { GroupOfQuestionsGraphType, PostWithForecasts } from "@/types/post";
 import { QuestionType } from "@/types/question";
 import { getGroupForecastAvailability } from "@/utils/questions/forecastAvailability";
@@ -27,15 +28,18 @@ const GroupForecastCard: FC<Props> = ({
   buttonVariant,
   forFeedPage,
 }) => {
+  const { hideCP } = useHideCP();
+
   // Check forecast availability for group posts
   const forecastAvailability = post.group_of_questions
     ? getGroupForecastAvailability(post.group_of_questions.questions)
     : null;
 
-  // Hide chart if no forecasts or CP not yet revealed
+  // Hide chart if no forecasts, CP not yet revealed, or user has hidden CP
   const shouldHideChart =
-    forecastAvailability &&
-    (forecastAvailability.isEmpty || !!forecastAvailability.cpRevealsOn);
+    hideCP ||
+    (forecastAvailability &&
+      (forecastAvailability.isEmpty || !!forecastAvailability.cpRevealsOn));
 
   if (
     post.group_of_questions?.graph_type === GroupOfQuestionsGraphType.FanGraph

--- a/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
@@ -6,6 +6,7 @@ import { FC, useState } from "react";
 
 import { useListChartExpanded } from "@/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell";
 import { getEffectiveVisibleCount } from "@/constants/questions";
+import { useHideCP } from "@/contexts/cp_context";
 import { useOverlayMaxHeight } from "@/hooks/use_overlay_max_height";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import { QuestionType, Scaling } from "@/types/question";
@@ -41,6 +42,7 @@ const NumericForecastCard: FC<Props> = ({
 }) => {
   const locale = useLocale();
   const t = useTranslations();
+  const { hideCP } = useHideCP();
   const [expanded, setExpanded] = useState(false);
   const { setIsExpanded, setHoveredChoiceName, cursorTimestamp } =
     useListChartExpanded();
@@ -145,10 +147,9 @@ const NumericForecastCard: FC<Props> = ({
         index
       ) => {
         const isChoiceClosed = closeTime ? closeTime < Date.now() : false;
-        const rawChoiceValue = getChoiceValue(
-          aggregationValues,
-          aggregationTimestamps
-        );
+        const rawChoiceValue = hideCP
+          ? null
+          : getChoiceValue(aggregationValues, aggregationTimestamps);
         const normalizedScaling: Scaling = {
           range_min: scaling?.range_min ?? 0,
           range_max: scaling?.range_max ?? 1,
@@ -158,18 +159,20 @@ const NumericForecastCard: FC<Props> = ({
           questionType: isDateGroup ? QuestionType.Date : QuestionType.Numeric,
           scaling: normalizedScaling,
           actual_resolve_time: actual_resolve_time ?? null,
-          emptyLabel: t("Upcoming"),
+          emptyLabel: hideCP ? t("hidden") : t("Upcoming"),
         });
         const scaledChoiceValue = !isNil(rawChoiceValue)
           ? scaleInternalLocation(rawChoiceValue, normalizedScaling)
           : NaN;
         const relativeWidth = !isNil(resolution)
           ? 100
-          : calculateRelativeWidth({
-              scaledChoiceValue,
-              maxScaledValue,
-              minScaledValue,
-            });
+          : hideCP
+            ? 0
+            : calculateRelativeWidth({
+                scaledChoiceValue,
+                maxScaledValue,
+                minScaledValue,
+              });
 
         return (
           <ForecastChoiceBar

--- a/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
@@ -5,6 +5,7 @@ import { FC, useMemo, useState } from "react";
 
 import { useListChartExpanded } from "@/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_list_chart_shell";
 import { getEffectiveVisibleCount } from "@/constants/questions";
+import { useHideCP } from "@/contexts/cp_context";
 import { useOverlayMaxHeight } from "@/hooks/use_overlay_max_height";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 import { QuestionType } from "@/types/question";
@@ -40,6 +41,7 @@ const PercentageForecastCard: FC<Props> = ({
 }) => {
   const locale = useLocale();
   const t = useTranslations();
+  const { hideCP } = useHideCP();
   const [expanded, setExpanded] = useState(false);
   const { setIsExpanded, cursorTimestamp } = useListChartExpanded();
   const { containerRef, overlayMaxHeight } = useOverlayMaxHeight(expanded);
@@ -47,7 +49,7 @@ const PercentageForecastCard: FC<Props> = ({
   const isMC = isMultipleChoicePost(post);
   const cpRevealTime = post.question?.cp_reveal_time;
   const emptyLabel =
-    cpRevealTime && new Date(cpRevealTime).getTime() > Date.now()
+    hideCP || (cpRevealTime && new Date(cpRevealTime).getTime() > Date.now())
       ? t("hidden")
       : t("Upcoming");
 
@@ -62,7 +64,7 @@ const PercentageForecastCard: FC<Props> = ({
     const raw = generateChoiceItems(post, visibleChoicesCount, locale, t);
     return raw.map((choice) => {
       const valueStr = getPredictionDisplayValue(
-        choice.latestValue ?? choice.aggregationValues.at(-1),
+        hideCP ? null : choice.latestValue ?? choice.aggregationValues.at(-1),
         {
           questionType: QuestionType.Binary,
           scaling: choice.scaling,
@@ -86,7 +88,7 @@ const PercentageForecastCard: FC<Props> = ({
         isChoiceClosed,
       };
     });
-  }, [post, visibleChoicesCount, locale, t, emptyLabel]);
+  }, [post, visibleChoicesCount, locale, t, emptyLabel, hideCP]);
 
   // Resolves each choice's value at the cursor (or last) timestamp using its
   // own timeline, since history lengths differ per sub-question.
@@ -107,8 +109,11 @@ const PercentageForecastCard: FC<Props> = ({
       const ownTimestamps = choice.aggregationTimestamps;
       const closestTs = findPreviousTimestamp(ownTimestamps, refTs);
       const ownIdx = ownTimestamps.indexOf(closestTs);
-      const rawVal =
-        ownIdx >= 0 ? choice.aggregationValues[ownIdx] ?? null : null;
+      const rawVal = hideCP
+        ? null
+        : ownIdx >= 0
+          ? choice.aggregationValues[ownIdx] ?? null
+          : null;
       const valueStr = getPredictionDisplayValue(rawVal, {
         questionType: QuestionType.Binary,
         scaling: choice.scaling,
@@ -121,7 +126,7 @@ const PercentageForecastCard: FC<Props> = ({
           : 0;
       return { ...choice, valueStr, percent };
     });
-  }, [allChoices, cursorTimestamp, emptyLabel]);
+  }, [allChoices, cursorTimestamp, emptyLabel, hideCP]);
 
   if (!isMC && !isGroupOfQuestionsPost(post)) return null;
 

--- a/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
@@ -62,7 +62,7 @@ const PercentageForecastCard: FC<Props> = ({
     const raw = generateChoiceItems(post, visibleChoicesCount, locale, t);
     return raw.map((choice) => {
       const valueStr = getPredictionDisplayValue(
-        choice.aggregationValues.at(-1),
+        choice.latestValue ?? choice.aggregationValues.at(-1),
         {
           questionType: QuestionType.Binary,
           scaling: choice.scaling,

--- a/front_end/src/components/forecast_maker/forecast_choice_option.tsx
+++ b/front_end/src/components/forecast_maker/forecast_choice_option.tsx
@@ -200,7 +200,9 @@ const ForecastChoiceOption = <T = string,>({
                 rail: {
                   height: "1px",
                   opacity: 0.35,
-                  backgroundColor: getThemeColor(METAC_COLORS.gray["1000"]),
+                  backgroundColor: mounted
+                    ? getThemeColor(METAC_COLORS.gray["1000"])
+                    : METAC_COLORS.gray["1000"].DEFAULT,
                 },
               }
             : {}

--- a/front_end/src/components/post_card/multiple_choice_tile/choice_option.tsx
+++ b/front_end/src/components/post_card/multiple_choice_tile/choice_option.tsx
@@ -80,7 +80,7 @@ const ChoiceOption: FC<Props> = ({
         .join(" ")
     : resolution;
 
-  const hasValue = !isNil(values.at(-1));
+  const hasValue = !isNil(latestValue);
   const isEmbed = useIsEmbedMode();
 
   return (

--- a/front_end/src/components/post_card/multiple_choice_tile/choice_option.tsx
+++ b/front_end/src/components/post_card/multiple_choice_tile/choice_option.tsx
@@ -80,7 +80,7 @@ const ChoiceOption: FC<Props> = ({
         .join(" ")
     : resolution;
 
-  const hasValue = !isNil(latestValue);
+  const hasValue = !isNil(valueAtCursor);
   const isEmbed = useIsEmbedMode();
 
   return (

--- a/front_end/src/components/post_card/multiple_choice_tile/choice_option.tsx
+++ b/front_end/src/components/post_card/multiple_choice_tile/choice_option.tsx
@@ -25,6 +25,7 @@ type Props = {
   withIcon?: boolean;
   cursorTimestamp?: number | null;
   timestamps?: number[];
+  latestValue?: number | null;
 };
 
 const ChoiceOption: FC<Props> = ({
@@ -41,6 +42,7 @@ const ChoiceOption: FC<Props> = ({
   cursorTimestamp = null,
   timestamps = [],
   withIcon = true,
+  latestValue,
 }) => {
   const idx =
     cursorTimestamp == null || !timestamps?.length
@@ -55,7 +57,8 @@ const ChoiceOption: FC<Props> = ({
           )
         );
 
-  const valueAtCursor = values[idx];
+  const valueAtCursor =
+    cursorTimestamp == null && !isNil(latestValue) ? latestValue : values[idx];
   const resolutionWords = String(displayedResolution)?.split(" ");
   const adjustedResolution = resolutionWords.length
     ? resolutionWords

--- a/front_end/src/components/post_card/multiple_choice_tile/multiple_choice_tile_legend.tsx
+++ b/front_end/src/components/post_card/multiple_choice_tile/multiple_choice_tile_legend.tsx
@@ -84,7 +84,7 @@ const MultipleChoiceTileLegend: FC<Props> = ({
               actual_resolve_time={actual_resolve_time}
               withIcon={withChoiceIcon}
               cursorTimestamp={cursorTimestamp}
-              latestValue={latestValue}
+              latestValue={hideCP ? undefined : latestValue}
             />
           </div>
         )

--- a/front_end/src/components/post_card/multiple_choice_tile/multiple_choice_tile_legend.tsx
+++ b/front_end/src/components/post_card/multiple_choice_tile/multiple_choice_tile_legend.tsx
@@ -64,6 +64,7 @@ const MultipleChoiceTileLegend: FC<Props> = ({
           displayedResolution,
           scaling,
           actual_resolve_time,
+          latestValue,
         }) => (
           <div
             key={`choice-option-${choice}`}
@@ -83,6 +84,7 @@ const MultipleChoiceTileLegend: FC<Props> = ({
               actual_resolve_time={actual_resolve_time}
               withIcon={withChoiceIcon}
               cursorTimestamp={cursorTimestamp}
+              latestValue={latestValue}
             />
           </div>
         )

--- a/front_end/src/types/choices.ts
+++ b/front_end/src/types/choices.ts
@@ -25,6 +25,7 @@ export type ChoiceItem = {
   aggregationMinValues: (number | null)[];
   aggregationMaxValues: (number | null)[];
   aggregationForecasterCounts: number[];
+  latestValue?: number | null;
   userTimestamps: number[];
   userValues: (number | null)[];
   actual_resolve_time?: string | null;

--- a/front_end/src/utils/questions/choices.ts
+++ b/front_end/src/utils/questions/choices.ts
@@ -400,6 +400,9 @@ export function generateChoiceItemsFromGroupQuestions(
       aggregationMinValues: aggregationMinValues,
       aggregationMaxValues: aggregationMaxValues,
       aggregationForecasterCounts: aggregationForecasterCounts,
+      latestValue:
+        question.aggregations[question.default_aggregation_method].latest
+          ?.centers?.[0] ?? null,
       userTimestamps: sortedUserTimestamps,
       userValues: userValues,
       userMinValues:


### PR DESCRIPTION
Resolves #4836
Resolves #4837
Resolves #4842

### Summary

**Fix 1: Expand gradient fadeout in consumer group/MC views**

The fadeout overlay stayed visible even when the list was fully expanded or had no overflow, causing a visual artifact at the bottom.

Implemented changes:

- **`ConsumerListChartShell`**: hide the gradient when scroll is at the bottom or content does not overflow the container.

---

**Fix 2: Fan chart tooltip contained within its parent**

The tooltip could overflow outside the chart container on questions with many options or near the edges.

Implemented changes:

- **`FanChart`**: constrained tooltip position to stay within the chart bounding box.

---

**Fix 3: Sidebar forecast % not updating live**

Group sub-question percentages in the similar questions sidebar showed stale values even after the community prediction had moved, persisting across refreshes.

Root cause: `generateChoiceItemsFromGroupQuestions` filters `aggregationHistory` by `closeTime`, which excluded the most recent forecast for closed sub-questions. The display value was read from that filtered array instead of `latest`. Standalone binary questions are unaffected – they read directly from `aggregations[method].latest.centers[0]` and never touch the filtered history.

Implemented changes:

- **`choices.ts`**: populate `latestValue` from `aggregations[method].latest.centers[0]` on each choice item.
- **`percentage_forecast_card.tsx`**, **`choice_option.tsx`**, **`compact_legend_bar`**: prefer `latestValue` over the last history entry when rendering the current percentage.


### Demo videos 

#### Before

- Sidebar forecast % not updating live

https://github.com/user-attachments/assets/0c255d70-2227-446c-a9df-b32bc66f5b10


#### After

- Expand gradient fadeout in consumer group/MC views

https://github.com/user-attachments/assets/a83b36b1-f226-41fa-89b5-e3408777178f

- Fan chart tooltip contained within its parent

https://github.com/user-attachments/assets/7d289fd6-b787-48e6-b2e2-ba3f83f8fa55

- Sidebar forecast % not updating live

https://github.com/user-attachments/assets/5889dfae-00ae-4a13-a075-ccc9e9b09ba3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forecast cards and tiles now support a “hide predictions” mode, showing a localized “hidden” state instead of CP content.
  * Forecast displays prefer an available latest value (with fallback to recent history) across charts/legends/tiles.

* **Bug Fixes**
  * Choice display and cursor/timeline styling now use the correct value source when latest data is present.

* **Style**
  * Expanded forecast cards better indicate whether more content can scroll.
  * Chart overflow and legend/slider visuals were adjusted for improved consistency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->