### PR TITLE
Fix: Posted comment appears as unread

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/meta_row.tsx
@@ -6,6 +6,7 @@ import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import { useTranslations } from "next-intl";
 import { FC } from "react";
 
+import { useCommentsFeedSafe } from "@/app/(main)/components/comments_feed_provider";
 import ForecastersCounter from "@/app/(main)/questions/components/forecaster_counter";
 import { PostDropdownMenu } from "@/components/post_actions";
 import CommentStatus from "@/components/post_card/basic_post_card/comment_status";
@@ -33,6 +34,11 @@ const MetaRow: FC<Props> = ({ post, className, variant }) => {
   const t = useTranslations();
   const resolutionData = extractPostResolution(post);
   const { ref, width } = useContainerSize<HTMLDivElement>();
+  const commentsFeed = useCommentsFeedSafe();
+  const commentCount =
+    typeof commentsFeed?.totalCount === "number"
+      ? commentsFeed.totalCount
+      : post.comment_count ?? 0;
 
   const projectsData = post.projects;
   const defaultProject = projectsData?.default_project ?? null;
@@ -71,7 +77,7 @@ const MetaRow: FC<Props> = ({ post, className, variant }) => {
         <div className="flex items-center gap-1.5">
           {variant === "forecaster" && <PostVoter post={post} compact />}
           <CommentStatus
-            totalCount={post.comment_count ?? 0}
+            totalCount={commentCount}
             unreadCount={post.unread_comment_count ?? 0}
             url={getPostLink(post)}
             className={cn(
@@ -115,7 +121,7 @@ const MetaRow: FC<Props> = ({ post, className, variant }) => {
         <div className="flex shrink-0 items-center gap-1.5">
           <PostVoter post={post} />
           <CommentStatus
-            totalCount={post.comment_count ?? 0}
+            totalCount={commentCount}
             unreadCount={post.unread_comment_count ?? 0}
             url={getPostLink(post)}
             className="bg-gray-200 dark:bg-gray-200-dark"

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tab_bar.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tab_bar.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import { FC, useEffect } from "react";
 
 import useCoherenceLinksContext from "@/app/(main)/components/coherence_links_provider";
+import { useCommentsFeedSafe } from "@/app/(main)/components/comments_feed_provider";
 import { Tabs, TabsList, TabsTab } from "@/components/ui/tabs";
 import { useBreakpoint } from "@/hooks/tailwind";
 import { PostStatus, PostWithForecasts } from "@/types/post";
@@ -50,7 +51,11 @@ const QuestionPageShellTabBar: FC<Props> = ({ post, variant, className }) => {
   const { activeTab, setActiveTab } = useQuestionLayout();
 
   const isSm = useBreakpoint("sm");
-  const commentCount = post.comment_count ?? 0;
+  const commentsFeed = useCommentsFeedSafe();
+  const commentCount =
+    typeof commentsFeed?.totalCount === "number"
+      ? commentsFeed.totalCount
+      : post.comment_count ?? 0;
   const { aggregateCoherenceLinks } = useCoherenceLinksContext();
   const questionLinksCount = aggregateCoherenceLinks.data.filter(
     isDisplayableQuestionLink

--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -80,6 +80,7 @@ type CommentChildrenTreeProps = {
   lastViewedAt?: string;
   shouldSuggestKeyFactors?: boolean;
   isSomeChildrenUnread?: boolean;
+  onReplyCreated?: (createdAt: string) => void;
 };
 
 const CommentChildrenTree: FC<CommentChildrenTreeProps> = ({
@@ -92,6 +93,7 @@ const CommentChildrenTree: FC<CommentChildrenTreeProps> = ({
   lastViewedAt,
   shouldSuggestKeyFactors = false,
   isSomeChildrenUnread = false,
+  onReplyCreated,
 }) => {
   const t = useTranslations();
   const sortedCommentChildren = sortComments([...commentChildren], sort);
@@ -212,6 +214,7 @@ const CommentChildrenTree: FC<CommentChildrenTreeProps> = ({
                   forceExpandedChildren={
                     forceExpandedChildren || forceExpandSubtree
                   }
+                  onReplyCreated={onReplyCreated}
                 />
               </div>
             );
@@ -233,6 +236,7 @@ type CommentProps = {
   isCommentJustCreated?: boolean;
   shouldSuggestKeyFactors?: boolean;
   forceExpandedChildren?: boolean;
+  onReplyCreated?: (createdAt: string) => void;
 };
 
 const Comment: FC<CommentProps> = ({
@@ -247,6 +251,7 @@ const Comment: FC<CommentProps> = ({
   isCommentJustCreated = false,
   shouldSuggestKeyFactors = false,
   forceExpandedChildren = false,
+  onReplyCreated,
 }) => {
   const t = useTranslations();
   const commentRef = useRef<HTMLDivElement>(null);
@@ -365,7 +370,7 @@ const Comment: FC<CommentProps> = ({
   const [hasExhaustedSuggestions, setHasExhaustedSuggestions] = useState(false);
   const hasAutoOpenedKeyFactorsRef = useRef(false);
 
-  const { combinedKeyFactors } = useCommentsFeed();
+  const { combinedKeyFactors, totalCount, setTotalCount } = useCommentsFeed();
   const {
     suggestedKeyFactors,
     isLoadingSuggestedKeyFactors,
@@ -1119,6 +1124,10 @@ const Comment: FC<CommentProps> = ({
             replyUsername={comment.author.username}
             onSubmit={(newComment: CommentType) => {
               addNewChildrenComment(comment, newComment);
+              onReplyCreated?.(newComment.created_at);
+              if (typeof totalCount === "number") {
+                setTotalCount(totalCount + 1);
+              }
               setIsReplying(false);
             }}
             isReplying={isReplying}
@@ -1152,6 +1161,7 @@ const Comment: FC<CommentProps> = ({
           lastViewedAt={lastViewedAt}
           shouldSuggestKeyFactors={shouldSuggestKeyFactors}
           isSomeChildrenUnread={isSomeChildrenUnread}
+          onReplyCreated={onReplyCreated}
         />
       )}
       <CommentReportModal

--- a/front_end/src/components/comment_feed/comment_wrapper.tsx
+++ b/front_end/src/components/comment_feed/comment_wrapper.tsx
@@ -21,6 +21,7 @@ type Props = {
   postData?: PostWithForecasts;
   suggestKeyFactorsOnFirstRender?: boolean;
   shouldSuggestKeyFactors?: boolean;
+  onReplyCreated?: (createdAt: string) => void;
 };
 
 export const CommentWrapper: FC<Props> = ({
@@ -31,6 +32,7 @@ export const CommentWrapper: FC<Props> = ({
   handleCommentPin,
   suggestKeyFactorsOnFirstRender = false,
   shouldSuggestKeyFactors = false,
+  onReplyCreated,
 }) => {
   const { user } = useAuth();
   const isUnread =
@@ -91,6 +93,7 @@ export const CommentWrapper: FC<Props> = ({
           isCommentJustCreated={suggestKeyFactorsOnFirstRender}
           shouldSuggestKeyFactors={shouldSuggestKeyFactors}
           forceExpandedChildren={isFocusedCommentInTree}
+          onReplyCreated={onReplyCreated}
         />
       </KeyFactorsProvider>
     </div>

--- a/front_end/src/components/comment_feed/comment_wrapper.tsx
+++ b/front_end/src/components/comment_feed/comment_wrapper.tsx
@@ -86,7 +86,7 @@ export const CommentWrapper: FC<Props> = ({
           /* replies should always be sorted from oldest to newest */
           sort={"created_at" as SortOption}
           postData={postData}
-          lastViewedAt={postData?.last_viewed_at}
+          lastViewedAt={last_viewed_at}
           isCollapsed={isCollapsed}
           isCommentJustCreated={suggestKeyFactorsOnFirstRender}
           shouldSuggestKeyFactors={shouldSuggestKeyFactors}

--- a/front_end/src/components/comment_feed/index.tsx
+++ b/front_end/src/components/comment_feed/index.tsx
@@ -119,6 +119,10 @@ const CommentFeed: FC<Props> = ({
   const [userKeyFactorsComment, setUserKeyFactorsComment] =
     useState<CommentType | null>(null);
 
+  const [lastViewedAt, setLastViewedAt] = useState<string | undefined>(
+    postData?.last_viewed_at
+  );
+
   const [feedFilters, setFeedFilters] = useState<getCommentsParams>(() => ({
     is_private: false,
     sort: "-created_at",
@@ -286,8 +290,8 @@ const CommentFeed: FC<Props> = ({
 
   const getUnreadCount = useCallback(
     (comments: CommentType[]): number => {
-      if (!postData?.last_viewed_at) return 0;
-      const lastViewedDate = new Date(postData.last_viewed_at);
+      if (!lastViewedAt) return 0;
+      const lastViewedDate = new Date(lastViewedAt);
 
       let unreadCount = 0;
       const countUnread = (comment: CommentType) => {
@@ -301,7 +305,7 @@ const CommentFeed: FC<Props> = ({
       comments.forEach(countUnread);
       return unreadCount;
     },
-    [postData?.last_viewed_at]
+    [lastViewedAt]
   );
 
   const handleCommentPin = useCallback(
@@ -329,6 +333,7 @@ const CommentFeed: FC<Props> = ({
 
   const onNewComment = (newComment: CommentType) => {
     setComments([newComment, ...comments]);
+    setLastViewedAt(newComment.created_at);
 
     fetchTotalCount({
       is_private: feedFilters.is_private,
@@ -415,7 +420,7 @@ const CommentFeed: FC<Props> = ({
             <span className="text-sm font-medium leading-5 text-gray-600 dark:text-gray-600-dark">
               {totalCount ? `${totalCount} ` : ""}
               {t("commentsWithCount", { count: totalCount })}
-              {postData?.last_viewed_at && (
+              {lastViewedAt && (
                 <>
                   {getUnreadCount(comments) > 0 && (
                     <span className="ml-1 font-bold text-purple-700 dark:text-purple-700-dark">
@@ -462,7 +467,7 @@ const CommentFeed: FC<Props> = ({
               comment={comment}
               handleCommentPin={handleCommentPin}
               profileId={profileId}
-              last_viewed_at={postData?.last_viewed_at}
+              last_viewed_at={lastViewedAt}
               postData={postData}
               suggestKeyFactorsOnFirstRender={
                 // This is the newly added comment, so we want to suggest key factors

--- a/front_end/src/components/comment_feed/index.tsx
+++ b/front_end/src/components/comment_feed/index.tsx
@@ -469,6 +469,7 @@ const CommentFeed: FC<Props> = ({
               profileId={profileId}
               last_viewed_at={lastViewedAt}
               postData={postData}
+              onReplyCreated={setLastViewedAt}
               suggestKeyFactorsOnFirstRender={
                 // This is the newly added comment, so we want to suggest key factors
                 comment.id === userKeyFactorsComment?.id


### PR DESCRIPTION
Resolves #4851

### Summary

Posted comments appeared unread immediately after submission because `postData.last_viewed_at` was a snapshot from page load and never updated on the frontend – causing every new comment's `created_at` to compare as newer than the stale timestamp.

Implemented changes:

- **`index.tsx`**: introduced a local `lastViewedAt` state initialized from `postData.last_viewed_at`; advances it to `newComment.created_at` in `onNewComment` so the just-posted comment never satisfies `created_at > lastViewedAt`; replaced all unread-detection consumers (`getUnreadCount`, unread label guard, `CommentWrapper` prop) to read from this state instead of the stale prop.
- **`comment_wrapper.tsx`**: fixed `<Comment lastViewedAt>` to use the `last_viewed_at` prop (which flows from the updated state) instead of reading `postData?.last_viewed_at` directly, closing the bypass in the reply tree.
- Reply submissions left the new reply marked unread and didn't increment the comment count in the tab bar or meta row, because the reply editor never called `setLastViewedAt` or updated `totalCount`, and both UI surfaces read a static `post.comment_count` snapshot that never changed client-side.

### Demo videos

#### Before

https://github.com/user-attachments/assets/4e167e3d-c282-4116-89d3-b35b24d85edd

https://github.com/user-attachments/assets/b169bda3-80d3-443c-b6ac-7f4b0832d65c

#### After

https://github.com/user-attachments/assets/1e44ac8f-9a69-47bd-aeff-0817b8ec1cad

https://github.com/user-attachments/assets/73c973b1-f1b8-4f7f-aa48-b11e74434a30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unread comment count accuracy and badge visibility by updating how the system tracks previously viewed comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->