### PR TITLE
use silver_medalists for midterm data

### DIFF
--- a/front_end/src/app/(main)/midterms-2026/helpers/fetch_dashboard_data.ts
+++ b/front_end/src/app/(main)/midterms-2026/helpers/fetch_dashboard_data.ts
@@ -284,7 +284,9 @@ const fetchMedalistsCdf = async (postId: number): Promise<number[] | null> => {
       aggregationMethods: "silver_medalists",
       includeBots: false,
     })) as NumericAggregationExtraQuestion;
-    return question?.aggregations?.medalists?.latest?.forecast_values ?? null;
+    return (
+      question?.aggregations?.silver_medalists?.latest?.forecast_values ?? null
+    );
   } catch {
     return null;
   }

--- a/front_end/src/app/(main)/midterms-2026/helpers/fetch_dashboard_data.ts
+++ b/front_end/src/app/(main)/midterms-2026/helpers/fetch_dashboard_data.ts
@@ -281,7 +281,7 @@ const fetchMedalistsCdf = async (postId: number): Promise<number[] | null> => {
   try {
     const question = (await ServerAggregationsExplorerApi.getAggregations({
       postId,
-      aggregationMethods: "medalists",
+      aggregationMethods: "silver_medalists",
       includeBots: false,
     })) as NumericAggregationExtraQuestion;
     return question?.aggregations?.medalists?.latest?.forecast_values ?? null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the seat-distribution charts to use **silver medalists** data for both senate and house divisions, improving the alignment of chart projections with the intended medal category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->