### PR TITLE
Fix: Comment images not loading on iOS Safari

### DIFF
--- a/front_end/src/app/globals.css
+++ b/front_end/src/app/globals.css
@@ -201,7 +201,7 @@ a {
 }
 
 .content img {
-  @apply mx-auto block max-h-[500px];
+  @apply mx-auto block max-h-[500px] max-w-full;
 }
 
 .content blockquote {

--- a/front_end/src/components/markdown_editor/editor.css
+++ b/front_end/src/components/markdown_editor/editor.css
@@ -88,7 +88,7 @@
 }
 
 [data-editor-block-type="image"] {
-  @apply mx-auto flex w-fit;
+  @apply mx-auto flex w-fit max-w-full;
 }
 
 [data-editor-block-type="image"] > :last-child:not(:only-child) {

--- a/front_end/src/components/markdown_editor/initialized_editor.tsx
+++ b/front_end/src/components/markdown_editor/initialized_editor.tsx
@@ -1,5 +1,6 @@
 import "@mdxeditor/editor/style.css";
 import "./editor.css";
+import "./plugins/read_only_image";
 
 import {
   CodeBlockEditorDescriptor,

--- a/front_end/src/components/markdown_editor/plugins/read_only_image.tsx
+++ b/front_end/src/components/markdown_editor/plugins/read_only_image.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { ImageNode } from "@mdxeditor/editor";
+import React from "react";
+
+// MDXEditor's imagePlugin uses an imgCache that preloads images via new Image() before
+// rendering. In some environments (reported on iOS Safari), this off-screen preload
+// silently hangs — neither onload nor onerror fires — leaving the imgCache Promise
+// permanently unresolved and React Suspense stuck on the ImagePlaceholder indefinitely.
+// In read-only mode (editor.isEditable() === false), bypass ImageEditor/Suspense/imgCache
+// entirely and render a plain <img> directly from the DecoratorNode.
+const _originalDecorate = ImageNode.prototype.decorate;
+
+ImageNode.prototype.decorate = function (
+  this: ImageNode,
+  parentEditor: Parameters<typeof _originalDecorate>[0],
+  config: Parameters<typeof _originalDecorate>[1]
+): ReturnType<typeof _originalDecorate> {
+  if (!parentEditor.isEditable()) {
+    return React.createElement("img", {
+      src: this.getSrc(),
+      alt: this.getAltText(),
+      title: this.getTitle() ?? undefined,
+      style: { maxWidth: "100%", display: "block", margin: "0 auto" },
+    });
+  }
+  return _originalDecorate.call(this, parentEditor, config);
+};


### PR DESCRIPTION
Resolves #4841

### Summary

Comment images were stuck showing a gray dashed placeholder (`ImagePlaceholder`) instead of loading on some iOS Safari versions. Root cause: MDXEditor's `imagePlugin` preloads every image via an off-screen `new Image()` before rendering. On affected iOS Safari versions, this preload silently hangs — neither `onload` nor `onerror` ever fires — leaving the internal `imgCache` Promise permanently unresolved and React Suspense indefinitely showing the placeholder.

Implemented changes:

- **`plugins/read_only_image.tsx`**: new side-effect module that patches `ImageNode.prototype.decorate` at import time. When the Lexical editor is in read-only mode (`editor.isEditable() === false`), it bypasses the entire `ImageEditor` → `imgCache` → `new Image()` → Suspense chain and renders a plain `<img>` element directly. Write mode (`editor.isEditable() === true`) falls through to the original implementation unchanged — image upload, resize handles, and all editor functionality are unaffected.
- **`initialized_editor.tsx`**: added side-effect import of `read_only_image.tsx` so the patch is applied before any editor instance mounts.
- **`globals.css`**: added `max-w-full` to `.content img` to prevent images from overflowing narrow mobile viewports.
- **`editor.css`**: added `max-w-full` to `[data-editor-block-type="image"]` wrapper for the same reason in write mode.

The patch is gated on `editor.isEditable()`, so write mode editors (comment editing, question descriptions) continue using the original MDXEditor image rendering path with full upload and resize support.

### Demo videos

#### Before (simulated with `new Image()` hang to reproduce iOS Safari behavior)

https://github.com/user-attachments/assets/5b941f6e-33b3-4a7c-8953-360e43190feb


#### After (same simulation applied – images now load correctly)

https://github.com/user-attachments/assets/3c6ed6b0-112c-48c6-98f9-44924c7e23f1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll-lock behavior and improved layout consistency
  * Enhanced image sizing constraints to prevent content overflow beyond container boundaries

* **New Features**
  * Improved image rendering in read-only editor mode with better display stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->