### PR TITLE
feat: add Claude Opus 4.8 launch to labor hub activity monitor

### DIFF
--- a/front_end/src/app/(main)/labor-hub/activity_data.tsx
+++ b/front_end/src/app/(main)/labor-hub/activity_data.tsx
@@ -187,4 +187,20 @@ export const RAW_ACTIVITY_MONITOR_DATA: RawActivityMonitorEntry[] = [
       </>
     ),
   },
+  {
+    date: "2026-05-28",
+    type: "news",
+    content: (
+      <>
+        Anthropic releases Claude Opus 4.8 -{" "}
+        <a
+          href="https://www.anthropic.com/news/claude-opus-4-8"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          Anthropic
+        </a>
+      </>
+    ),
+  },
 ];


### PR DESCRIPTION
Adds a new activity monitor entry for Anthropic's Claude Opus 4.8 launch on May 28, 2026.

Resolves #4862.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new news item to the activity monitor dashboard, featuring curated content and an external link to relevant announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->