### PR TITLE
Fix: Sidebar similar questions client-side fetch to prevent streaming null error

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/similar_questions.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tabs/similar_questions.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import { FC } from "react";
 
 import LoadingSpinner from "@/components/ui/loading_spiner";
-import ClientPostsApi from "@/services/api/posts/posts.client";
-import { PostStatus, PostWithForecasts } from "@/types/post";
+import { PostWithForecasts } from "@/types/post";
 
 import SimilarQuestionsList from "../../sidebar/similar_questions/similar_questions_list";
+import { useSimilarQuestions } from "../../sidebar/similar_questions/use_similar_questions";
 
 type Props = {
   post: PostWithForecasts;
@@ -15,58 +14,12 @@ type Props = {
 };
 
 const SimilarQuestionsTab: FC<Props> = ({ post, variant }) => {
-  const isApproved = post.curation_status === PostStatus.APPROVED;
+  const { questions, isLoading } = useSimilarQuestions(post, variant);
 
-  const {
-    data: similarQuestions = [],
-    isSuccess: hasSimilarQuestionsResult,
-    isError: isSimilarError,
-    isLoading: isSimilarLoading,
-  } = useQuery({
-    queryKey: ["similar-posts", post.id],
-    queryFn: () => ClientPostsApi.getSimilarPosts(post.id),
-    enabled: isApproved,
-  });
+  if (isLoading) return <LoadingSpinner className="my-4" />;
+  if (!questions.length) return null;
 
-  const { data: topQuestions = [], isLoading: isTopLoading } = useQuery({
-    queryKey: ["top-posts-fallback", variant],
-    queryFn: () =>
-      ClientPostsApi.getPostsWithCP({
-        topic: "top-50",
-        for_main_feed: "false",
-        for_consumer_view: variant === "consumer" ? "true" : "false",
-        order_by: "-hotness",
-        statuses: [
-          PostStatus.OPEN,
-          PostStatus.CLOSED,
-          PostStatus.RESOLVED,
-          PostStatus.UPCOMING,
-        ],
-        limit: 8,
-      }),
-    // only fetch when similar posts query settled with no results or errored
-    enabled:
-      !isApproved ||
-      isSimilarError ||
-      (hasSimilarQuestionsResult && !similarQuestions.length),
-    select: (data) => data.results.filter((q) => q.id !== post.id),
-    staleTime: 5 * 60 * 1000,
-  });
-
-  const displayQuestions = similarQuestions.length
-    ? similarQuestions
-    : topQuestions;
-
-  if (!displayQuestions.length) {
-    if (isSimilarLoading || isTopLoading) {
-      return <LoadingSpinner className="my-4" />;
-    }
-    return null;
-  }
-
-  return (
-    <SimilarQuestionsList questions={displayQuestions} variant={variant} />
-  );
+  return <SimilarQuestionsList questions={questions} variant={variant} />;
 };
 
 export default SimilarQuestionsTab;

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/index.tsx
@@ -1,6 +1,5 @@
-import { FC, Suspense } from "react";
+import { FC } from "react";
 
-import LoadingSpinner from "@/components/ui/loading_spiner";
 import { PostStatus, PostWithForecasts } from "@/types/post";
 
 import SidebarContainer from "./sidebar_container";
@@ -33,9 +32,7 @@ const Sidebar: FC<Props> = ({
       )}
 
       {postData.curation_status === PostStatus.APPROVED && (
-        <Suspense fallback={<LoadingSpinner className="my-4" />}>
-          <SimilarQuestions post_id={postData.id} variant={variant} />
-        </Suspense>
+        <SimilarQuestions post={postData} variant={variant} />
       )}
     </section>
   );

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/index.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import { FC } from "react";
 
 import LoadingSpinner from "@/components/ui/loading_spiner";
-import ClientPostsApi from "@/services/api/posts/posts.client";
-import { PostStatus, PostWithForecasts } from "@/types/post";
+import { PostWithForecasts } from "@/types/post";
 
 import SimilarQuestionsList from "./similar_questions_list";
+import { useSimilarQuestions } from "./use_similar_questions";
 
 type Props = {
   post: PostWithForecasts;
@@ -15,57 +14,12 @@ type Props = {
 };
 
 const SimilarQuestions: FC<Props> = ({ post, variant }) => {
-  const isApproved = post.curation_status === PostStatus.APPROVED;
+  const { questions, isLoading } = useSimilarQuestions(post, variant);
 
-  const {
-    data: similarQuestions = [],
-    isSuccess: hasSimilarQuestionsResult,
-    isError: isSimilarError,
-    isLoading: isSimilarLoading,
-  } = useQuery({
-    queryKey: ["similar-posts", post.id],
-    queryFn: () => ClientPostsApi.getSimilarPosts(post.id),
-    enabled: isApproved,
-  });
+  if (isLoading) return <LoadingSpinner className="my-4" />;
+  if (!questions.length) return null;
 
-  const { data: topQuestions = [], isLoading: isTopLoading } = useQuery({
-    queryKey: ["top-posts-fallback", variant],
-    queryFn: () =>
-      ClientPostsApi.getPostsWithCP({
-        topic: "top-50",
-        for_main_feed: "false",
-        for_consumer_view: variant === "consumer" ? "true" : "false",
-        order_by: "-hotness",
-        statuses: [
-          PostStatus.OPEN,
-          PostStatus.CLOSED,
-          PostStatus.RESOLVED,
-          PostStatus.UPCOMING,
-        ],
-        limit: 8,
-      }),
-    enabled:
-      !isApproved ||
-      isSimilarError ||
-      (hasSimilarQuestionsResult && !similarQuestions.length),
-    select: (data) => data.results.filter((q) => q.id !== post.id),
-    staleTime: 5 * 60 * 1000,
-  });
-
-  const displayQuestions = similarQuestions.length
-    ? similarQuestions
-    : topQuestions;
-
-  if (!displayQuestions.length) {
-    if (isSimilarLoading || isTopLoading) {
-      return <LoadingSpinner className="my-4" />;
-    }
-    return null;
-  }
-
-  return (
-    <SimilarQuestionsList questions={displayQuestions} variant={variant} />
-  );
+  return <SimilarQuestionsList questions={questions} variant={variant} />;
 };
 
 export default SimilarQuestions;

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/index.tsx
@@ -1,39 +1,71 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
 import { FC } from "react";
 
-import WithServerComponentErrorBoundary from "@/components/server_component_error_boundary";
-import ServerPostsApi from "@/services/api/posts/posts.server";
-import { PostStatus } from "@/types/post";
+import LoadingSpinner from "@/components/ui/loading_spiner";
+import ClientPostsApi from "@/services/api/posts/posts.client";
+import { PostStatus, PostWithForecasts } from "@/types/post";
 
 import SimilarQuestionsList from "./similar_questions_list";
 
 type Props = {
-  post_id: number;
+  post: PostWithForecasts;
   variant?: "forecaster" | "consumer";
 };
 
-const SimilarQuestions: FC<Props> = async ({ post_id, variant }) => {
-  let questions = await ServerPostsApi.getSimilarPosts(post_id);
+const SimilarQuestions: FC<Props> = ({ post, variant }) => {
+  const isApproved = post.curation_status === PostStatus.APPROVED;
 
-  if (!questions.length) {
-    const { results } = await ServerPostsApi.getPostsWithCP({
-      topic: "top-50",
-      for_main_feed: "false",
-      for_consumer_view: variant === "consumer" ? "true" : "false",
-      order_by: "-hotness",
-      statuses: [
-        PostStatus.OPEN,
-        PostStatus.CLOSED,
-        PostStatus.RESOLVED,
-        PostStatus.UPCOMING,
-      ],
-      limit: 8,
-    });
-    questions = results.filter((q) => q.id !== post_id);
+  const {
+    data: similarQuestions = [],
+    isSuccess: hasSimilarQuestionsResult,
+    isError: isSimilarError,
+    isLoading: isSimilarLoading,
+  } = useQuery({
+    queryKey: ["similar-posts", post.id],
+    queryFn: () => ClientPostsApi.getSimilarPosts(post.id),
+    enabled: isApproved,
+  });
+
+  const { data: topQuestions = [], isLoading: isTopLoading } = useQuery({
+    queryKey: ["top-posts-fallback", variant],
+    queryFn: () =>
+      ClientPostsApi.getPostsWithCP({
+        topic: "top-50",
+        for_main_feed: "false",
+        for_consumer_view: variant === "consumer" ? "true" : "false",
+        order_by: "-hotness",
+        statuses: [
+          PostStatus.OPEN,
+          PostStatus.CLOSED,
+          PostStatus.RESOLVED,
+          PostStatus.UPCOMING,
+        ],
+        limit: 8,
+      }),
+    enabled:
+      !isApproved ||
+      isSimilarError ||
+      (hasSimilarQuestionsResult && !similarQuestions.length),
+    select: (data) => data.results.filter((q) => q.id !== post.id),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const displayQuestions = similarQuestions.length
+    ? similarQuestions
+    : topQuestions;
+
+  if (!displayQuestions.length) {
+    if (isSimilarLoading || isTopLoading) {
+      return <LoadingSpinner className="my-4" />;
+    }
+    return null;
   }
 
-  if (!questions.length) return null;
-
-  return <SimilarQuestionsList questions={questions} variant={variant} />;
+  return (
+    <SimilarQuestionsList questions={displayQuestions} variant={variant} />
+  );
 };
 
-export default WithServerComponentErrorBoundary(SimilarQuestions) as FC<Props>;
+export default SimilarQuestions;

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/use_similar_questions.ts
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/use_similar_questions.ts
@@ -1,0 +1,52 @@
+import { useQuery } from "@tanstack/react-query";
+
+import ClientPostsApi from "@/services/api/posts/posts.client";
+import { PostStatus, PostWithForecasts } from "@/types/post";
+
+export function useSimilarQuestions(
+  post: PostWithForecasts,
+  variant?: "forecaster" | "consumer"
+) {
+  const isApproved = post.curation_status === PostStatus.APPROVED;
+
+  const {
+    data: similarQuestions = [],
+    isSuccess: hasSimilarQuestionsResult,
+    isError: isSimilarError,
+    isLoading: isSimilarLoading,
+  } = useQuery({
+    queryKey: ["similar-posts", post.id],
+    queryFn: () => ClientPostsApi.getSimilarPosts(post.id),
+    enabled: isApproved,
+  });
+
+  const { data: topQuestions = [], isLoading: isTopLoading } = useQuery({
+    queryKey: ["top-posts-fallback", variant],
+    queryFn: () =>
+      ClientPostsApi.getPostsWithCP({
+        topic: "top-50",
+        for_main_feed: "false",
+        for_consumer_view: variant === "consumer" ? "true" : "false",
+        order_by: "-hotness",
+        statuses: [
+          PostStatus.OPEN,
+          PostStatus.CLOSED,
+          PostStatus.RESOLVED,
+          PostStatus.UPCOMING,
+        ],
+        limit: 8,
+      }),
+    // only fetch when similar posts query settled with no results or errored
+    enabled:
+      !isApproved ||
+      isSimilarError ||
+      (hasSimilarQuestionsResult && !similarQuestions.length),
+    select: (data) => data.results.filter((q) => q.id !== post.id),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const questions = similarQuestions.length ? similarQuestions : topQuestions;
+  const isLoading = isSimilarLoading || isTopLoading;
+
+  return { questions, isLoading };
+}


### PR DESCRIPTION
### Summary

https://metaculus.sentry.io/issues/7513507834/events/latest/?notification_uuid=448a08cc-ec78-4632-8761-9a599f992d5f&project=4507883273125888&referrer=latest-event

A recurring Sentry error `TypeError: Cannot read properties of null (reading 'parentNode')` was thrown inside React's internal `$RS` streaming reveal function on the question page (`/questions/:id`). The root cause was traced to the `Suspense` boundary wrapping the async server component `SimilarQuestions` in the desktop sidebar – React generates an `$RS` call for every Suspense boundary in the HTML stream, and if the target element is missing from the DOM when that call fires, it throws.

Implemented changes:

- **`sidebar/similar_questions/index.tsx`**: converted from an async server component (wrapped in `WithServerComponentErrorBoundary`) to a `"use client"` component using `useQuery`. Mirrors the identical logic already in `question_page_shell/tabs/similar_questions.tsx`. No Suspense boundary means no `$RS` call is generated for this component – the error physically cannot occur.
- **`sidebar/index.tsx`**: removed the `Suspense` wrapper and `LoadingSpinner` fallback (now handled internally by the component), updated prop from `post_id` to `post`, kept the `PostStatus.APPROVED` guard.
- Extracted the duplicated query logic into a shared `useSimilarQuestions` hook (`sidebar/similar_questions/use_similar_questions.ts`) – the sidebar and tab components were line-for-line identical, now both are thin wrappers around a single source of truth.


The `queryKey: ["similar-posts", post.id]` is shared with `SimilarQuestionsTab`, so desktop sidebar and mobile tab view share the same React Query cache entry – no duplicate network requests when both are mounted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized similar questions functionality for improved code maintainability and loading state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->