### PR TITLE
remove Y axis for discrete questions in feed and in collapsed group view

### DIFF
--- a/front_end/src/components/charts/continuous_area_chart.tsx
+++ b/front_end/src/components/charts/continuous_area_chart.tsx
@@ -100,6 +100,7 @@ type Props = {
   onCursorChange?: (value: ContinuousAreaHoverState | null) => void;
   hideCP?: boolean;
   hideLabels?: boolean;
+  hideYAxis?: boolean;
   shortLabels?: boolean;
   alignChartTabs?: boolean;
   forceTickCount?: number; // is used on feed page
@@ -123,6 +124,7 @@ const ContinuousAreaChart: FC<Props> = ({
   onCursorChange,
   hideCP,
   hideLabels = false,
+  hideYAxis = false,
   shortLabels = false,
   alignChartTabs,
   forceTickCount,
@@ -154,6 +156,9 @@ const ContinuousAreaChart: FC<Props> = ({
     : chartTheme;
 
   const discrete = question.type === QuestionType.Discrete;
+  const showYAxis =
+    graphType === "cdf" ||
+    (question.type === QuestionType.Discrete && !hideYAxis);
   const paddingTop = graphType === "cdf" || discrete ? TOP_PADDING : 0;
 
   const hasUserData = useMemo(
@@ -375,11 +380,7 @@ const ContinuousAreaChart: FC<Props> = ({
   // const massBelowBounds = dataset[0];
   // const massAboveBounds = dataset[dataset.length - 1];
   const horizontalPadding = useMemo(() => {
-    if (
-      alignChartTabs ||
-      graphType === "cdf" ||
-      question.type === QuestionType.Discrete
-    ) {
+    if (alignChartTabs || showYAxis) {
       const labels = yScale.ticks.map((tick) => yScale.tickFormat(tick));
       const longestLabelLength = Math.max(
         ...labels.map((label) => label.length)
@@ -390,7 +391,7 @@ const ContinuousAreaChart: FC<Props> = ({
     }
 
     return HORIZONTAL_PADDING;
-  }, [graphType, yScale, question.type, alignChartTabs]);
+  }, [yScale, showYAxis, alignChartTabs]);
 
   const handleMouseLeave = useCallback(() => {
     onCursorChange?.(null);
@@ -750,7 +751,7 @@ const ContinuousAreaChart: FC<Props> = ({
                 />
               ))
             : null}
-          {(graphType === "cdf" || question.type === QuestionType.Discrete) && (
+          {showYAxis && (
             // Prevent Y axis being cut off in edge cases
             <VictoryPortal>
               <VictoryAxis

--- a/front_end/src/components/forecast_maker/continuous_group_accordion/group_forecast_accordion_item.tsx
+++ b/front_end/src/components/forecast_maker/continuous_group_accordion/group_forecast_accordion_item.tsx
@@ -14,7 +14,7 @@ import TruncatedTextTooltip from "@/components/truncated_text_tooltip";
 import { useBreakpoint } from "@/hooks/tailwind";
 import { ContinuousForecastInputType } from "@/types/charts";
 import { QuestionStatus } from "@/types/post";
-import { Quantile, Scaling } from "@/types/question";
+import { Quantile, QuestionType, Scaling } from "@/types/question";
 import cn from "@/utils/core/cn";
 import {
   getQuantileNumericForecastDataset,
@@ -210,6 +210,7 @@ const AccordionItem: FC<PropsWithChildren<AccordionItemProps>> = memo(
                         graphType="pmf"
                         height={55}
                         hideLabels
+                        hideYAxis={question.type === QuestionType.Discrete}
                         hideCP={!showCP}
                         question={question}
                         withResolutionChip={false}

--- a/front_end/src/components/post_card/question_tile/question_continuous_tile.tsx
+++ b/front_end/src/components/post_card/question_tile/question_continuous_tile.tsx
@@ -223,6 +223,7 @@ const QuestionContinuousTile: FC<Props> = ({
                 height={HEIGHT}
                 question={question}
                 hideCP={hideCP}
+                hideYAxis={question.type === QuestionType.Discrete}
                 forceTickCount={3}
                 variant={forFeedPage ? "feed" : "question"}
                 centerOOBResolution
@@ -257,6 +258,7 @@ const QuestionContinuousTile: FC<Props> = ({
                 height={HEIGHT}
                 question={question}
                 hideCP={hideCP}
+                hideYAxis={question.type === QuestionType.Discrete}
                 forceTickCount={3}
                 variant={forFeedPage ? "feed" : "question"}
                 centerOOBResolution
@@ -295,6 +297,7 @@ const QuestionContinuousTile: FC<Props> = ({
             height={HEIGHT}
             question={question}
             hideCP={hideCP}
+            hideYAxis={question.type === QuestionType.Discrete}
             forceTickCount={3}
             variant={forFeedPage ? "feed" : "question"}
             centerOOBResolution


### PR DESCRIPTION
Resolves #4900

Removes the Y-axis from discrete question distribution charts in feed cards and collapsed group rows.

Implemented changes:

* Added support for hiding the chart Y-axis while preserving the distribution, median/range markers, and X-axis.
* Applied the hidden Y-axis behavior to discrete questions in feed cards and collapsed group forecast rows.

<img width="945" height="393" alt="image" src="https://github.com/user-attachments/assets/0dcbac6c-5955-468f-93e4-1a1fd661ab40" />

<img width="840" height="232" alt="image" src="https://github.com/user-attachments/assets/8d4e7e07-6adf-43f4-a6fc-6aee6f7e11d7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to hide the chart’s Y-axis on certain views.
  * Discrete questions now automatically display charts with a cleaner layout by hiding the Y-axis where appropriate.
* **Bug Fixes**
  * Updated chart spacing so labels no longer reserve unnecessary room when the Y-axis is hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->