### PR TITLE
Posts feed: virtualize list view

### DIFF
--- a/front_end/src/components/posts_feed/paginated_feed.tsx
+++ b/front_end/src/components/posts_feed/paginated_feed.tsx
@@ -13,7 +13,7 @@ import CompactSearchPostCard from "@/components/post_card/compact_search_post_ca
 import Button from "@/components/ui/button";
 import { type FeedLayout } from "@/components/ui/layout_switcher";
 import LoadingSpinner from "@/components/ui/loading_spiner";
-import { Masonry, useMediaValues } from "@/components/ui/masonry";
+import { useMediaValues } from "@/components/ui/masonry";
 import VirtualizedMasonry from "@/components/ui/virtualized_masonry";
 import { POST_PAGE_FILTER, POSTS_PER_PAGE } from "@/constants/posts_feed";
 import { useAuth } from "@/contexts/auth_context";
@@ -51,6 +51,8 @@ const GRID_COLUMNS = [1, 2, 3];
 const GRID_GAPS = [12, 12, 12];
 const GRID_MEDIA = [1024, 1280, 1536];
 const GRID_OVERSCAN = 9;
+const LIST_GAP = 12;
+const LIST_OVERSCAN = 12;
 
 function shouldShowProjectTilesForParams(params: URLSearchParams) {
   return Array.from(params.keys()).every((key) => key === POST_PAGE_FILTER);
@@ -60,6 +62,17 @@ function estimateFeedItemSize(item: FeedItem) {
   if (item.type === "project") return 360;
   if (isNotebookPost(item.post)) return 220;
   return 440;
+}
+
+function estimateFeedItemSizeList(item: FeedItem) {
+  if (item.type === "project") return 220;
+  if (isNotebookPost(item.post)) return 180;
+  return 280;
+}
+
+function estimateFeedItemSizeCompact(item: FeedItem) {
+  if (item.type === "project") return 220;
+  return 96;
 }
 
 type Props = {
@@ -399,13 +412,18 @@ const FeedLayoutView: FC<{
   }
 
   return (
-    <Masonry
+    <VirtualizedMasonry
       className={className}
+      columns={1}
+      estimateSize={
+        compactSearchMode
+          ? estimateFeedItemSizeCompact
+          : estimateFeedItemSizeList
+      }
+      gap={LIST_GAP}
+      getItemKey={getFeedItemKey}
       items={items}
-      config={{
-        columns: 1,
-        gap: 12,
-      }}
+      overscan={LIST_OVERSCAN}
       render={renderItem}
     />
   );


### PR DESCRIPTION
### Summary

Extends #4928 virtualization to the list view of the main feed.

Related to #4937

Implemented changes:

* Replaced the non-virtualized 1-column `Masonry` branch in `FeedLayoutView` with `VirtualizedMasonry` (`columns={1}`), reusing the same `@tanstack/react-virtual` window-virtualizer already used by the grid view.
* Added list-mode size estimators (`estimateFeedItemSizeList` for regular/notebook/project cards and `estimateFeedItemSizeCompact` for compact search results); actual heights are corrected on first paint via the virtualizer's `measured` lane-assignment mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the feed’s list view to render more smoothly with virtualization.
  * Added better item sizing for standard list browsing and compact search results.
  * Improved spacing and loading performance in non-grid feed layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->