### PR TITLE
fix: main-feed filter handling unlisted posts

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/use_similar_questions.ts
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/use_similar_questions.ts
@@ -25,7 +25,6 @@ export function useSimilarQuestions(
     queryFn: () =>
       ClientPostsApi.getPostsWithCP({
         topic: "top-50",
-        for_main_feed: "false",
         for_consumer_view: variant === "consumer" ? "true" : "false",
         order_by: "-hotness",
         statuses: [

--- a/front_end/src/app/(main)/questions/discovery/components/categories.tsx
+++ b/front_end/src/app/(main)/questions/discovery/components/categories.tsx
@@ -26,7 +26,7 @@ const CategoriesDiscovery: FC<Props> = ({ categories }) => {
       <div className="grid w-full gap-3 md:grid-cols-5">
         {categoriesToDisplay.map((category) => (
           <Link
-            href={`/questions/?${POST_CATEGORIES_FILTER}=${category.slug}&for_main_feed=false`}
+            href={`/questions/?${POST_CATEGORIES_FILTER}=${category.slug}`}
             key={category.id}
             className="flex items-center gap-4 rounded bg-olive-300 p-4 text-olive-900 no-underline dark:bg-olive-300-dark dark:text-olive-900-dark md:min-h-[145px] md:flex-col md:items-start md:justify-between md:gap-0"
             onClick={() =>

--- a/front_end/src/app/(main)/questions/helpers/__tests__/filters.test.ts
+++ b/front_end/src/app/(main)/questions/helpers/__tests__/filters.test.ts
@@ -1,0 +1,83 @@
+import {
+  POST_CATEGORIES_FILTER,
+  POST_FOR_MAIN_FEED,
+  POST_IDS_FILTER,
+  POST_TEXT_SEARCH_FILTER,
+  POST_TOPIC_FILTER,
+} from "@/constants/posts_feed";
+
+import { generateFiltersFromSearchParams } from "../filters";
+
+describe("generateFiltersFromSearchParams", () => {
+  it("keeps main-feed filtering enabled for text search by default", () => {
+    expect(
+      generateFiltersFromSearchParams(
+        { [POST_TEXT_SEARCH_FILTER]: "ai safety" },
+        { defaultForMainFeed: true }
+      )
+    ).toEqual(
+      expect.objectContaining({
+        search: "ai safety",
+        for_main_feed: "true",
+      })
+    );
+  });
+
+  it("does not apply the main-feed default to id lookups", () => {
+    expect(
+      generateFiltersFromSearchParams(
+        { [POST_IDS_FILTER]: "123" },
+        { defaultForMainFeed: true }
+      )
+    ).toEqual({
+      ids: [123],
+    });
+  });
+
+  it("ignores explicit main-feed bypasses outside id lookups", () => {
+    expect(
+      generateFiltersFromSearchParams(
+        {
+          [POST_TOPIC_FILTER]: "ai",
+          [POST_FOR_MAIN_FEED]: "false",
+        },
+        { defaultForMainFeed: true }
+      )
+    ).toEqual(
+      expect.objectContaining({
+        topic: "ai",
+        for_main_feed: "true",
+      })
+    );
+
+    expect(
+      generateFiltersFromSearchParams(
+        {
+          [POST_CATEGORIES_FILTER]: "geopolitics",
+          [POST_FOR_MAIN_FEED]: "false",
+        },
+        { defaultForMainFeed: true }
+      )
+    ).toEqual(
+      expect.objectContaining({
+        categories: "geopolitics",
+        for_main_feed: "true",
+      })
+    );
+  });
+
+  it("allows an explicit main-feed bypass for id lookups", () => {
+    expect(
+      generateFiltersFromSearchParams(
+        {
+          [POST_IDS_FILTER]: "123",
+          [POST_FOR_MAIN_FEED]: "false",
+        },
+        { defaultForMainFeed: true }
+      )
+    ).toEqual({
+      ids: [123],
+      for_main_feed: "false",
+    });
+  });
+});

--- a/front_end/src/app/(main)/questions/helpers/filters.ts
+++ b/front_end/src/app/(main)/questions/helpers/filters.ts
@@ -79,7 +79,6 @@ const EXPLICIT_FEED_FILTER_KEYS = [
   POST_CATEGORIES_FILTER,
   POST_COMMENTED_BY_FILTER,
   POST_FOLLOWING_FILTER,
-  POST_FOR_MAIN_FEED,
   POST_FORECASTER_ID_FILTER,
   POST_IDS_FILTER,
   POST_LEADERBOARD_TAGS_FILTER,
@@ -165,13 +164,15 @@ export function generateFiltersFromSearchParams(
         .filter((id) => !isNaN(id));
     }
   }
-  if (typeof searchParams[POST_FOR_MAIN_FEED] === "string") {
-    filters.for_main_feed = searchParams[POST_FOR_MAIN_FEED];
-  } else if (
-    typeof defaultForMainFeed !== "undefined" &&
-    !searchParams[POST_TEXT_SEARCH_FILTER] &&
-    !filters.ids
-  ) {
+  const hasIdsFilter = !!filters.ids?.length;
+  const requestedForMainFeed = searchParams[POST_FOR_MAIN_FEED];
+  const shouldUseRequestedForMainFeed =
+    typeof requestedForMainFeed === "string" &&
+    (requestedForMainFeed === "true" || hasIdsFilter);
+
+  if (shouldUseRequestedForMainFeed) {
+    filters.for_main_feed = requestedForMainFeed;
+  } else if (typeof defaultForMainFeed !== "undefined" && !hasIdsFilter) {
     filters.for_main_feed = defaultForMainFeed.toString();
   }
 

--- a/front_end/src/app/(main)/questions/hooks/use_feed_query.tsx
+++ b/front_end/src/app/(main)/questions/hooks/use_feed_query.tsx
@@ -31,7 +31,6 @@ import {
   POST_COMMUNITIES_FILTER,
   POST_COMMENTS_FEED_FILTER,
   POST_FOLLOWING_FILTER,
-  POST_FOR_MAIN_FEED,
   POST_FORECASTER_ID_FILTER,
   POST_ORDER_BY_FILTER,
   POST_TEXT_SEARCH_FILTER,
@@ -169,14 +168,12 @@ export const FeedQueryProvider: FC<Props> = ({
         case FeedType.MY_PREDICTIONS:
           if (!user) return {};
           return {
-            [POST_FOR_MAIN_FEED]: "false",
             [POST_FORECASTER_ID_FILTER]: user.id.toString(),
             [POST_ORDER_BY_FILTER]: QuestionOrder.WeeklyMovementDesc,
           };
         case FeedType.MY_QUESTIONS_AND_POSTS:
           if (!user) return {};
           return {
-            [POST_FOR_MAIN_FEED]: "false",
             [POST_USERNAMES_FILTER]: user.username,
           };
         case FeedType.COMMUNITIES:

--- a/front_end/src/app/(storefront)/page.tsx
+++ b/front_end/src/app/(storefront)/page.tsx
@@ -22,7 +22,7 @@ const STAFF_PICKS = [
   {
     name: "Iran War",
     emoji: "💥",
-    url: "/questions/?topic=2026-iran-war&for_main_feed=false",
+    url: "/questions/?topic=2026-iran-war",
   },
   {
     name: "Metaculus Cup",
@@ -32,7 +32,7 @@ const STAFF_PICKS = [
   {
     name: "Top Questions",
     emoji: "❓",
-    url: "/questions/?topic=top-50&for_main_feed=false",
+    url: "/questions/?topic=top-50",
   },
   {
     name: "Current Events",
@@ -42,22 +42,22 @@ const STAFF_PICKS = [
   {
     name: "Artificial Intelligence",
     emoji: "🤖",
-    url: "/questions/?categories=artificial-intelligence&for_main_feed=false",
+    url: "/questions/?categories=artificial-intelligence",
   },
   {
     name: "Geopolitics",
     emoji: "🌍",
-    url: "/questions/?categories=geopolitics&for_main_feed=false",
+    url: "/questions/?categories=geopolitics",
   },
   {
     name: "Economy and Business",
     emoji: "💼",
-    url: "/questions/?categories=economy-business&for_main_feed=false",
+    url: "/questions/?categories=economy-business",
   },
   {
     name: "Space",
     emoji: "🚀",
-    url: "/questions/?categories=space&for_main_feed=false",
+    url: "/questions/?categories=space",
   },
 ];
 

--- a/front_end/src/utils/navigation.ts
+++ b/front_end/src/utils/navigation.ts
@@ -101,9 +101,9 @@ export const getProjectLink = (
     case TournamentType.Index:
       return `/index/${getProjectSlug(project)}/`;
     case TaxonomyProjectType.Topic:
-      return `/questions/?topic=${project.slug}&for_main_feed=false`;
+      return `/questions/?topic=${project.slug}`;
     case TaxonomyProjectType.Category:
-      return `/questions/?categories=${project.slug}&for_main_feed=false`;
+      return `/questions/?categories=${project.slug}`;
     case TaxonomyProjectType.LeaderboardTag:
       return getLeaderboardTagUrl(project);
     default:
@@ -144,7 +144,7 @@ export function getLeaderboardTagUrl({
 }
 
 export function getLeaderboardTagFeedUrl({ slug }: LeaderboardTag) {
-  return `/questions/?leaderboard_tags=${slug}&for_main_feed=false`;
+  return `/questions/?leaderboard_tags=${slug}`;
 }
 
 /**


### PR DESCRIPTION
**Summary**
- Stop UI-generated feed links from using `for_main_feed=false` for category, topic, leaderboard, storefront, discovery, and fallback feed links.
- Keep normal feed/text search constrained to main-feed-visible posts by default.
- Preserve the `for_main_feed=false` bypass only for explicit `ids=` lookups, so direct ID searches can still find link-accessible posts.

**Why**
Unlisted projects should behave like real unlisted content: accessible by direct link, but not exposed through normal site browsing/search surfaces. Several UI paths were generating `for_main_feed=false`, which could surface posts from unlisted or non-main-feed projects.

**Testing**
- `bun run test -- --runTestsByPath 'src/app/(main)/questions/helpers/__tests__/filters.test.ts'`
- `bunx eslint ...` on touched frontend files

`bun run lint:types` still fails due to existing unrelated `.next` labor-hub generated type references and geo/topojson type issues.
