### PR TITLE
Fixed generateMetadata permissions

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/[slug]/page.tsx
@@ -41,9 +41,7 @@ type Props = {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const { slug } = await props.params;
-  const tournament = await ServerProjectsApi.getTournament(slug, {
-    next: { revalidate: 60 },
-  });
+  const tournament = await ServerProjectsApi.getTournament(slug);
   if (!tournament) return {};
 
   const raw = tournament.subtitle || tournament.description || "";

--- a/front_end/src/app/(main)/c/[slug]/[id]/[[...postSlug]]/page.tsx
+++ b/front_end/src/app/(main)/c/[slug]/[id]/[[...postSlug]]/page.tsx
@@ -18,9 +18,7 @@ type Props = {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
-  const postData = await ServerPostsApi.getPost(params.id, false, {
-    next: { revalidate: 60 },
-  });
+  const postData = await ServerPostsApi.getPost(params.id, false);
 
   if (!postData) {
     return {};

--- a/front_end/src/app/(main)/c/[slug]/page.tsx
+++ b/front_end/src/app/(main)/c/[slug]/page.tsx
@@ -28,9 +28,7 @@ type Props = {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
-  const community = await ServerProjectsApi.getCommunity(params.slug, {
-    next: { revalidate: 60 },
-  });
+  const community = await ServerProjectsApi.getCommunity(params.slug);
 
   if (!community) {
     return {};

--- a/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/page.tsx
@@ -16,9 +16,7 @@ type Props = {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
-  const postData = await ServerPostsApi.getPost(params.id, false, {
-    next: { revalidate: 60 },
-  });
+  const postData = await ServerPostsApi.getPost(params.id, false);
 
   if (!postData) {
     return {};

--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/utils/get_post.ts
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/utils/get_post.ts
@@ -55,7 +55,7 @@ async function getPost(
 export const cachedGetPost = cache(getPost);
 
 async function getPostForMetadata(id: number) {
-  return getPost(id, false, { next: { revalidate: 60 } });
+  return getPost(id, false);
 }
 
 export const cachedGetPostForMetadata = cache(getPostForMetadata);

--- a/front_end/src/app/(prediction-flow)/tournament/[slug]/prediction-flow/page.tsx
+++ b/front_end/src/app/(prediction-flow)/tournament/[slug]/prediction-flow/page.tsx
@@ -22,9 +22,7 @@ type Props = {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const { slug } = await props.params;
-  const tournament = await ServerProjectsApi.getTournament(slug, {
-    next: { revalidate: 60 },
-  });
+  const tournament = await ServerProjectsApi.getTournament(slug);
   const t = await getTranslations();
 
   if (!tournament) {

--- a/front_end/src/services/api/projects/projects.shared.ts
+++ b/front_end/src/services/api/projects/projects.shared.ts
@@ -69,8 +69,7 @@ class ProjectsApi extends ApiService {
     const queryParams = encodeQueryParams(params ?? {});
 
     return await this.get<TournamentPreview[]>(
-      `/projects/tournaments/${queryParams}`,
-      { next: { revalidate: 60 } }
+      `/projects/tournaments/${queryParams}`
     );
   }
 


### PR DESCRIPTION
https://metaculus.slack.com/archives/C01Q9AQBVHB/p1781787837622709

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated server-side metadata fetching to remove the explicit fixed 60-second revalidation setting across tournaments, communities, posts, questions, notebooks, and related listings.
  * Metadata will now follow the platform’s default caching/revalidation behavior rather than a uniform 60-second interval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->