### PR TITLE
fix: hide forecast maker for bot users

### DIFF
--- a/front_end/src/components/forecast_maker/index.tsx
+++ b/front_end/src/components/forecast_maker/index.tsx
@@ -24,6 +24,12 @@ const ForecastMaker: FC<Props> = ({ post, onPredictionSubmit }) => {
   const t = useTranslations();
   const { user } = useAuth();
 
+  // Bots predict via API; hide the maker so its default starting curve isn't
+  // mistaken for the bot's actual forecast.
+  if (user?.is_bot) {
+    return null;
+  }
+
   const { group_of_questions: groupOfQuestions, conditional, question } = post;
   const canPredict = canPredictQuestion(post, user);
   const isPrePrediction = isPostPrePrediction(post);


### PR DESCRIPTION
Closes #4881

## Summary

- Short-circuits `<ForecastMaker />` to render nothing when `user.is_bot`.
- Bots predict via the API and cannot edit forecasts in the UI; the maker rendered a "my prediction" overlay using the default starting curve, which bot owners mistook for their bot's actual forecast.
- Bots still see their submitted forecasts on the main timeline chart (`DetailedQuestionCard`).

## Test plan

- [ ] Log in as a bot user and visit a continuous question — confirm no "my prediction" chart/slider is shown below the question chart.
- [ ] Log in as a bot user and visit a binary question — confirm no slider is shown.
- [ ] Log in as a bot user and visit a multiple-choice/group/conditional question — confirm no forecast input is shown.
- [ ] Log in as a non-bot user — confirm the forecast maker still renders normally.
- [ ] Confirm bots can still see their own submitted forecasts on the timeline chart at the top of the question page.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Forecast-making interface is now hidden for bot accounts, preventing default starting curves from being mistaken for actual bot forecasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->