### PR TITLE
fix: labor hub commentary misalignments (Jun 21)

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -34,9 +34,9 @@ export const JOBS_INSIGHTS = {
   "2035": {
     positive: (
       <>
-        By 2035, <strong>nurses</strong>, <strong>physicians</strong>, and{" "}
-        <strong>law enforcement</strong> are expected to see the highest growth,
-        driven by hands-on needs that cannot be easily automated.
+        By 2035, <strong>nurses</strong>, <strong>restaurant servers</strong>,
+        and <strong>law enforcement</strong> are expected to see the highest
+        growth, driven by hands-on needs that cannot be easily automated.
       </>
     ),
     negative: (
@@ -44,8 +44,8 @@ export const JOBS_INSIGHTS = {
         By 2035, <strong>software</strong>, <strong>sales</strong> and{" "}
         <strong>law</strong> are expected to see sharp staff reductions as AI
         systems take over large portions of coding, outreach, and detailed
-        research work, while <strong>laborers</strong> see a modest decline as
-        more advanced robotics expand their reach.
+        research work, while <strong>laborers</strong> see modest gains as
+        robotics have yet to fully displace physical roles by this horizon.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -198,7 +198,7 @@ export default function LaborAutomationHubPage() {
               </span>
               , <strong>median wages are expected to grow.</strong> The workweek
               is also expected to become{" "}
-              <strong>about five hours shorter by 2035</strong> among all
+              <strong>about four hours shorter by 2035</strong> among all
               workers, while productivity grows.
             </ContentParagraph>
             <ContentParagraph>

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-20">Jun 20</time>
+              Commentary last updated: <time dateTime="2026-06-21">Jun 21</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated commentary audit found three forecast/prediction misalignments between chart data and commentary text on the Labor Hub. All fixes align the static text to the current forecast values displayed in the charts.

## Fixes

### 1. Jobs Monitor 2035 — highest growth occupations (jobs_insights.tsx)
- **Before:** "By 2035, **nurses**, **physicians**, and **law enforcement** are expected to see the highest growth…"
- **After:** "By 2035, **nurses**, **restaurant servers**, and **law enforcement** are expected to see the highest growth…"
- **Why:** Chart ranks: Nurses +12.1% (#1), Restaurant Servers +9.6% (#2), Law Enforcement +7.1% (#3), Physicians +6.7% (#4). Physicians are 4th, not in the top 3.

### 2. Jobs Monitor 2035 — laborers direction (jobs_insights.tsx)
- **Before:** "…while **laborers** see a modest decline as more advanced robotics expand their reach."
- **After:** "…while **laborers** see modest gains as robotics have yet to fully displace physical roles by this horizon."
- **Why:** Laborers and Movers 2035 forecast is +1.3% (growth, not decline).

### 3. Wages section — hours shorter estimate (page.tsx)
- **Before:** "The workweek is also expected to become **about five hours shorter by 2035**…"
- **After:** "The workweek is also expected to become **about four hours shorter by 2035**…"
- **Why:** From 2025 baseline (~38.3 hrs) to 2035 forecast (33.9 hrs) = 4.4 hrs difference, which rounds to ~4, not 5. Consistent with Key Insights which states "down from 38 now" → 33.9.

### 4. Commentary date (hero.tsx)
- Updated `Commentary last updated` from Jun 20 → Jun 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVmgN6oTAWzVxriUqaPNjH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVmgN6oTAWzVxriUqaPNjH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Revised 2035 job market outlook with updated profession examples and labor trend projections.
  * Adjusted forecasted workweek reduction from five hours to four hours shorter.
  * Updated commentary timestamp to June 21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->