### PR TITLE
fix: add post permission checks to comment interaction endpoints

### DIFF
--- a/comments/views/common.py
+++ b/comments/views/common.py
@@ -36,7 +36,6 @@ from comments.services.common import (
 from comments.services.feed import get_comments_feed
 from comments.services.key_factors.common import create_key_factors
 from notifications.services import send_comment_report_notification_to_staff
-from posts.models import Post
 from posts.services.common import get_post_permission_for_user
 from projects.permissions import ObjectPermission
 from users.models import User
@@ -336,9 +335,6 @@ def comments_of_week_view(request: Request):
     # Admins can see all top (max 18) candidates for the weekly top comments
     top_comments_of_week_entries = CommentsOfTheWeekEntry.objects.filter(
         week_start_date=week_start_date,
-        comment__on_post__in=Post.objects.filter_permission(
-            user=user if user.is_authenticated else None
-        ),
     ).order_by("-score", "comment__created_at")
 
     # Users only see the top 6 comments which are not excluded

--- a/comments/views/common.py
+++ b/comments/views/common.py
@@ -36,6 +36,7 @@ from comments.services.common import (
 from comments.services.feed import get_comments_feed
 from comments.services.key_factors.common import create_key_factors
 from notifications.services import send_comment_report_notification_to_staff
+from posts.models import Post
 from posts.services.common import get_post_permission_for_user
 from projects.permissions import ObjectPermission
 from users.models import User
@@ -225,6 +226,9 @@ def comment_toggle_cmm_view(request, pk=int):
     enabled = request.data.get("enabled", False)
     comment = get_object_or_404(Comment, pk=pk)
 
+    permission = get_post_permission_for_user(comment.on_post, user=request.user)
+    ObjectPermission.can_view(permission, raise_exception=True)
+
     result = toggle_cmm(comment, request.user, enabled)
 
     if result is None:
@@ -240,6 +244,9 @@ def comment_toggle_cmm_view(request, pk=int):
 def comment_report_api_view(request, pk=int):
     comment = get_object_or_404(Comment, pk=pk)
     post = comment.on_post
+
+    permission = get_post_permission_for_user(post, user=request.user)
+    ObjectPermission.can_view(permission, raise_exception=True)
 
     reason = serializers.ChoiceField(choices=CommentReportType.choices).run_validation(
         request.data.get("reason")
@@ -329,7 +336,10 @@ def comments_of_week_view(request: Request):
 
     # Admins can see all top (max 18) candidates for the weekly top comments
     top_comments_of_week_entries = CommentsOfTheWeekEntry.objects.filter(
-        week_start_date=week_start_date
+        week_start_date=week_start_date,
+        comment__on_post__in=Post.objects.filter_permission(
+            user=user if user.is_authenticated else None
+        ),
     ).order_by("-score", "comment__created_at")
 
     # Users only see the top 6 comments which are not excluded

--- a/comments/views/common.py
+++ b/comments/views/common.py
@@ -252,8 +252,7 @@ def comment_report_api_view(request, pk=int):
         request.data.get("reason")
     )
 
-    if post:
-        send_comment_report_notification_to_staff(comment, reason, request.user)
+    send_comment_report_notification_to_staff(comment, reason, request.user)
 
     return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/comments/views/key_factors.py
+++ b/comments/views/key_factors.py
@@ -30,6 +30,11 @@ from projects.permissions import ObjectPermission
 def key_factor_vote_view(request: Request, pk: int):
     key_factor = get_object_or_404(KeyFactor, pk=pk)
 
+    permission = get_post_permission_for_user(
+        key_factor.comment.on_post, user=request.user
+    )
+    ObjectPermission.can_view(permission, raise_exception=True)
+
     vote_type, vote_choices = get_key_factor_vote_type_and_choices(key_factor)
 
     vote = serializers.ChoiceField(
@@ -83,6 +88,9 @@ def comment_add_key_factors_view(request: Request, pk: int):
 @permission_classes([IsAuthenticated])
 def comment_suggested_key_factors_view(request: Request, pk: int):
     comment = get_object_or_404(Comment, pk=pk)
+
+    permission = get_post_permission_for_user(comment.on_post, user=request.user)
+    ObjectPermission.can_view(permission, raise_exception=True)
 
     existing_keyfactors = (
         KeyFactor.objects.for_posts([comment.on_post])


### PR DESCRIPTION
Closes several secondary permission gaps where users could interact with comments on posts they don't have access to:
- comment_toggle_cmm_view, comment_report_api_view: add can_view check
- comments_of_week_view: filter entries to posts visible to the user
- key_factor_vote_view, comment_suggested_key_factors_view: add can_view check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Comment toggle and report endpoints now enforce post-level view permissions before processing requests or notifying staff.
  * Key factor voting and suggested key factors now require authorization to view the related post before returning results or recording votes.
  * Minor adjustment to weekly comments query formatting (no functional change expected).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->