### PR TITLE
MC Question Creation: max option length

### DIFF
--- a/front_end/src/app/(main)/questions/components/question_form.tsx
+++ b/front_end/src/app/(main)/questions/components/question_form.tsx
@@ -269,6 +269,9 @@ const createQuestionSchemas = (
         z
           .string()
           .min(1, { message: t("errorRequired") })
+          .max(30, {
+            message: t("errorMaxLength", { field: "String", maxLength: 30 }),
+          })
           .refine((value) => value.trim() !== "", {
             message: t("emptyOptionError"),
           })
@@ -774,6 +777,7 @@ const QuestionForm: FC<Props> = ({
                         <Input
                           {...form.register(`options.${opt_index}`)}
                           readOnly={optionsLocked}
+                          maxLength={30}
                           className="my-2 w-full min-w-32 rounded border  border-gray-500 p-2 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
                           value={option}
                           placeholder={`Option ${opt_index + 1}`}


### PR DESCRIPTION
https://metaculus.slack.com/archives/C01Q9AQBVHB/p1781615789325759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multiple-choice option inputs are now limited to a maximum of 30 characters, with validation enforced at both the form validation and input field levels to ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->