### PR TITLE
fix: labor hub commentary - correct 2035 jobs insight

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -35,8 +35,8 @@ export const JOBS_INSIGHTS = {
     positive: (
       <>
         By 2035, <strong>nurses</strong>, <strong>restaurant servers</strong>,
-        and <strong>law enforcement</strong> are expected to see the highest
-        growth, driven by hands-on needs that cannot be easily automated.
+        and <strong>physicians</strong> are expected to see the highest growth,
+        driven by hands-on needs that cannot be easily automated.
       </>
     ),
     negative: (

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-24">Jun 24</time>
+              Commentary last updated: <time dateTime="2026-06-25">Jun 25</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- **Jobs Monitor 2035 positive insight**: replaced "law enforcement" with "physicians" — data shows Physicians are the 3rd highest growing occupation in 2035 (+7.3%), while Law Enforcement is 5th (+5.9%)
- **Commentary date**: bumped "Commentary last updated" from Jun 24 to Jun 25

## Details

Cross-referencing the live chart data against the hardcoded `JOBS_INSIGHTS` text in `jobs_insights.tsx` revealed one misalignment:

| Year | Insight | Old text | Correct text |
|------|---------|----------|-------------|
| 2035 | Positive (growth) | "…nurses, restaurant servers, and **law enforcement**…" | "…nurses, restaurant servers, and **physicians**…" |

No other commentary misalignments were found across 2027, 2030, or 2035 views.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — automated labor-hub commentary audit

https://claude.ai/code/session_01LZNFnmsiMTejMjiZxjyKvM

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZNFnmsiMTejMjiZxjyKvM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an on-page commentary timestamp to reflect the latest revision date.
* **Content Updates**
  * Refined one insight narrative in the labor hub to reference physicians instead of law enforcement, with minor wording adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->