### PR TITLE
fix: labor hub commentary — hours worked and financial specialists

### DIFF
--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -198,7 +198,7 @@ export default function LaborAutomationHubPage() {
               </span>
               , <strong>median wages are expected to grow.</strong> The workweek
               is also expected to become{" "}
-              <strong>about three hours shorter by 2035</strong> among all
+              <strong>about five hours shorter by 2035</strong> among all
               workers, while productivity grows.
             </ContentParagraph>
             <ContentParagraph>

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-17">Jun 17</time>
+              Commentary last updated: <time dateTime="2026-06-20">Jun 20</time>
             </div>
           </div>
         </div>

--- a/front_end/src/app/(main)/labor-hub/sections/research.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/research.tsx
@@ -73,7 +73,7 @@ export function ResearchSection({
             high exposure and vulnerability of lawyers, sales representatives,
             and software developers will translate to significant employment
             reductions in these fields over the next decade, while financial
-            specialists are expected to see only modest decline. These forecasts
+            specialists are expected to see only modest growth. These forecasts
             provide important context to our understanding of workforce
             prospects by quantifying the predicted impact of AI on employment
             levels.


### PR DESCRIPTION
## Summary

Automated commentary audit of https://www.metaculus.com/labor-hub found two misalignments between chart forecast data and surrounding commentary text.

## Fixes

### 1. Wages section — hours worked reduction
- **Old text:** "The workweek is also expected to become **about three hours shorter by 2035** among all workers"
- **Chart data:** Average weekly hours: 38.3 (2025) → 33.7 (2035) = ~4.6 hours shorter
- **New text:** "The workweek is also expected to become **about five hours shorter by 2035** among all workers"

### 2. Research / Comparison section — financial specialists direction
- **Old text:** "while financial specialists are expected to see only modest **decline**"
- **Chart data:** Financial Specialists employment: +0.9% (2030), +1.2% (2035) — consistent growth, not decline
- **New text:** "while financial specialists are expected to see only modest **growth**"

### 3. Commentary date
- Updated "Commentary last updated" from Jun 17 → Jun 20

## Files changed
- `front_end/src/app/(main)/labor-hub/page.tsx` — hours worked claim
- `front_end/src/app/(main)/labor-hub/sections/research.tsx` — financial specialists direction
- `front_end/src/app/(main)/labor-hub/sections/hero.tsx` — commentary date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjrkGGgbcED6D3StCFFWE1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjrkGGgbcED6D3StCFFWE1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Revised workweek shortening forecast: increased from approximately three hours to five hours shorter by 2035
  * Updated specialist employment outlook from "modest decline" to "modest growth"
  * Refreshed commentary timestamp to June 20, 2026

<!-- end of auto-generated comment: release notes by coderabbit.ai -->