### PR TITLE
fix: labor hub commentary — remove incorrect financial specialists contraction claim

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -44,10 +44,8 @@ export const JOBS_INSIGHTS = {
         By 2035, <strong>software</strong>, <strong>sales</strong> and{" "}
         <strong>law</strong> are expected to see sharp staff reductions as AI
         systems take over large portions of coding, outreach, and detailed
-        research work, while <strong>laborers</strong> and{" "}
-        <strong>financial specialists</strong> see a contraction as more
-        advanced robotics roll out and AI automates accounting and
-        administrative tasks.
+        research work, while <strong>laborers</strong> see a modest decline as
+        more advanced robotics expand their reach.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-09">Jun 9</time>
+              Commentary last updated: <time dateTime="2026-06-11">Jun 11</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated commentary audit of https://www.metaculus.com/labor-hub found one misalignment between chart forecast data and commentary text in the Jobs Monitor section.

### Fix

**Section:** Jobs Monitor — 2035 negative insight

**Old text:**
> By 2035, software, sales and law are expected to see sharp staff reductions as AI systems take over large portions of coding, outreach, and detailed research work, while **laborers** and **financial specialists** see a contraction as more advanced robotics roll out and AI automates accounting and administrative tasks.

**Chart data that contradicts it:**
- Financial Specialists employment 2030: **+0.2%** (growth)
- Financial Specialists employment 2035: **+1.0%** (growth)
- Financial Specialists wages 2035: **+13.1%** (highest wage growth in the table)

Financial Specialists are forecast to see slight employment _growth_ in both 2030 and 2035, not a contraction.

**New text:**
> By 2035, software, sales and law are expected to see sharp staff reductions as AI systems take over large portions of coding, outreach, and detailed research work, while **laborers** see a modest decline as more advanced robotics expand their reach.

Laborers and Movers (-1.5% by 2035) correctly remain in the declining category.

Also updated the "Commentary last updated" date from Jun 9 → Jun 11.

## Files changed

- `front_end/src/app/(main)/labor-hub/jobs_insights.tsx` — removed financial specialists from 2035 contraction narrative
- `front_end/src/app/(main)/labor-hub/sections/hero.tsx` — updated commentary date

https://claude.ai/code/session_0183YiTq43qHtejo6DQ9oAbk

---
_Generated by [Claude Code](https://claude.ai/code/session_0183YiTq43qHtejo6DQ9oAbk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated 2035 labor market insights to reflect a revised outlook focused on advanced robotics impact.
  * Refreshed the commentary timestamp to June 11, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->