### PR TITLE
Fix: reduce N+1 backend requests triggered by RSC prefetch

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
@@ -41,7 +41,9 @@ type Props = {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const { slug } = await props.params;
-  const tournament = await ServerProjectsApi.getTournament(slug);
+  const tournament = await ServerProjectsApi.getTournament(slug, {
+    next: { revalidate: 60 },
+  });
   if (!tournament) return {};
 
   const raw = tournament.subtitle || tournament.description || "";

--- a/front_end/src/app/(main)/accounts/profile/[id]/(overview)/page.tsx
+++ b/front_end/src/app/(main)/accounts/profile/[id]/(overview)/page.tsx
@@ -122,7 +122,9 @@ const PerformanceCard: FC<{
 
 export default async function MedalsPage(props: Props) {
   const params = await props.params;
-  const profile = await ServerProfileApi.getProfileById(params.id);
+  const profile = await ServerProfileApi.getProfileById(params.id, {
+    includeStats: true,
+  });
 
   const t = await getTranslations();
   const [userMedals, userMedalRanks] = await Promise.all([

--- a/front_end/src/app/(main)/accounts/profile/[id]/layout.tsx
+++ b/front_end/src/app/(main)/accounts/profile/[id]/layout.tsx
@@ -25,7 +25,11 @@ type Props = {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
-  const profile = await ServerProfileApi.getProfileById(+params.id);
+  const profile = await ServerProfileApi.getProfileById(
+    +params.id,
+    {},
+    { next: { revalidate: 60 } }
+  );
 
   if (!profile) {
     return {};

--- a/front_end/src/app/(main)/accounts/profile/[id]/layout.tsx
+++ b/front_end/src/app/(main)/accounts/profile/[id]/layout.tsx
@@ -11,7 +11,7 @@ import UserInfo from "@/app/(main)/accounts/profile/components/user_info";
 import Button from "@/components/ui/button";
 import { defaultDescription } from "@/constants/metadata";
 import ServerProfileApi from "@/services/api/profile/profile.server";
-import { UserProfile } from "@/types/users";
+import { UserProfileWithStats } from "@/types/users";
 import cn from "@/utils/core/cn";
 
 const SoftDeleteButton = dynamic(
@@ -46,7 +46,12 @@ export default async function ProfileLayout(props: Props) {
   const currentUser = await ServerProfileApi.getMyProfile();
   const isCurrentUser = currentUser?.id === id;
 
-  let profile: UserProfile = await ServerProfileApi.getProfileById(id);
+  let profile: UserProfileWithStats = await ServerProfileApi.getProfileById(
+    id,
+    {
+      includeStats: true,
+    }
+  );
 
   if (!profile) {
     return notFound();

--- a/front_end/src/app/(main)/accounts/profile/[id]/track-record/page.tsx
+++ b/front_end/src/app/(main)/accounts/profile/[id]/track-record/page.tsx
@@ -10,7 +10,9 @@ type Props = {
 
 export default async function TrackRecord(props: Props) {
   const params = await props.params;
-  const profile = await ServerProfileApi.getProfileById(params.id);
+  const profile = await ServerProfileApi.getProfileById(params.id, {
+    includeStats: true,
+  });
 
   const keyStatStyles =
     "flex w-full md:w-1/3 flex-col min-h-[100px] justify-center gap-1.5 rounded bg-blue-200 p-3 text-center dark:bg-blue-950";

--- a/front_end/src/app/(main)/accounts/profile/components/profile_menu.tsx
+++ b/front_end/src/app/(main)/accounts/profile/components/profile_menu.tsx
@@ -6,11 +6,11 @@ import { FC } from "react";
 
 import ButtonGroup, { GroupButton } from "@/components/ui/button_group";
 import { useAuth } from "@/contexts/auth_context";
-import { UserProfile } from "@/types/users";
+import { UserProfileWithStats } from "@/types/users";
 import { isPathEqual } from "@/utils/navigation";
 
 type Props = {
-  profile: UserProfile;
+  profile: UserProfileWithStats;
 };
 
 const ProfileMenu: FC<Props> = ({

--- a/front_end/src/app/(main)/accounts/profile/components/social_media_section.tsx
+++ b/front_end/src/app/(main)/accounts/profile/components/social_media_section.tsx
@@ -13,7 +13,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Link from "next/link";
 import { FC } from "react";
 
-import { UserProfile } from "@/types/users";
+import { User } from "@/types/users";
 
 export type SocialMediaFieldName =
   | "website"
@@ -34,7 +34,7 @@ export type SocialMediaEntry = {
   label: string;
 };
 
-export const getSocialMediaArray = (user: UserProfile): SocialMediaEntry[] => [
+export const getSocialMediaArray = (user: User): SocialMediaEntry[] => [
   { icon: faEarth, link: user.website, name: "website", label: "Website" },
   { icon: faXTwitter, link: user.twitter, name: "twitter", label: "Twitter/X" },
   {
@@ -72,12 +72,12 @@ export const getSocialMediaArray = (user: UserProfile): SocialMediaEntry[] => [
   },
 ];
 
-export const hasUserSocialMediaLink = (user: UserProfile) => {
+export const hasUserSocialMediaLink = (user: User) => {
   return getSocialMediaArray(user).some(({ link }) => !!link);
 };
 
 const SocialMediaFragment: FC<{
-  user: UserProfile;
+  user: User;
 }> = ({ user }) => {
   const socialMedia = getSocialMediaArray(user).filter(
     ({ link }) => !!link

--- a/front_end/src/app/(main)/accounts/profile/components/social_media_section.tsx
+++ b/front_end/src/app/(main)/accounts/profile/components/social_media_section.tsx
@@ -87,7 +87,7 @@ const SocialMediaFragment: FC<{
       {socialMedia.map(({ icon, link, name }) => {
         return (
           <div key={name} className="flex flex-col">
-            <Link href={link} target="_blank" rel="ugc">
+            <Link href={link} target="_blank" rel="ugc noopener noreferrer">
               <FontAwesomeIcon
                 icon={icon}
                 size="lg"

--- a/front_end/src/app/(main)/accounts/profile/components/user_info.tsx
+++ b/front_end/src/app/(main)/accounts/profile/components/user_info.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/ui/form_field";
 import { useAuth } from "@/contexts/auth_context";
 import useContainerSize from "@/hooks/use_container_size";
-import { UserProfile } from "@/types/users";
+import { UserProfileWithStats } from "@/types/users";
 import cn from "@/utils/core/cn";
 import { formatUsername } from "@/utils/formatters/users";
 
@@ -36,7 +36,7 @@ import SocialMediaFragment, {
 } from "./social_media_section";
 
 export type UserInfoProps = {
-  profile: UserProfile;
+  profile: UserProfileWithStats;
   isCurrentUser: boolean;
 };
 

--- a/front_end/src/app/(main)/c/[slug]/[id]/[[...postSlug]]/page.tsx
+++ b/front_end/src/app/(main)/c/[slug]/[id]/[[...postSlug]]/page.tsx
@@ -18,7 +18,9 @@ type Props = {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
-  const postData = await ServerPostsApi.getPost(params.id);
+  const postData = await ServerPostsApi.getPost(params.id, false, {
+    next: { revalidate: 60 },
+  });
 
   if (!postData) {
     return {};

--- a/front_end/src/app/(main)/c/[slug]/page.tsx
+++ b/front_end/src/app/(main)/c/[slug]/page.tsx
@@ -28,7 +28,9 @@ type Props = {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
-  const community = await ServerProjectsApi.getCommunity(params.slug);
+  const community = await ServerProjectsApi.getCommunity(params.slug, {
+    next: { revalidate: 60 },
+  });
 
   if (!community) {
     return {};

--- a/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page.tsx
@@ -16,7 +16,9 @@ type Props = {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
-  const postData = await ServerPostsApi.getPost(params.id);
+  const postData = await ServerPostsApi.getPost(params.id, false, {
+    next: { revalidate: 60 },
+  });
 
   if (!postData) {
     return {};

--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
@@ -6,7 +6,7 @@ import { getValidString } from "@/utils/formatters/string";
 import { getPostTitle } from "@/utils/questions/helpers";
 
 import IndividualQuestionPage from "./page_component";
-import { cachedGetPost } from "./utils/get_post";
+import { cachedGetPostForMetadata } from "./utils/get_post";
 
 type Props = {
   params: Promise<{ id: number; slug: string[] }>;
@@ -15,7 +15,7 @@ type Props = {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
-  const postData = await cachedGetPost(params.id);
+  const postData = await cachedGetPostForMetadata(params.id);
 
   if (!postData) {
     return {};

--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/utils/get_post.ts
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/utils/get_post.ts
@@ -48,3 +48,9 @@ async function getPost(id: number, with_cp = true) {
 }
 
 export const cachedGetPost = cache(getPost);
+
+async function getPostForMetadata(id: number) {
+  return ServerPostsApi.getPost(id, false, { next: { revalidate: 60 } });
+}
+
+export const cachedGetPostForMetadata = cache(getPostForMetadata);

--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/utils/get_post.ts
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/utils/get_post.ts
@@ -4,6 +4,7 @@ import { cache } from "react";
 
 import ServerPostsApi from "@/services/api/posts/posts.server";
 import ServerQuestionsApi from "@/services/api/questions/questions.server";
+import { FetchOptions } from "@/types/fetch";
 import { getPostLink } from "@/utils/navigation";
 
 import { SLUG_POST_SUB_QUESTION_ID } from "../../search_params";
@@ -11,9 +12,13 @@ import { SLUG_POST_SUB_QUESTION_ID } from "../../search_params";
 /**
  * A backward compatibility util
  */
-async function getPost(id: number, with_cp = true) {
+async function getPost(
+  id: number,
+  with_cp = true,
+  fetchOptions?: FetchOptions
+) {
   try {
-    return await ServerPostsApi.getPost(id, with_cp);
+    return await ServerPostsApi.getPost(id, with_cp, fetchOptions);
   } catch (e) {
     const lastLegacyQuestionId = parseInt(
       process.env.LAST_LEGACY_QUESTION_ID || ""
@@ -50,7 +55,7 @@ async function getPost(id: number, with_cp = true) {
 export const cachedGetPost = cache(getPost);
 
 async function getPostForMetadata(id: number) {
-  return ServerPostsApi.getPost(id, false, { next: { revalidate: 60 } });
+  return getPost(id, false, { next: { revalidate: 60 } });
 }
 
 export const cachedGetPostForMetadata = cache(getPostForMetadata);

--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/item_view/question_link/question_link_key_factor_item.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/item_view/question_link/question_link_key_factor_item.tsx
@@ -271,6 +271,7 @@ const QuestionLinkKeyFactorItem: FC<Props> = ({
             <Link
               href={getPostLink({ id: otherQuestion.post_id })}
               target="_blank"
+              prefetch={false}
               onClick={(e) => e.stopPropagation()}
               className={cn(
                 "min-w-0 font-medium text-gray-800 no-underline hover:underline dark:text-gray-800-dark",

--- a/front_end/src/app/(main)/questions/[id]/components/key_factors/questions_feed_view/key_factor_tile_view.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/key_factors/questions_feed_view/key_factor_tile_view.tsx
@@ -187,6 +187,7 @@ export const KeyFactorTileQuestionLinkView: FC<
       {href ? (
         <Link
           href={href}
+          prefetch={false}
           className="no-underline hover:underline"
           onClick={(e) => e.stopPropagation()}
         >

--- a/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/similar_question_card.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/sidebar/similar_questions/similar_question_card.tsx
@@ -51,6 +51,7 @@ const SimilarQuestionCard: FC<Props> = ({ post, variant = "forecaster" }) => {
     >
       <Link
         href={getPostLink(post)}
+        prefetch={false}
         className="flex flex-col gap-3 no-underline"
       >
         {!isForecaster && (

--- a/front_end/src/app/(main)/questions/components/coherence_links/display_coherence_link.tsx
+++ b/front_end/src/app/(main)/questions/components/coherence_links/display_coherence_link.tsx
@@ -93,7 +93,11 @@ const DisplayCoherenceLink: FC<Props> = ({ link, post, compact }) => {
   if (compact)
     return (
       <div>
-        <Link href={getPostLink({ id: otherQuestion.post_id })} target="_blank">
+        <Link
+          href={getPostLink({ id: otherQuestion.post_id })}
+          target="_blank"
+          prefetch={false}
+        >
           <b>{otherQuestion.title}</b>
         </Link>
         <Button
@@ -123,6 +127,7 @@ const DisplayCoherenceLink: FC<Props> = ({ link, post, compact }) => {
       <Link
         href={getPostLink({ id: otherQuestion.post_id })}
         target="_blank"
+        prefetch={false}
         className="font-normal text-blue-700 no-underline hover:text-blue-800 hover:underline dark:text-blue-700-dark dark:hover:text-blue-800-dark md:flex-grow"
       >
         {otherQuestion.title}

--- a/front_end/src/app/(prediction-flow)/tournament/[slug]/prediction-flow/page.tsx
+++ b/front_end/src/app/(prediction-flow)/tournament/[slug]/prediction-flow/page.tsx
@@ -22,7 +22,9 @@ type Props = {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const { slug } = await props.params;
-  const tournament = await ServerProjectsApi.getTournament(slug);
+  const tournament = await ServerProjectsApi.getTournament(slug, {
+    next: { revalidate: 60 },
+  });
   const t = await getTranslations();
 
   if (!tournament) {

--- a/front_end/src/components/comment_feed/comment_post_preview/compact_comment_post_card.tsx
+++ b/front_end/src/components/comment_feed/comment_post_preview/compact_comment_post_card.tsx
@@ -77,6 +77,7 @@ const CompactCommentPostCard: FC<Props> = ({ post, className }) => {
       </HideCPProvider>
       <Link
         href={getPostLink(post)}
+        prefetch={false}
         aria-label={post.title}
         className="absolute left-0 top-0 z-100 h-full w-full @container"
       />

--- a/front_end/src/components/communities_feed/community_feed_card.tsx
+++ b/front_end/src/components/communities_feed/community_feed_card.tsx
@@ -27,6 +27,7 @@ const CommunityFeedCard: FC<Props> = ({ community }) => {
   return (
     <Link
       href={`/c/${community.slug}`}
+      prefetch={false}
       className="group flex h-[186px] flex-col rounded-lg border border-purple-300 bg-gray-0 p-5 no-underline hover:border-blue-700 dark:border-purple-300-dark dark:bg-gray-0-dark dark:hover:border-blue-700-dark"
     >
       <div className="flex items-center justify-between">

--- a/front_end/src/components/conditional_tile/conditional_card.tsx
+++ b/front_end/src/components/conditional_tile/conditional_card.tsx
@@ -39,7 +39,7 @@ const ConditionalCard: FC<PropsWithChildren<Props>> = ({
 
   if (href) {
     return (
-      <Link href={href} className="no-underline">
+      <Link href={href} prefetch={false} className="no-underline">
         {CardContent}
       </Link>
     );

--- a/front_end/src/components/consumer_post_card/basic_consumer_post_card.tsx
+++ b/front_end/src/components/consumer_post_card/basic_consumer_post_card.tsx
@@ -63,6 +63,7 @@ const BasicConsumerPostCard: FC<PropsWithChildren<Props>> = ({
               totalCount={post.comment_count ?? 0}
               unreadCount={post.unread_comment_count ?? 0}
               url={getPostLink(post)}
+              prefetch={false}
               variant="gray"
               className="z-[101]"
             />
@@ -92,6 +93,7 @@ const BasicConsumerPostCard: FC<PropsWithChildren<Props>> = ({
           </div>
           <Link
             href={getPostLink(post)}
+            prefetch={false}
             className="absolute top-0 z-100 h-full w-full @container"
           ></Link>
         </div>

--- a/front_end/src/components/forecast_card.tsx
+++ b/front_end/src/components/forecast_card.tsx
@@ -260,6 +260,7 @@ const ForecastCard: FC<Props> = ({
     >
       <Link
         href={getPostLink(post)}
+        prefetch={false}
         className="absolute inset-0"
         target={navigateToNewTab ? "_blank" : "_self"}
       />

--- a/front_end/src/components/news_card.tsx
+++ b/front_end/src/components/news_card.tsx
@@ -26,6 +26,7 @@ const NewsCard: FC<Props> = ({ post }) => {
     <div className="overflow-hidden rounded border border-gray-300 bg-gray-0 transition-colors hover:border-gray-400 dark:border-gray-300-dark dark:bg-gray-0-dark dark:hover:border-gray-400-dark dark:hover:bg-gray-100-dark">
       <Link
         href={getPostLink(post)}
+        prefetch={false}
         className="flex flex-col items-stretch no-underline sm:h-64 sm:flex-row-reverse"
       >
         {post.notebook.image_url &&

--- a/front_end/src/components/post_card/basic_post_card/comment_status.tsx
+++ b/front_end/src/components/post_card/basic_post_card/comment_status.tsx
@@ -21,6 +21,7 @@ type Props = {
   variant?: "default" | "gray";
   target?: string;
   rel?: string;
+  prefetch?: boolean | null;
 };
 
 const CommentStatus: FC<Props> = ({
@@ -32,6 +33,7 @@ const CommentStatus: FC<Props> = ({
   variant = "default",
   target,
   rel,
+  prefetch,
 }) => {
   const t = useTranslations();
   const { user } = useAuth();
@@ -61,6 +63,7 @@ const CommentStatus: FC<Props> = ({
         className
       )}
       href={url + "#comments"}
+      prefetch={prefetch}
       target={target}
       rel={rel}
     >

--- a/front_end/src/components/post_card/basic_post_card/index.tsx
+++ b/front_end/src/components/post_card/basic_post_card/index.tsx
@@ -67,7 +67,11 @@ const BasicPostCard: FC<PropsWithChildren<Props>> = ({
           }[borderColor]
         )}
       >
-        <Link href={getPostLink(post)} className="block no-underline">
+        <Link
+          href={getPostLink(post)}
+          prefetch={false}
+          className="block no-underline"
+        >
           {!hideTitle && (
             <div className="mb-[18px] flex flex-col gap-[10px] @[480px]:mb-0 @[480px]:flex-row @[480px]:gap-3">
               <h4

--- a/front_end/src/components/post_card/basic_post_card/status_rail.tsx
+++ b/front_end/src/components/post_card/basic_post_card/status_rail.tsx
@@ -33,6 +33,7 @@ const PostStatusRail: FC<Props> = ({
         totalCount={post.comment_count ?? 0}
         unreadCount={post.unread_comment_count ?? 0}
         url={postUrl}
+        prefetch={false}
         className="bg-gray-200 @[480px]:hidden dark:bg-gray-200-dark"
         compact
       />
@@ -40,6 +41,7 @@ const PostStatusRail: FC<Props> = ({
         totalCount={post.comment_count ?? 0}
         unreadCount={post.unread_comment_count ?? 0}
         url={postUrl}
+        prefetch={false}
         className="hidden bg-gray-200 @[480px]:flex dark:bg-gray-200-dark"
         compact={false}
       />

--- a/front_end/src/components/post_card/community_disclaimer.tsx
+++ b/front_end/src/components/post_card/community_disclaimer.tsx
@@ -25,6 +25,7 @@ const getDisclaimerCopy = (
       community: () => (
         <Button
           href={getProjectLink(project)}
+          prefetch={false}
           variant="link"
           className="text-xs"
         >

--- a/front_end/src/components/post_card/compact_search_post_card.tsx
+++ b/front_end/src/components/post_card/compact_search_post_card.tsx
@@ -44,7 +44,11 @@ const CompactSearchPostCard: FC<Props> = ({ post }) => {
       <HideCPProvider post={post}>
         <div className="flex items-start gap-4 p-3 sm:items-center sm:px-4">
           <div className="min-w-0 flex-1">
-            <Link href={postUrl} className="block no-underline">
+            <Link
+              href={postUrl}
+              prefetch={false}
+              className="block no-underline"
+            >
               <h4 className="m-0 text-pretty text-sm font-medium leading-5 text-gray-800 transition-colors hover:text-blue-700 dark:text-gray-800-dark dark:hover:text-blue-700-dark sm:text-base sm:leading-6">
                 <HighlightedTitle title={post.title} query={searchQuery} />
               </h4>

--- a/front_end/src/components/post_default_project.tsx
+++ b/front_end/src/components/post_default_project.tsx
@@ -26,6 +26,7 @@ const PostDefaultProject: FC<Props> = ({ defaultProject }) => {
     <Link
       className="inline-flex items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-l rounded-r border-inherit bg-orange-200 text-xs font-medium leading-4 text-orange-900 no-underline hover:bg-orange-300 dark:bg-orange-200-dark dark:text-orange-900-dark hover:dark:bg-orange-300-dark [&>div]:max-w-full"
       href={getProjectLink(defaultProject)}
+      prefetch={false}
     >
       <TruncatedTextTooltip
         text={defaultProject.name}

--- a/front_end/src/components/posts_feed/feed_tournament_tile.tsx
+++ b/front_end/src/components/posts_feed/feed_tournament_tile.tsx
@@ -23,6 +23,7 @@ type Props = {
 const FeedTournamentTile: FC<Props> = ({ tile, feedPage }) => {
   const t = useTranslations();
   const { project, rule, project_resolution_date } = tile;
+  const now = useMemo(() => Date.now(), []);
   const href = useMemo(() => {
     const base = getProjectLink(project);
     return tile.rule === FeedTileRule.ALL_QUESTIONS_RESOLVED
@@ -35,21 +36,22 @@ const FeedTournamentTile: FC<Props> = ({ tile, feedPage }) => {
   );
 
   const ruleLabel = getRuleLabel(t, tile);
-  const statusLabel = getStatusLabel(t, tile);
+  const statusLabel = getStatusLabel(t, tile, now);
   const rawCloseTime =
     rule === FeedTileRule.ALL_QUESTIONS_RESOLVED && project_resolution_date
       ? project_resolution_date
       : project.close_date ??
         project.forecasting_end_date ??
         project.start_date;
-  const rawCloseTs = safeTs(rawCloseTime) ?? Date.now() + 1000;
+  const rawCloseTs = safeTs(rawCloseTime) ?? now + 1000;
   const scheduled_close_time = new Date(
-    Math.max(rawCloseTs, Date.now() + 1000)
+    Math.max(rawCloseTs, now + 1000)
   ).toISOString();
 
   return (
     <Link
       href={href}
+      prefetch={false}
       onClick={() =>
         sendAnalyticsEvent("feedProjectTileClick", {
           project_id: project.id,
@@ -154,9 +156,9 @@ function getRuleLabel(
 
 function getStatusLabel(
   t: ReturnType<typeof useTranslations>,
-  { project, all_questions_resolved, project_resolution_date }: FeedProjectTile
+  { project, all_questions_resolved, project_resolution_date }: FeedProjectTile,
+  now: number
 ): ReactNode | null {
-  const now = Date.now();
   const startTs = safeTs(project.start_date);
   const closeTs = safeTs(project.close_date);
   const resolveTs = safeTs(project_resolution_date);

--- a/front_end/src/components/posts_feed/feed_tournament_tile.tsx
+++ b/front_end/src/components/posts_feed/feed_tournament_tile.tsx
@@ -23,7 +23,7 @@ type Props = {
 const FeedTournamentTile: FC<Props> = ({ tile, feedPage }) => {
   const t = useTranslations();
   const { project, rule, project_resolution_date } = tile;
-  const now = useMemo(() => Date.now(), []);
+  const now = Date.now();
   const href = useMemo(() => {
     const base = getProjectLink(project);
     return tile.rule === FeedTileRule.ALL_QUESTIONS_RESOLVED

--- a/front_end/src/components/ui/button.tsx
+++ b/front_end/src/components/ui/button.tsx
@@ -27,6 +27,7 @@ type Props = {
   variant?: ButtonVariant;
   presentationType?: PresentationType;
   as?: ElementType;
+  prefetch?: boolean | null;
 } & ButtonHTMLAttributes<HTMLButtonElement> &
   AnchorHTMLAttributes<HTMLAnchorElement>;
 
@@ -40,6 +41,7 @@ const Button = forwardRef<HTMLButtonElement, Props>(
       className,
       children,
       as,
+      prefetch,
       ...props
     },
     ref
@@ -49,6 +51,7 @@ const Button = forwardRef<HTMLButtonElement, Props>(
         ref={ref}
         href={href}
         as={as}
+        prefetch={prefetch}
         className={cn(
           "inline-flex items-center justify-center rounded-full disabled:opacity-30",
           {
@@ -86,14 +89,21 @@ Button.displayName = "Button";
 type ContainerProps = ButtonHTMLAttributes<HTMLButtonElement> &
   AnchorHTMLAttributes<HTMLAnchorElement> & {
     as?: ElementType;
+    prefetch?: boolean | null;
   };
 const Container = forwardRef<
   HTMLButtonElement,
   PropsWithChildren<ContainerProps>
->(({ href, children, as, ...props }, ref) => {
+>(({ href, children, as, prefetch, ...props }, ref) => {
   if (href) {
     return (
-      <HeadlessButton ref={ref} as={Link} href={href} {...props}>
+      <HeadlessButton
+        ref={ref}
+        as={Link}
+        href={href}
+        prefetch={prefetch}
+        {...props}
+      >
         {children}
       </HeadlessButton>
     );

--- a/front_end/src/services/api/posts/posts.shared.ts
+++ b/front_end/src/services/api/posts/posts.shared.ts
@@ -68,9 +68,14 @@ export type PrivateNoteWithPost = {
 export type BoostDirection = 1 | -1;
 
 class PostsApi extends ApiService {
-  async getPost(id: number, with_cp = true): Promise<PostWithForecasts> {
+  async getPost(
+    id: number,
+    with_cp = true,
+    fetchOptions?: FetchOptions
+  ): Promise<PostWithForecasts> {
     return await this.get<PostWithForecasts>(
-      `/posts/${id}/${encodeQueryParams({ with_cp })}`
+      `/posts/${id}/${encodeQueryParams({ with_cp })}`,
+      fetchOptions
     );
   }
 

--- a/front_end/src/services/api/profile/profile.shared.ts
+++ b/front_end/src/services/api/profile/profile.shared.ts
@@ -1,10 +1,28 @@
 import { ApiService } from "@/services/api/api_service";
-import { CurrentBot, UserProfile } from "@/types/users";
+import {
+  CurrentBot,
+  User,
+  UserProfile,
+  UserProfileWithStats,
+} from "@/types/users";
 import { encodeQueryParams } from "@/utils/navigation";
 
 class ProfileApi extends ApiService {
-  async getProfileById(id: number): Promise<UserProfile> {
-    return await this.get<UserProfile>(`/users/${id}/`);
+  async getProfileById(
+    id: number,
+    options: { includeStats: true }
+  ): Promise<UserProfileWithStats>;
+  async getProfileById(
+    id: number,
+    options?: { includeStats?: false }
+  ): Promise<UserProfile>;
+  async getProfileById(
+    id: number,
+    { includeStats = false }: { includeStats?: boolean } = {}
+  ): Promise<UserProfile | UserProfileWithStats> {
+    return await this.get<UserProfileWithStats>(
+      `/users/${id}/${encodeQueryParams({ include_stats: includeStats })}`
+    );
   }
 
   async searchUsers(query: string, postId?: number) {
@@ -12,7 +30,7 @@ class ProfileApi extends ApiService {
     if (postId) {
       params.post_id = postId;
     }
-    return await this.get<UserProfile[]>(`/users/${encodeQueryParams(params)}`);
+    return await this.get<User[]>(`/users/${encodeQueryParams(params)}`);
   }
 
   async getMyBots() {

--- a/front_end/src/services/api/profile/profile.shared.ts
+++ b/front_end/src/services/api/profile/profile.shared.ts
@@ -1,4 +1,5 @@
 import { ApiService } from "@/services/api/api_service";
+import { FetchOptions } from "@/types/fetch";
 import {
   CurrentBot,
   User,
@@ -10,18 +11,22 @@ import { encodeQueryParams } from "@/utils/navigation";
 class ProfileApi extends ApiService {
   async getProfileById(
     id: number,
-    options: { includeStats: true }
+    options: { includeStats: true },
+    fetchOptions?: FetchOptions
   ): Promise<UserProfileWithStats>;
   async getProfileById(
     id: number,
-    options?: { includeStats?: false }
+    options?: { includeStats?: false },
+    fetchOptions?: FetchOptions
   ): Promise<UserProfile>;
   async getProfileById(
     id: number,
-    { includeStats = false }: { includeStats?: boolean } = {}
+    { includeStats = false }: { includeStats?: boolean } = {},
+    fetchOptions?: FetchOptions
   ): Promise<UserProfile | UserProfileWithStats> {
     return await this.get<UserProfileWithStats>(
-      `/users/${id}/${encodeQueryParams({ include_stats: includeStats })}`
+      `/users/${id}/${encodeQueryParams({ include_stats: includeStats })}`,
+      fetchOptions
     );
   }
 

--- a/front_end/src/services/api/projects/projects.shared.ts
+++ b/front_end/src/services/api/projects/projects.shared.ts
@@ -1,5 +1,9 @@
 import { ApiService } from "@/services/api/api_service";
-import { PaginatedPayload, PaginationParams } from "@/types/fetch";
+import {
+  FetchOptions,
+  PaginatedPayload,
+  PaginationParams,
+} from "@/types/fetch";
 import { Post, ProjectPermissions } from "@/types/post";
 import {
   Category,
@@ -65,12 +69,19 @@ class ProjectsApi extends ApiService {
     const queryParams = encodeQueryParams(params ?? {});
 
     return await this.get<TournamentPreview[]>(
-      `/projects/tournaments/${queryParams}`
+      `/projects/tournaments/${queryParams}`,
+      { next: { revalidate: 60 } }
     );
   }
 
-  async getTournament(slug: string | number): Promise<Tournament | null> {
-    return await this.get<Tournament>(`/projects/tournaments/${slug}/`);
+  async getTournament(
+    slug: string | number,
+    fetchOptions?: FetchOptions
+  ): Promise<Tournament | null> {
+    return await this.get<Tournament>(
+      `/projects/tournaments/${slug}/`,
+      fetchOptions
+    );
   }
 
   async getMinibenchTournaments(): Promise<TournamentPreview[]> {
@@ -95,8 +106,11 @@ class ProjectsApi extends ApiService {
     );
   }
 
-  async getCommunity(slug: string): Promise<Community> {
-    return this.get<Community>(`/projects/communities/${slug}/`);
+  async getCommunity(
+    slug: string,
+    fetchOptions?: FetchOptions
+  ): Promise<Community> {
+    return this.get<Community>(`/projects/communities/${slug}/`, fetchOptions);
   }
 }
 

--- a/front_end/src/types/projects.ts
+++ b/front_end/src/types/projects.ts
@@ -1,5 +1,5 @@
 import { PostWithForecasts, ProjectPermissions } from "@/types/post";
-import { UserBase, UserProfile } from "@/types/users";
+import { User, UserBase } from "@/types/users";
 
 export enum ProjectVisibility {
   Normal = "normal",
@@ -50,7 +50,7 @@ export enum TournamentsSortBy {
 }
 
 export type TournamentMember = {
-  user: UserProfile;
+  user: User;
   permission: ProjectPermissions;
 };
 

--- a/front_end/src/types/users.ts
+++ b/front_end/src/types/users.ts
@@ -37,6 +37,10 @@ export type User = UserBase & {
 };
 
 export type UserProfile = User & {
+  spam_count?: number;
+};
+
+export type UserProfileStats = {
   calibration_curve?: TrackRecordCalibrationCurveItem[];
   score_histogram?: TrackRecordHistogramItem[];
   score_scatter_plot?: TrackRecordScatterPlotItem[];
@@ -48,8 +52,9 @@ export type UserProfile = User & {
   forecasts_on_authored_questions_count?: number;
   notebooks_authored_count?: number;
   comments_count?: number;
-  spam_count?: number;
 };
+
+export type UserProfileWithStats = UserProfile & UserProfileStats;
 
 export type CurrentUser = User & {
   email: string;

--- a/users/views.py
+++ b/users/views.py
@@ -72,6 +72,12 @@ def current_user_api_view(request):
 def user_profile_api_view(request, pk: int):
     current_user = request.user
 
+    # Forecasting stats (scatter plot, histogram, calibration curve, etc.) are
+    # expensive to compute and only needed on the profile page itself.
+    include_stats = serializers.BooleanField(allow_null=True).run_validation(
+        request.query_params.get("include_stats")
+    )
+
     qs = User.objects.all()
     if not current_user.is_staff:
         qs = qs.filter(is_active=True, is_spam=False)
@@ -86,8 +92,8 @@ def user_profile_api_view(request, pk: int):
             {"spam_count": UserSpamActivity.objects.filter(user=user).count()}
         )
 
-    # Performing slow but cached profile request
-    profile.update(serialize_user_stats(user))
+    if include_stats:
+        profile.update(serialize_user_stats(user))
 
     return Response(profile)
 


### PR DESCRIPTION
### Summary

Next.js 16 changed RSC prefetching behavior: it calls `generateMetadata()` for every visible `<Link>` on a page during server-side rendering, causing an N+1 request pattern on the main feed – 12–20 individual `/api/posts/{id}/` requests to Django on every page load.

Two complementary fixes were applied to eliminate this N+1:

- Introduced a lightweight cached metadata fetch path (`with_cp=false` + `revalidate: 60`) used by `generateMetadata` across question, tournament, and community pages, so repeated prefetch triggers within 60s are served from Next.js server-side cache without hitting Django
- Added `prefetch={false}` to all `<Link>` components visible in feeds and post cards to prevent Next.js from triggering RSC prefetch for every visible link in the viewport

Note: `KeyFactorsTileView` was investigated as a source of additional `with_cp=true` requests – these are legitimate client-side fetches to render the "% chance" label when CP data is absent from the coherence links response, not part of the N+1 pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for conditionally including profile statistics, and updated profile pages to request the enriched stats when needed.

* **Chores**
  * Improved metadata freshness by applying explicit 60-second revalidation for tournament, community, post, notebook, and prediction-flow metadata (including question-page metadata).
  * Standardized metadata/post fetching options and added cached metadata fetch for question pages.
  * Reduced unnecessary link prefetching across many cards and navigation elements by introducing a configurable `prefetch` behavior, with small related rendering/timestamp cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->