### PR TITLE
fix: render date/numeric values in group compact legend bar

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/compact_legend_bar/index.tsx
@@ -5,7 +5,7 @@ import { FC, useState } from "react";
 import { ChoiceItem } from "@/types/choices";
 import { QuestionType } from "@/types/question";
 import cn from "@/utils/core/cn";
-import { getForecastPctDisplayValue } from "@/utils/formatters/prediction";
+import { getPredictionDisplayValue } from "@/utils/formatters/prediction";
 import { isUnsuccessfullyResolved } from "@/utils/questions/resolution";
 
 const MAX_ITEMS = 5;
@@ -83,7 +83,15 @@ const CompactLegendBar: FC<Props> = ({
       {visibleItems.map((item) => {
         const resolvedNo = isResolvedNo(item, questionType);
         const resolvedYes = isResolvedYes(item, questionType);
-        const pct = getForecastPctDisplayValue(getLastAggregationValue(item));
+        const displayValue = getPredictionDisplayValue(
+          getLastAggregationValue(item),
+          {
+            questionType,
+            scaling: item.scaling,
+            actual_resolve_time: item.actual_resolve_time ?? null,
+            emptyLabel: "?",
+          }
+        );
 
         return (
           <div
@@ -152,7 +160,7 @@ const CompactLegendBar: FC<Props> = ({
                 </span>
                 {(resolvedYes || (!item.isDeleted && !hideCP)) && (
                   <span className="shrink-0 text-sm tabular-nums leading-4 text-gray-600 dark:text-gray-600-dark md:text-base md:leading-6">
-                    {resolvedYes ? `(${t("Yes")})` : pct}
+                    {resolvedYes ? `(${t("Yes")})` : displayValue}
                   </span>
                 )}
               </>


### PR DESCRIPTION
Closes #4901

## Summary
The compact legend bar above the group chart on the detailed question page always formatted choice values as percentages, so a Date group's centered internal value `0.114` displayed as "11.4%" instead of being scaled to a date. Now uses `getPredictionDisplayValue` with the question's type and scaling, matching the behavior of `ChoiceOption` on the tile legend.

## Test plan
- [ ] Open a Date group question (e.g. #/44159) on the detailed view and confirm the checkbox legend renders dates rather than percentages
- [ ] Confirm Binary group, Multiple Choice, and Numeric group legends still render their expected values

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced legend display accuracy for multiple-choice question charts by improving how non-confirmed values are calculated and presented with better context awareness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->