### PR TITLE
fix: labor hub commentary misalignment in Jobs Monitor 2027 view

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -8,8 +8,9 @@ export const JOBS_INSIGHTS = {
     ),
     negative: (
       <>
-        By 2027, <strong>software developers</strong> are expected to see
-        stagnant growth, as early AI coding capabilities begin to dampen demand.
+        By 2027, <strong>sales representatives</strong> are expected to see
+        early declines as AI begins to automate outreach and client
+        interactions.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-22">Jun 22</time>
+              Commentary last updated: <time dateTime="2026-06-24">Jun 24</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated commentary audit of https://www.metaculus.com/labor-hub found one misalignment between chart data and callout text:

**Jobs Monitor → 2027 tab → Negative insight card**

| | Text |
|---|---|
| **Before** | "By 2027, **software developers** are expected to see stagnant growth, as early AI coding capabilities begin to dampen demand." |
| **After** | "By 2027, **sales representatives** are expected to see early declines as AI begins to automate outreach and client interactions." |

**Why:** The chart shows Software Developers at **+0.77%** for 2027 (positive growth column). Services Sales Representatives is the **only** occupation projected to decline in 2027 at **−2.26%**. The old callout had the wrong occupation highlighted.

Also updated the "Commentary last updated" date from Jun 22 → Jun 24.

## Test plan
- [ ] Visit /labor-hub, click "Jobs Monitor" and select the **by 2027** tab
- [ ] Verify the negative insight card now mentions sales representatives (not software developers)
- [ ] Verify "Commentary last updated" shows Jun 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rZkEutCwAHLg77d9d3UGC

---
_Generated by [Claude Code](https://claude.ai/code/session_015rZkEutCwAHLg77d9d3UGC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Refreshed the labor market insights text for 2027 to reflect a revised outlook for sales representatives, including earlier declines tied to AI-driven automation.
  * Updated the “Commentary last updated” date in the hero section from Jun 22 to Jun 24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->