### PR TITLE
fix: labor hub commentary — 2030 jobs monitor financial roles (Jun 22)

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -24,10 +24,9 @@ export const JOBS_INSIGHTS = {
     ),
     negative: (
       <>
-        By 2030, <strong>software developers</strong> and{" "}
-        <strong>sales representatives</strong> are expected to see steep
-        declines, while <strong>financial</strong> roles begin to see the
-        effects of AI capabilities substitution.
+        By 2030, <strong>software developers</strong>,{" "}
+        <strong>sales representatives</strong>, and <strong>lawyers</strong> are
+        expected to see steep declines, as AI takes over their core tasks.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-21">Jun 21</time>
+              Commentary last updated: <time dateTime="2026-06-22">Jun 22</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

One misalignment found in the Jobs Monitor 2030 commentary where the text incorrectly implied financial roles were being displaced by AI, contradicting forecast data showing positive growth.

## Fix

**Jobs Monitor — 2030 view (negative insight box)**

- **Old text:** "By 2030, **software developers** and **sales representatives** are expected to see steep declines, while **financial** roles begin to see the effects of AI capabilities substitution."
- **Chart data:** Financial Specialists forecast = **+1.0%** employment growth in 2030 (not decline/substitution)
- **New text:** "By 2030, **software developers**, **sales representatives**, and **lawyers** are expected to see steep declines, as AI takes over their core tasks."
  - Lawyers and Law Clerks show **−4.4%** in 2030, making them the third-steepest declining occupation — accurate to include here.

Also updated commentary last-updated date to Jun 22.

## Files changed

- `front_end/src/app/(main)/labor-hub/jobs_insights.tsx` — 2030 negative insight corrected
- `front_end/src/app/(main)/labor-hub/sections/hero.tsx` — date updated to Jun 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKtbXyRZbNhcfgYr8Wi4TQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKtbXyRZbNhcfgYr8Wi4TQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refined labor market projections for 2030, including updated insights on software developer career outlook and AI's impact on professional roles
  * Updated the "Commentary last updated" timestamp in the hero section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->