### PR TITLE
fix: hide notebook tile thumbnail when rendered narrow

### DIFF
--- a/front_end/src/components/post_card/notebook_tile.tsx
+++ b/front_end/src/components/post_card/notebook_tile.tsx
@@ -8,6 +8,12 @@ import { NotebookPost } from "@/types/post";
 import { getMarkdownSummary } from "@/utils/markdown";
 
 const NOTEBOOK_THUMBNAIL_HEIGHT = 96;
+// Below this rendered tile width (Tailwind `sm`) we drop the thumbnail so the
+// text can use the full width. Covers both narrow causes: multi-column grid
+// tiles (~480-520px) and narrow-screen devices.
+const NARROW_TILE_THRESHOLD = 640;
+const NOTEBOOK_IMAGE_WIDTH = 176; // matches the image's min-w-44/max-w-44
+const NOTEBOOK_IMAGE_GAP = 16; // matches the container's gap-4
 
 type Props = {
   post: NotebookPost;
@@ -17,13 +23,16 @@ const NotebookTile: FC<Props> = ({ post }) => {
   const { ref, width } = useContainerSize<HTMLDivElement>();
 
   const { notebook } = post;
-  const hasImage =
+  const hasImageUrl =
     !!notebook.image_url && notebook.image_url.startsWith("https:");
+  const hasImage = hasImageUrl && width >= NARROW_TILE_THRESHOLD;
+  const textWidth = hasImage
+    ? width - NOTEBOOK_IMAGE_WIDTH - NOTEBOOK_IMAGE_GAP
+    : width;
 
   return (
-    <div className="flex gap-4">
+    <div ref={ref} className="flex gap-4">
       <div
-        ref={ref}
         className={
           hasImage ? "h-24 min-w-0 flex-1 overflow-hidden" : "min-w-0 flex-1"
         }
@@ -35,7 +44,7 @@ const NotebookTile: FC<Props> = ({ post }) => {
               notebook.feed_tile_summary ||
               getMarkdownSummary({
                 markdown: notebook.markdown,
-                width,
+                width: textWidth,
                 height: hasImage ? NOTEBOOK_THUMBNAIL_HEIGHT : 80,
               })
             }


### PR DESCRIPTION
In the feed, a notebook post renders as summary text on the left and a thumbnail on the right. When the tile is rendered narrow (Tile/grid mode multi-column, or a narrow-screen device) the image crowds out the text.

Hide the thumbnail when the tile's rendered width is below 640px (Tailwind `sm`) so the text can use the full width. This is a single self-contained rule in NotebookTile: the existing useContainerSize ref now measures the outer container (stable regardless of whether the image shows), and the text summary is fed a derived width so truncation behavior is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive behavior in notebook tiles: thumbnails now hide when container width is below a threshold
  * Markdown editor width dynamically adjusts based on available space, ensuring proper layout alignment across different screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->