### PR TITLE
fix: labor hub commentary — correct WA technology sector forecast direction

### DIFF
--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -756,7 +756,7 @@ export default function LaborAutomationHubPage() {
               forecasted to grow through 2027, largely unaffected by AI in this
               timeframe. Aerospace (employing 2%) is expected to see minor
               growth in the short-term, while technology (employing 10%) is
-              expected to see marginal growth, largely consistent with
+              expected to see marginal decline, largely consistent with
               historical trends. These forecasts are short-term, leading to
               minimal predicted change.
             </ContentParagraph>

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-04">Jun 4</time>
+              Commentary last updated: <time dateTime="2026-06-09">Jun 9</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated commentary audit of https://www.metaculus.com/labor-hub identified one misalignment between forecast data and commentary text.

## Fix

**Section:** State-Level View

**Old text:**
> "Aerospace (employing 2%) is expected to see minor growth in the short-term, while technology (employing 10%) is expected to see **marginal growth**, largely consistent with historical trends."

**Chart data:** Technology Sector = **-0.1%** (displayed in red as a decline)

**New text:**
> "Aerospace (employing 2%) is expected to see minor growth in the short-term, while technology (employing 10%) is expected to see **marginal decline**, largely consistent with historical trends."

The commentary date was also updated from Jun 4 → Jun 9.

## Audit scope

All sections were checked: Overall Employment, By Job Vulnerability, Key Insights, Jobs Monitor (2027, 2030, 2035 views), Wages, Graduates, Economy, Research comparison table, State-Level View. Only the above forecast/prediction misalignment was found.

https://claude.ai/code/session_01Cr3UHfoz5AeFNmWeHzMXda

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cr3UHfoz5AeFNmWeHzMXda)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Washington state technology sector outlook from marginal growth to marginal decline in the State-Level View narrative.
  * Refreshed the "Commentary last updated" timestamp in the Labor Hub hero section to reflect the latest information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->