### PR TITLE
Track Reddit SignUp event on successful registration

### DIFF
--- a/front_end/src/components/auth/signup.tsx
+++ b/front_end/src/components/auth/signup.tsx
@@ -112,6 +112,7 @@ export const SignupForm: FC<{
         event_category: new URLSearchParams(window.location.search).toString(),
         signupPath: redirectLocation,
       });
+      window.rdt?.("track", "SignUp");
       if (response?.is_active) {
         setCurrentModal(null);
       } else {

--- a/front_end/src/declarations/globals.d.ts
+++ b/front_end/src/declarations/globals.d.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface Window {
+    rdt?: (
+      command: string,
+      event?: string,
+      data?: Record<string, unknown>
+    ) => void;
+  }
+}
+
+export {};


### PR DESCRIPTION
### Summary

Signup flow was not sending a conversion event to Reddit Ads after a successful registration.

Implemented changes:

- **`signup.tsx`**: Added `window.rdt?.("track", "SignUp")` call after a successful signup response, firing the Reddit Pixel conversion event. Uses optional chaining so it silently no-ops when the Reddit Pixel script hasn't loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved analytics tracking for user sign-up activities to provide better insights into registration patterns and user engagement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->