### PR TITLE
chore: remove storefront services-copy PostHog experiment

### DIFF
--- a/front_end/src/app/(storefront)/components/hero_section.tsx
+++ b/front_end/src/app/(storefront)/components/hero_section.tsx
@@ -4,7 +4,6 @@ import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { useFeatureFlagVariantKey } from "posthog-js/react";
 import { FC, useEffect, useRef, useState } from "react";
 
 import { SiteStats } from "@/services/api/misc/misc.shared";
@@ -134,13 +133,6 @@ const AccentOverlay: FC<{ accentKey: keyof typeof CARD_ACCENT_COLORS }> = ({
 
 const HeroSection: FC<HeroSectionProps> = ({ stats }) => {
   const t = useTranslations();
-  const servicesCopyVariant = useFeatureFlagVariantKey("services-copy");
-  const servicesCopyTitle =
-    servicesCopyVariant === "B"
-      ? t("services")
-      : servicesCopyVariant === "C"
-        ? t("partnerWithMetaculus")
-        : t("businessSolutions");
 
   const [hoveredCard, setHoveredCard] = useState<HoveredCard>(null);
   const { color: globeColor, speed: globeSpeed } =
@@ -235,7 +227,7 @@ const HeroSection: FC<HeroSectionProps> = ({ stats }) => {
                 <div className="relative z-10 flex h-full flex-col justify-between gap-2 md:justify-start">
                   <div className="flex items-start justify-between md:items-center">
                     <span className="text-sm font-semibold text-purple-900 md:text-2xl">
-                      {servicesCopyTitle}
+                      {t("services")}
                     </span>
                     <FontAwesomeIcon
                       icon={faArrowRight}


### PR DESCRIPTION
Removes the `services-copy` PostHog experiment from the storefront hero section and hardcodes the "Services" copy on the Business Solutions card.

Closes #4924

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the Business Solutions card title rendering to use standard localization instead of variant-specific copy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->