### PR TITLE
fix: labor hub commentary — correct 2035 Jobs Monitor top-growth occupations

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -34,9 +34,9 @@ export const JOBS_INSIGHTS = {
   "2035": {
     positive: (
       <>
-        By 2035, <strong>nurses</strong>, <strong>restaurant workers</strong>,
-        and <strong>law enforcement</strong> are expected to see the highest
-        growth, driven by hands-on needs that cannot be easily automated.
+        By 2035, <strong>nurses</strong>, <strong>physicians</strong>, and{" "}
+        <strong>law enforcement</strong> are expected to see the highest growth,
+        driven by hands-on needs that cannot be easily automated.
       </>
     ),
     negative: (

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-11">Jun 11</time>
+              Commentary last updated: <time dateTime="2026-06-12">Jun 12</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

One misalignment found between Jobs Monitor chart data and commentary text for the 2035 forecast year.

### Fix

**Section:** Jobs Monitor — 2035 positive commentary  
**Old text:** "By 2035, **nurses**, **restaurant workers**, and **law enforcement** are expected to see the highest growth, driven by hands-on needs that cannot be easily automated."  
**Chart data:** 2035 employment growth rankings: Registered Nurses (+10.4%), **Physicians (+5.7%)**, Law Enforcement (+5.4%), Construction Workers (+4.3%), Restaurant Servers (+1.3%)  
**New text:** "By 2035, **nurses**, **physicians**, and **law enforcement** are expected to see the highest growth, driven by hands-on needs that cannot be easily automated."

Restaurant Servers rank 5th in 2035 growth (+1.3%), while Physicians rank 2nd (+5.7%). The commentary was incorrectly naming restaurant workers instead of physicians.

Also updated "Commentary last updated" date from Jun 11 → Jun 12.

https://claude.ai/code/session_01QrXyQHfQky32KZCtyq5HxB

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrXyQHfQky32KZCtyq5HxB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the 2035 labor market insights with revised professional role highlights to better reflect current job market trends
  * Refreshed the commentary timestamp to June 12 to indicate the latest content modifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->