### PR TITLE
feat: note US government restriction in Fable 5 labor hub news item

### DIFF
--- a/front_end/src/app/(main)/labor-hub/activity_data.tsx
+++ b/front_end/src/app/(main)/labor-hub/activity_data.tsx
@@ -241,7 +241,8 @@ export const RAW_ACTIVITY_MONITOR_DATA: RawActivityMonitorEntry[] = [
     content: (
       <>
         Anthropic launches Claude Fable 5, a Mythos-class model made safe for
-        general use -{" "}
+        general use, and 3 days later the US government restricts all public
+        use. -{" "}
         <a
           href="https://www.anthropic.com/news/claude-fable-5-mythos-5"
           target="_blank"


### PR DESCRIPTION
Adds "and 3 days later the US government restricts all public use." to the existing Fable 5 news entry in the Labor Hub activity monitor. Source link unchanged since the original post has the update.

Closes #4933

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated one activity feed entry to include a clearer notice about US government public-use restrictions after general release.
  * Kept the existing link and layout unchanged while improving the displayed wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->