### PR TITLE
fix: restore Forecast Timeline on conditional questions in forecaster view

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -5,6 +5,7 @@ import { FC, Fragment, ReactNode, useEffect } from "react";
 
 import useCoherenceLinksContext from "@/app/(main)/components/coherence_links_provider";
 import { PostStatusBox } from "@/app/(main)/questions/[id]/components/post_status_box";
+import ConditionalTimeline from "@/components/conditional_timeline";
 import DateForecastCard from "@/components/consumer_post_card/group_forecast_card/date_forecast_card";
 import NumericForecastCard from "@/components/consumer_post_card/group_forecast_card/numeric_forecast_card";
 import PercentageForecastCard from "@/components/consumer_post_card/group_forecast_card/percentage_forecast_card";
@@ -155,6 +156,9 @@ export const ForecasterShell: FC<
                   preselectedQuestionId={preselectedGroupQuestionId}
                 />
               ))}
+            {isConditionalPost(postData) && (
+              <ConditionalTimeline post={postData} />
+            )}
           </div>
           {(!isResolved || isGroup) && <ForecastMaker post={postData} />}
           <ResolutionCriteria post={postData} defaultOpen />


### PR DESCRIPTION
Closes #4871.

The `ForecasterShell` chart block had no branch for conditional posts, so the timeline was missing for conditional questions in forecaster mode. This PR adds an `isConditionalPost` branch rendering `ConditionalTimeline` in the same block as `DetailedQuestionCard`/`DetailedGroupCard`, which places it below `ActionRow` (Question controls) and above `ForecastMaker` (Prediction input).

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conditional posts now display an enhanced timeline view alongside question information for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->