### PR TITLE
Comment Save Does Not Capture Very Recent Edits

### DIFF
--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -9,6 +9,7 @@ import {
   faEllipsis,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { MDXEditorMethods } from "@mdxeditor/editor";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -32,6 +33,7 @@ import CommentVoter from "@/components/comment_feed/comment_voter";
 import { Admin } from "@/components/icons/admin";
 import { Moderator } from "@/components/icons/moderator";
 import MarkdownEditor from "@/components/markdown_editor";
+import { processMarkdown } from "@/components/markdown_editor/helpers";
 import RichText from "@/components/rich_text";
 import Button from "@/components/ui/button";
 import Checkbox from "@/components/ui/checkbox";
@@ -255,6 +257,7 @@ const Comment: FC<CommentProps> = ({
 }) => {
   const t = useTranslations();
   const commentRef = useRef<HTMLDivElement>(null);
+  const editEditorRef = useRef<MDXEditorMethods>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [editorKey, setEditorKey] = useState<number>(0);
   const originalTextRef = useRef<string>(comment.text);
@@ -534,7 +537,11 @@ const Comment: FC<CommentProps> = ({
       setIsLoading(true);
       setErrorMessage("");
 
-      const parsedMarkdown = commentMarkdown.replace(userTagPattern, (match) =>
+      const latestMarkdown = processMarkdown(
+        editEditorRef.current?.getMarkdown() ?? commentMarkdown,
+        { revert: true, withTwitterPreview: false }
+      );
+      const parsedMarkdown = latestMarkdown.replace(userTagPattern, (match) =>
         match.replace(/[\\]/g, "")
       );
 
@@ -894,6 +901,7 @@ const Comment: FC<CommentProps> = ({
                   <div>
                     <MarkdownEditor
                       key={`edit-${comment.id}-${editorKey}`}
+                      ref={editEditorRef}
                       className="rounded border border-gray-500 dark:border-gray-500-dark"
                       markdown={commentMarkdown}
                       mode="write"

--- a/front_end/src/components/comment_feed/comment_editor.tsx
+++ b/front_end/src/components/comment_feed/comment_editor.tsx
@@ -7,6 +7,7 @@ import toast from "react-hot-toast";
 
 import { createComment } from "@/app/(main)/questions/actions";
 import MarkdownEditor from "@/components/markdown_editor";
+import { processMarkdown } from "@/components/markdown_editor/helpers";
 import Button from "@/components/ui/button";
 import Checkbox from "@/components/ui/checkbox";
 import { FormErrorMessage, Textarea } from "@/components/ui/form_field";
@@ -128,7 +129,10 @@ const CommentEditor: FC<CommentEditorProps> = ({
     setServerError(undefined);
     setIsLoading(true);
 
-    const markdown = markdownRef.current ?? "";
+    const markdown = processMarkdown(
+      editorRef.current?.getMarkdown() ?? markdownRef.current ?? "",
+      { revert: true, withTwitterPreview: false }
+    );
 
     if (user && !PUBLIC_MINIMAL_UI) {
       const validateNode = validateComment(markdown.trim(), user, t);

--- a/front_end/src/components/markdown_editor/helpers.ts
+++ b/front_end/src/components/markdown_editor/helpers.ts
@@ -102,9 +102,9 @@ function escapePlainTextSymbols(str: string) {
   });
 
   // escape { that is not correctly used
-  tempStr = tempStr
-    .replace(/([^{]){(?![^}]*})/g, "$1\\{")
-    .replace(/^{(?![^}]*})/g, "\\{");
+  tempStr = tempStr.replace(/{(?![^}]*})/g, (match, offset, input) =>
+    isEscapedAt(input, offset) ? match : `\\${match}`
+  );
 
   return tempStr;
 }


### PR DESCRIPTION
### Summary

Ensures comment saves capture the most recent edits.

Implemented changes:

* Read the latest markdown directly from the editor when creating or editing comments while preserving the existing input debounce.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the comment editing save flow to reliably use the latest markdown from the editor before saving.
  * Added markdown normalization during comment validation/submission to reduce inconsistent formatting.
  * Fixed markdown escaping for `{` so it correctly preserves already-escaped content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->