### PR TITLE
filter for post permissions when retrieving comments list

### DIFF
--- a/comments/serializers/common.py
+++ b/comments/serializers/common.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from django.db.models.query import QuerySet
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import NotFound, ValidationError
 
 from comments.constants import TimeWindow
 from comments.models import Comment, KeyFactor, CommentsOfTheWeekEntry
@@ -43,10 +43,12 @@ class CommentFilterSerializer(serializers.Serializer):
     )
 
     def validate_post(self, value: int):
+        request = self.context.get("request")
+        user = request.user if request else None
         try:
-            return Post.objects.get(pk=value)
+            return Post.objects.filter_permission(user=user).get(pk=value)
         except Post.DoesNotExist:
-            raise ValidationError("Post Does not exist")
+            raise NotFound("Post not found")
 
     def validate(self, attrs):
         sort = attrs.get("sort")

--- a/comments/views/common.py
+++ b/comments/views/common.py
@@ -89,7 +89,9 @@ def comments_list_api_view(request: Request):
     ).run_validation(request.query_params.get("use_root_comments_pagination"))
 
     # Validate query parameters using the serializer
-    filters_serializer = CommentFilterSerializer(data=request.query_params)
+    filters_serializer = CommentFilterSerializer(
+        data=request.query_params, context={"request": request}
+    )
     filters_serializer.is_valid(raise_exception=True)
 
     validated_data = filters_serializer.validated_data


### PR DESCRIPTION
Filter comments feed based on permissions to avoid allowing access to comments on posts not accessible to the user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced post permission validation in comments to properly enforce user authorization checks. Users can only access and comment on posts they have permission to view.
  * Improved error handling for unauthorized post access with consistent, clear error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->