### PR TITLE
Revert "filter for post permissions when retrieving comments list"

### DIFF
--- a/comments/serializers/common.py
+++ b/comments/serializers/common.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from django.db.models.query import QuerySet
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
-from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.exceptions import ValidationError
 
 from comments.constants import TimeWindow
 from comments.models import Comment, KeyFactor, CommentsOfTheWeekEntry
@@ -43,12 +43,10 @@ class CommentFilterSerializer(serializers.Serializer):
     )
 
     def validate_post(self, value: int):
-        request = self.context.get("request")
-        user = request.user if request else None
         try:
-            return Post.objects.filter_permission(user=user).get(pk=value)
+            return Post.objects.get(pk=value)
         except Post.DoesNotExist:
-            raise NotFound("Post not found")
+            raise ValidationError("Post Does not exist")
 
     def validate(self, attrs):
         sort = attrs.get("sort")

--- a/comments/views/common.py
+++ b/comments/views/common.py
@@ -89,9 +89,7 @@ def comments_list_api_view(request: Request):
     ).run_validation(request.query_params.get("use_root_comments_pagination"))
 
     # Validate query parameters using the serializer
-    filters_serializer = CommentFilterSerializer(
-        data=request.query_params, context={"request": request}
-    )
+    filters_serializer = CommentFilterSerializer(data=request.query_params)
     filters_serializer.is_valid(raise_exception=True)
 
     validated_data = filters_serializer.validated_data


### PR DESCRIPTION
Reverts Metaculus/metaculus#4911

No need for this PR, it was handled in `get_comments_feed` already. False alarm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for comment operations when accessing non-existent posts. The API now provides consistent validation error responses instead of mixed error types, improving error message clarity.

* **Changes**
  * Optimized comment filtering and validation processes for improved consistency and reliability in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->