### PR TITLE
feat(labor-hub): add GPT 5.5, Gemini 3.5, and Claude Fable 5 to activity monitor

### DIFF
--- a/front_end/src/app/(main)/labor-hub/activity_data.tsx
+++ b/front_end/src/app/(main)/labor-hub/activity_data.tsx
@@ -102,6 +102,22 @@ export const RAW_ACTIVITY_MONITOR_DATA: RawActivityMonitorEntry[] = [
     ),
   },
   {
+    date: "2026-04-23",
+    type: "news",
+    content: (
+      <>
+        OpenAI launches their latest GPT 5.5 model -{" "}
+        <a
+          href="https://openai.com/index/introducing-gpt-5-5/"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          OpenAI
+        </a>
+      </>
+    ),
+  },
+  {
     date: "2026-04-24",
     type: "news",
     content: (
@@ -171,6 +187,22 @@ export const RAW_ACTIVITY_MONITOR_DATA: RawActivityMonitorEntry[] = [
     ),
   },
   {
+    date: "2026-05-19",
+    type: "news",
+    content: (
+      <>
+        Google launches Gemini 3.5, their latest model -{" "}
+        <a
+          href="https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          Google
+        </a>
+      </>
+    ),
+  },
+  {
     date: "2026-05-21",
     type: "news",
     content: (
@@ -195,6 +227,23 @@ export const RAW_ACTIVITY_MONITOR_DATA: RawActivityMonitorEntry[] = [
         Anthropic releases Claude Opus 4.8 -{" "}
         <a
           href="https://www.anthropic.com/news/claude-opus-4-8"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          Anthropic
+        </a>
+      </>
+    ),
+  },
+  {
+    date: "2026-06-09",
+    type: "news",
+    content: (
+      <>
+        Anthropic launches Claude Fable 5, a Mythos-class model made safe for
+        general use -{" "}
+        <a
+          href="https://www.anthropic.com/news/claude-fable-5-mythos-5"
           target="_blank"
           rel="noreferrer noopener"
         >


### PR DESCRIPTION
Adds three new `news` entries to the Labor Hub activity monitor:

- OpenAI launches GPT 5.5 (2026-04-23)
- Google launches Gemini 3.5 (2026-05-19)
- Anthropic launches Claude Fable 5 (2026-06-09)

Resolves #4872.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new activity monitor news entries for April, May, and June 2026, each containing descriptive information and linked source references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->