### PR TITLE
Feed chart lttb downsampling

### DIFF
--- a/front_end/src/components/charts/continuous_area_chart.tsx
+++ b/front_end/src/components/charts/continuous_area_chart.tsx
@@ -52,6 +52,7 @@ import {
   getClosestYValue,
   interpolateYValue,
 } from "@/utils/charts/helpers";
+import { FEED_CHART_TARGET_POINTS, lttb } from "@/utils/charts/lttb";
 import { getResolutionPoint } from "@/utils/charts/resolution";
 import { isForecastActive } from "@/utils/forecasts/helpers";
 import { formatResolution } from "@/utils/formatters/resolution";
@@ -102,6 +103,7 @@ type Props = {
   shortLabels?: boolean;
   alignChartTabs?: boolean;
   forceTickCount?: number; // is used on feed page
+  variant?: "feed" | "question";
   withResolutionChip?: boolean;
   withTodayLine?: boolean;
   globalScaling?: Scaling;
@@ -124,6 +126,7 @@ const ContinuousAreaChart: FC<Props> = ({
   shortLabels = false,
   alignChartTabs,
   forceTickCount,
+  variant = "question",
   withResolutionChip = true,
   withTodayLine = true,
   globalScaling,
@@ -199,8 +202,14 @@ const ContinuousAreaChart: FC<Props> = ({
         }
       }
     }
+    if (variant === "feed" && question.type !== QuestionType.Discrete) {
+      return chartData.map((chart) => ({
+        ...chart,
+        graphLine: lttb(chart.graphLine, FEED_CHART_TARGET_POINTS),
+      }));
+    }
     return chartData;
-  }, [data, graphType, hideCP, question, globalScaling]);
+  }, [data, graphType, hideCP, question, globalScaling, variant]);
 
   const { xDomain, yDomain } = useMemo<{
     xDomain: Tuple<number>;

--- a/front_end/src/components/charts/group_chart.tsx
+++ b/front_end/src/components/charts/group_chart.tsx
@@ -58,6 +58,10 @@ import {
   Y_AXIS_LABEL_ANCHOR_OFFSET,
   Y_AXIS_LABEL_RESERVED_PX,
 } from "@/utils/charts/axis";
+import {
+  downsampleAreaSegments,
+  downsampleLineSegments,
+} from "@/utils/charts/lttb";
 import { getResolutionPoint } from "@/utils/charts/resolution";
 import { scaleInternalLocation, unscaleNominalLocation } from "@/utils/math";
 
@@ -1085,8 +1089,8 @@ function buildChartData({
       const item: ChoiceGraph = {
         choice,
         color,
-        line: line,
-        area: area,
+        line: forFeedPage ? downsampleLineSegments(line) : line,
+        area: forFeedPage ? downsampleAreaSegments(area) : area,
         scatter: scatter,
         active,
         highlighted,

--- a/front_end/src/components/charts/group_chart.tsx
+++ b/front_end/src/components/charts/group_chart.tsx
@@ -58,11 +58,11 @@ import {
   Y_AXIS_LABEL_ANCHOR_OFFSET,
   Y_AXIS_LABEL_RESERVED_PX,
 } from "@/utils/charts/axis";
-import {
-  downsampleAreaSegments,
-  downsampleLineSegments,
-} from "@/utils/charts/lttb";
 import { getResolutionPoint } from "@/utils/charts/resolution";
+import {
+  reduceStepAreaSegments,
+  reduceStepLineSegments,
+} from "@/utils/charts/step_reducer";
 import { scaleInternalLocation, unscaleNominalLocation } from "@/utils/math";
 
 import ForecastAvailabilityChartOverflow from "../post_card/chart_overflow";
@@ -1089,8 +1089,8 @@ function buildChartData({
       const item: ChoiceGraph = {
         choice,
         color,
-        line: forFeedPage ? downsampleLineSegments(line) : line,
-        area: forFeedPage ? downsampleAreaSegments(area) : area,
+        line: forFeedPage ? reduceStepLineSegments(line) : line,
+        area: forFeedPage ? reduceStepAreaSegments(area) : area,
         scatter: scatter,
         active,
         highlighted,

--- a/front_end/src/components/charts/helpers.ts
+++ b/front_end/src/components/charts/helpers.ts
@@ -23,10 +23,9 @@ import {
   getTickLabelFontSize,
 } from "@/utils/charts/axis";
 import {
-  downsampleAreaSegments,
-  downsampleLineSegments,
-} from "@/utils/charts/lttb";
-
+  reduceStepAreaSegments,
+  reduceStepLineSegments,
+} from "@/utils/charts/step_reducer";
 export type ChartData = BaseChartData & {
   line: Line;
   area: Area;
@@ -53,7 +52,7 @@ export function buildNumericChartData({
   inboundOutcomeCount,
   alwaysShowYTicks,
   resolutionPoint,
-  downsample,
+  reduceStepData,
 }: {
   questionType: QuestionType;
   actualCloseTime?: number | null;
@@ -72,7 +71,7 @@ export function buildNumericChartData({
   inboundOutcomeCount?: number | null;
   alwaysShowYTicks?: boolean;
   resolutionPoint?: LinePoint | null;
-  downsample?: boolean;
+  reduceStepData?: boolean;
 }): ChartData {
   const line: Line = [];
   const area: Area = [];
@@ -263,8 +262,8 @@ export function buildNumericChartData({
   });
 
   return {
-    line: downsample ? downsampleLineSegments(line) : line,
-    area: downsample ? downsampleAreaSegments(area) : area,
+    line: reduceStepData ? reduceStepLineSegments(line) : line,
+    area: reduceStepData ? reduceStepAreaSegments(area) : area,
     yDomain: zoomedYDomain,
     xDomain,
     xScale,

--- a/front_end/src/components/charts/helpers.ts
+++ b/front_end/src/components/charts/helpers.ts
@@ -22,6 +22,10 @@ import {
   generateTimeSeriesYDomain,
   getTickLabelFontSize,
 } from "@/utils/charts/axis";
+import {
+  downsampleAreaSegments,
+  downsampleLineSegments,
+} from "@/utils/charts/lttb";
 
 export type ChartData = BaseChartData & {
   line: Line;
@@ -49,6 +53,7 @@ export function buildNumericChartData({
   inboundOutcomeCount,
   alwaysShowYTicks,
   resolutionPoint,
+  downsample,
 }: {
   questionType: QuestionType;
   actualCloseTime?: number | null;
@@ -67,6 +72,7 @@ export function buildNumericChartData({
   inboundOutcomeCount?: number | null;
   alwaysShowYTicks?: boolean;
   resolutionPoint?: LinePoint | null;
+  downsample?: boolean;
 }): ChartData {
   const line: Line = [];
   const area: Area = [];
@@ -257,8 +263,8 @@ export function buildNumericChartData({
   });
 
   return {
-    line,
-    area,
+    line: downsample ? downsampleLineSegments(line) : line,
+    area: downsample ? downsampleAreaSegments(area) : area,
     yDomain: zoomedYDomain,
     xDomain,
     xScale,

--- a/front_end/src/components/charts/minified_continuous_area_chart.tsx
+++ b/front_end/src/components/charts/minified_continuous_area_chart.tsx
@@ -33,7 +33,7 @@ import {
 } from "@/types/question";
 import { generateScale } from "@/utils/charts/axis";
 import { getClosestYValue, interpolateYValue } from "@/utils/charts/helpers";
-import { lttb } from "@/utils/charts/lttb";
+import { FEED_CHART_TARGET_POINTS, lttb } from "@/utils/charts/lttb";
 import { getResolutionPoint } from "@/utils/charts/resolution";
 import { isForecastActive } from "@/utils/forecasts/helpers";
 import { cdfToPmf, computeQuartilesFromCDF } from "@/utils/math";
@@ -57,7 +57,6 @@ export type ContinuousAreaGraphInput = Array<{
 
 const BOTTOM_PADDING = 15;
 const HORIZONTAL_PADDING = 10;
-const FEED_CHART_TARGET_POINTS = 50;
 
 type Props = {
   question: Question | GraphingQuestionProps;
@@ -88,7 +87,7 @@ const MinifiedContinuousAreaChart: FC<Props> = ({
   shortLabels = false,
   alignChartTabs,
   forceTickCount,
-  variant = "feed",
+  variant = "question",
   colorOverride,
   showBaseline = false,
   minMaxLabelsOnly = false,

--- a/front_end/src/components/charts/minified_continuous_area_chart.tsx
+++ b/front_end/src/components/charts/minified_continuous_area_chart.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/types/question";
 import { generateScale } from "@/utils/charts/axis";
 import { getClosestYValue, interpolateYValue } from "@/utils/charts/helpers";
+import { lttb } from "@/utils/charts/lttb";
 import { getResolutionPoint } from "@/utils/charts/resolution";
 import { isForecastActive } from "@/utils/forecasts/helpers";
 import { cdfToPmf, computeQuartilesFromCDF } from "@/utils/math";
@@ -56,6 +57,7 @@ export type ContinuousAreaGraphInput = Array<{
 
 const BOTTOM_PADDING = 15;
 const HORIZONTAL_PADDING = 10;
+const FEED_CHART_TARGET_POINTS = 50;
 
 type Props = {
   question: Question | GraphingQuestionProps;
@@ -139,8 +141,14 @@ const MinifiedContinuousAreaChart: FC<Props> = ({
         }
       }
     }
+    if (variant === "feed" && question.type !== QuestionType.Discrete) {
+      return chartData.map((chart) => ({
+        ...chart,
+        graphLine: lttb(chart.graphLine, FEED_CHART_TARGET_POINTS),
+      }));
+    }
     return chartData;
-  }, [data, hideCP, question]);
+  }, [data, hideCP, question, variant]);
 
   const { xDomain, yDomain } = useMemo<{
     xDomain: Tuple<number>;

--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -58,7 +58,6 @@ import {
   Y_AXIS_LABEL_RESERVED_PX,
 } from "@/utils/charts/axis";
 import { findPreviousTimestamp } from "@/utils/charts/cursor";
-import { downsampleLineSegments } from "@/utils/charts/lttb";
 import { truncateLabel } from "@/utils/formatters/string";
 import { scaleInternalLocation, unscaleNominalLocation } from "@/utils/math";
 
@@ -784,7 +783,7 @@ function buildChartData({
           const item: ChoiceGraph = {
             choice,
             color,
-            line: forFeedPage ? downsampleLineSegments(line) : line,
+            line,
             scatter,
             active,
             highlighted,

--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -58,6 +58,7 @@ import {
   Y_AXIS_LABEL_RESERVED_PX,
 } from "@/utils/charts/axis";
 import { findPreviousTimestamp } from "@/utils/charts/cursor";
+import { downsampleLineSegments } from "@/utils/charts/lttb";
 import { truncateLabel } from "@/utils/formatters/string";
 import { scaleInternalLocation, unscaleNominalLocation } from "@/utils/math";
 
@@ -783,7 +784,7 @@ function buildChartData({
           const item: ChoiceGraph = {
             choice,
             color,
-            line,
+            line: forFeedPage ? downsampleLineSegments(line) : line,
             scatter,
             active,
             highlighted,

--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -58,6 +58,7 @@ import {
   Y_AXIS_LABEL_RESERVED_PX,
 } from "@/utils/charts/axis";
 import { findPreviousTimestamp } from "@/utils/charts/cursor";
+import { getSharedStepKeepMask } from "@/utils/charts/step_reducer";
 import { truncateLabel } from "@/utils/formatters/string";
 import { scaleInternalLocation, unscaleNominalLocation } from "@/utils/math";
 
@@ -634,6 +635,18 @@ function buildChartData({
   const activeItems = choiceItems.filter((c) => c.active);
   const shouldNormalize = activeItems.length > 1;
 
+  // Feed previews: downsample the CP timelines on a single shared index grid so
+  // every stacked option keeps identical x-coordinates. Reducing each option's
+  // line independently would desync the grids and corrupt VictoryStack. Keeping
+  // any index where some active option changes value is lossless for stepAfter.
+  const cpKeepMask =
+    forFeedPage && !hideCP && activeItems.length > 0
+      ? getSharedStepKeepMask(
+          activeItems.map((it) => it.aggregationValues),
+          activeItems[0]?.aggregationValues.length ?? 0
+        )
+      : null;
+
   // for MC questions userTimestamps will be the same array for every choice item
   const userTimestamps = choiceItems[0]?.userTimestamps ?? [];
   const userScatters: ColoredLine = [];
@@ -729,6 +742,11 @@ function buildChartData({
           });
           if (!hideCP) {
             aggregationTimestamps.forEach((timestamp, timestampIndex) => {
+              // Drop indices no active option changes at (feed only). Endpoints
+              // and every value/null transition stay, so stepAfter is unchanged.
+              if (active && cpKeepMask?.[timestampIndex] === false) {
+                return;
+              }
               const aggregationValue = aggregationValues[timestampIndex];
               // build line (CP data)
               const val =

--- a/front_end/src/components/charts/numeric_timeline.tsx
+++ b/front_end/src/components/charts/numeric_timeline.tsx
@@ -177,6 +177,7 @@ const NumericTimeline: FC<Props> = ({
         alwaysShowYTicks: true,
         inboundOutcomeCount,
         resolutionPoint,
+        downsample: forFeedPage,
       }),
     [
       questionType,

--- a/front_end/src/components/charts/numeric_timeline.tsx
+++ b/front_end/src/components/charts/numeric_timeline.tsx
@@ -177,7 +177,7 @@ const NumericTimeline: FC<Props> = ({
         alwaysShowYTicks: true,
         inboundOutcomeCount,
         resolutionPoint,
-        downsample: forFeedPage,
+        reduceStepData: forFeedPage,
       }),
     [
       questionType,

--- a/front_end/src/components/post_card/question_tile/question_continuous_tile.tsx
+++ b/front_end/src/components/post_card/question_tile/question_continuous_tile.tsx
@@ -224,6 +224,7 @@ const QuestionContinuousTile: FC<Props> = ({
                 question={question}
                 hideCP={hideCP}
                 forceTickCount={3}
+                variant={forFeedPage ? "feed" : "question"}
                 centerOOBResolution
               />
               <ForecastAvailabilityChartOverflow
@@ -257,6 +258,7 @@ const QuestionContinuousTile: FC<Props> = ({
                 question={question}
                 hideCP={hideCP}
                 forceTickCount={3}
+                variant={forFeedPage ? "feed" : "question"}
                 centerOOBResolution
               />
               <ForecastAvailabilityChartOverflow
@@ -294,6 +296,7 @@ const QuestionContinuousTile: FC<Props> = ({
             question={question}
             hideCP={hideCP}
             forceTickCount={3}
+            variant={forFeedPage ? "feed" : "question"}
             centerOOBResolution
           />
           <ForecastAvailabilityChartOverflow

--- a/front_end/src/utils/charts/__tests__/lttb.test.ts
+++ b/front_end/src/utils/charts/__tests__/lttb.test.ts
@@ -1,6 +1,6 @@
 import { Line } from "@/types/charts";
 
-import { lttb } from "../lttb";
+import { downsampleLineSegments, lttb } from "../lttb";
 
 function makePoints(n: number, fn: (i: number) => number): Line {
   return Array.from({ length: n }, (_, i) => ({ x: i, y: fn(i) }));
@@ -46,5 +46,26 @@ describe("lttb", () => {
     const result = lttb(points, 4);
     expect(result).toHaveLength(4);
     expect(result.every((p) => p.y !== null)).toBe(true);
+  });
+});
+describe("downsampleLineSegments", () => {
+  it("preserves null separators between timeline segments", () => {
+    const points: Line = [
+      ...makePoints(20, (i) => i),
+      { x: 20, y: null },
+      ...makePoints(20, (i) => 100 - i).map((point) => ({
+        ...point,
+        x: Number(point.x) + 21,
+      })),
+    ];
+
+    const result = downsampleLineSegments(points, 5);
+
+    expect(result.filter((point) => point.y === null)).toHaveLength(1);
+    expect(result.some((point) => point.x === 20 && point.y === null)).toBe(
+      true
+    );
+    expect(result[0]).toEqual(points[0]);
+    expect(result[result.length - 1]).toEqual(points[points.length - 1]);
   });
 });

--- a/front_end/src/utils/charts/__tests__/lttb.test.ts
+++ b/front_end/src/utils/charts/__tests__/lttb.test.ts
@@ -1,0 +1,50 @@
+import { Line } from "@/types/charts";
+
+import { lttb } from "../lttb";
+
+function makePoints(n: number, fn: (i: number) => number): Line {
+  return Array.from({ length: n }, (_, i) => ({ x: i, y: fn(i) }));
+}
+
+describe("lttb", () => {
+  it("returns input unchanged when target is >= input length", () => {
+    const points = makePoints(5, (i) => i);
+    expect(lttb(points, 5)).toBe(points);
+    expect(lttb(points, 10)).toBe(points);
+  });
+
+  it("returns input unchanged when target is < 3", () => {
+    const points = makePoints(10, (i) => i);
+    expect(lttb(points, 2)).toBe(points);
+  });
+
+  it("downsamples to the requested count and preserves endpoints", () => {
+    const points = makePoints(200, (i) => Math.sin(i / 10));
+    const result = lttb(points, 50);
+    expect(result).toHaveLength(50);
+    expect(result[0]).toEqual(points[0]);
+    expect(result[result.length - 1]).toEqual(points[points.length - 1]);
+  });
+
+  it("keeps the visually important peak of a spike", () => {
+    const points = makePoints(100, (i) => (i === 50 ? 1000 : 0));
+    const result = lttb(points, 10);
+    expect(result.some((p) => p.y === 1000)).toBe(true);
+  });
+
+  it("skips points with non-numeric y", () => {
+    const points: Line = [
+      { x: 0, y: 0 },
+      { x: 1, y: null },
+      { x: 2, y: 5 },
+      { x: 3, y: null },
+      { x: 4, y: 2 },
+      { x: 5, y: 8 },
+      { x: 6, y: 3 },
+      { x: 7, y: 1 },
+    ];
+    const result = lttb(points, 4);
+    expect(result).toHaveLength(4);
+    expect(result.every((p) => p.y !== null)).toBe(true);
+  });
+});

--- a/front_end/src/utils/charts/__tests__/lttb.test.ts
+++ b/front_end/src/utils/charts/__tests__/lttb.test.ts
@@ -1,6 +1,6 @@
 import { Line } from "@/types/charts";
 
-import { downsampleLineSegments, lttb } from "../lttb";
+import { lttb } from "../lttb";
 
 function makePoints(n: number, fn: (i: number) => number): Line {
   return Array.from({ length: n }, (_, i) => ({ x: i, y: fn(i) }));
@@ -46,26 +46,5 @@ describe("lttb", () => {
     const result = lttb(points, 4);
     expect(result).toHaveLength(4);
     expect(result.every((p) => p.y !== null)).toBe(true);
-  });
-});
-describe("downsampleLineSegments", () => {
-  it("preserves null separators between timeline segments", () => {
-    const points: Line = [
-      ...makePoints(20, (i) => i),
-      { x: 20, y: null },
-      ...makePoints(20, (i) => 100 - i).map((point) => ({
-        ...point,
-        x: Number(point.x) + 21,
-      })),
-    ];
-
-    const result = downsampleLineSegments(points, 5);
-
-    expect(result.filter((point) => point.y === null)).toHaveLength(1);
-    expect(result.some((point) => point.x === 20 && point.y === null)).toBe(
-      true
-    );
-    expect(result[0]).toEqual(points[0]);
-    expect(result[result.length - 1]).toEqual(points[points.length - 1]);
   });
 });

--- a/front_end/src/utils/charts/__tests__/lttb.test.ts
+++ b/front_end/src/utils/charts/__tests__/lttb.test.ts
@@ -47,4 +47,19 @@ describe("lttb", () => {
     expect(result).toHaveLength(4);
     expect(result.every((p) => p.y !== null)).toBe(true);
   });
+
+  it("does not coerce a null y into a real y=0 sample", () => {
+    // A null sits among uniformly high values. If null were coerced to 0,
+    // LTTB would treat it as a large downward spike and select it.
+    const points: Line = [
+      { x: 0, y: 10 },
+      { x: 1, y: 10 },
+      { x: 2, y: null },
+      { x: 3, y: 10 },
+      { x: 4, y: 10 },
+      { x: 5, y: 10 },
+    ];
+    const result = lttb(points, 4);
+    expect(result.some((p) => p.y === null)).toBe(false);
+  });
 });

--- a/front_end/src/utils/charts/__tests__/step_reducer.test.ts
+++ b/front_end/src/utils/charts/__tests__/step_reducer.test.ts
@@ -1,0 +1,62 @@
+import { Area, Line } from "@/types/charts";
+
+import {
+  reduceStepAreaSegments,
+  reduceStepLineSegments,
+} from "../step_reducer";
+
+describe("reduceStepLineSegments", () => {
+  it("removes redundant plateau points while preserving transition timestamps", () => {
+    const points: Line = [
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+      { x: 2, y: 1 },
+      { x: 3, y: 2 },
+      { x: 4, y: 2 },
+      { x: 5, y: 2 },
+    ];
+
+    expect(reduceStepLineSegments(points)).toEqual([
+      { x: 0, y: 1 },
+      { x: 3, y: 2 },
+      { x: 5, y: 2 },
+    ]);
+  });
+
+  it("preserves null separators and segment boundaries", () => {
+    const points: Line = [
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+      { x: 2, y: null },
+      { x: 3, y: 2 },
+      { x: 4, y: 2 },
+    ];
+
+    expect(reduceStepLineSegments(points)).toEqual([
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+      { x: 2, y: null },
+      { x: 3, y: 2 },
+      { x: 4, y: 2 },
+    ]);
+  });
+});
+
+describe("reduceStepAreaSegments", () => {
+  it("keeps interval changes when either y or y0 changes", () => {
+    const points: Area = [
+      { x: 0, y: 4, y0: 1 },
+      { x: 1, y: 4, y0: 1 },
+      { x: 2, y: 5, y0: 1 },
+      { x: 3, y: 5, y0: 2 },
+      { x: 4, y: 5, y0: 2 },
+    ];
+
+    expect(reduceStepAreaSegments(points)).toEqual([
+      { x: 0, y: 4, y0: 1 },
+      { x: 2, y: 5, y0: 1 },
+      { x: 3, y: 5, y0: 2 },
+      { x: 4, y: 5, y0: 2 },
+    ]);
+  });
+});

--- a/front_end/src/utils/charts/__tests__/step_reducer.test.ts
+++ b/front_end/src/utils/charts/__tests__/step_reducer.test.ts
@@ -1,6 +1,7 @@
 import { Area, Line } from "@/types/charts";
 
 import {
+  getSharedStepKeepMask,
   reduceStepAreaSegments,
   reduceStepLineSegments,
 } from "../step_reducer";
@@ -58,5 +59,41 @@ describe("reduceStepAreaSegments", () => {
       { x: 3, y: 5, y0: 2 },
       { x: 4, y: 5, y0: 2 },
     ]);
+  });
+});
+
+describe("getSharedStepKeepMask", () => {
+  it("keeps endpoints and any index where a series changes value", () => {
+    // series A is flat; series B changes at index 3 only.
+    const a = [5, 5, 5, 5, 5, 5];
+    const b = [1, 1, 1, 9, 9, 9];
+
+    expect(getSharedStepKeepMask([a, b], 6)).toEqual([
+      true, // endpoint
+      false,
+      false,
+      true, // B changes here
+      false,
+      true, // endpoint
+    ]);
+  });
+
+  it("treats null<->real transitions as changes and keeps them aligned", () => {
+    const a = [1, 1, null, 1, 1];
+    const b = [2, 2, 2, 2, 2];
+
+    expect(getSharedStepKeepMask([a, b], 5)).toEqual([
+      true, // endpoint
+      false,
+      true, // A goes null
+      true, // A comes back
+      true, // endpoint
+    ]);
+  });
+
+  it("returns all-kept for short grids and empty for zero length", () => {
+    expect(getSharedStepKeepMask([[1]], 1)).toEqual([true]);
+    expect(getSharedStepKeepMask([[1, 2]], 2)).toEqual([true, true]);
+    expect(getSharedStepKeepMask([], 0)).toEqual([]);
   });
 });

--- a/front_end/src/utils/charts/lttb.ts
+++ b/front_end/src/utils/charts/lttb.ts
@@ -20,6 +20,9 @@ export function lttb<X = number, Y = number | null>(
   const numericPoints: NumericPoint[] = [];
   for (let i = 0; i < points.length; i++) {
     const point = points[i] as LinePoint<X, Y>;
+    // Skip nulls explicitly: Number(null) === 0 is finite, so coercing first
+    // would turn gap markers into real y=0 samples.
+    if (point.x == null || point.y == null) continue;
     const x = Number(point.x);
     const y = Number(point.y);
     if (Number.isFinite(x) && Number.isFinite(y)) {

--- a/front_end/src/utils/charts/lttb.ts
+++ b/front_end/src/utils/charts/lttb.ts
@@ -1,0 +1,92 @@
+import { Line, LinePoint } from "@/types/charts";
+
+type NumericPoint = { index: number; x: number; y: number };
+
+// Largest-Triangle-Three-Buckets downsampling.
+// Reference: Sveinn Steinarsson, "Downsampling Time Series for Visual Representation" (2013).
+// Preserves the first and last points; for each interior bucket, picks the point
+// that forms the largest triangle with the previously selected point and the
+// average point of the next bucket. Points with non-numeric y are skipped.
+export function lttb<X = number, Y = number | null>(
+  points: Line<X, Y>,
+  targetCount: number
+): Line<X, Y> {
+  if (targetCount < 3 || targetCount >= points.length) {
+    return points;
+  }
+
+  const numericPoints: NumericPoint[] = [];
+  for (let i = 0; i < points.length; i++) {
+    const point = points[i] as LinePoint<X, Y>;
+    const x = Number(point.x);
+    const y = Number(point.y);
+    if (Number.isFinite(x) && Number.isFinite(y)) {
+      numericPoints.push({ index: i, x, y });
+    }
+  }
+
+  const n = numericPoints.length;
+  const first = numericPoints[0];
+  const last = numericPoints[n - 1];
+  if (n <= targetCount || !first || !last) {
+    return points;
+  }
+
+  const bucketSize = (n - 2) / (targetCount - 2);
+  const sampledIndices: number[] = [first.index];
+
+  let previous = first;
+  for (let bucket = 0; bucket < targetCount - 2; bucket++) {
+    const currentStart = Math.floor(bucket * bucketSize) + 1;
+    const currentEnd = Math.min(
+      Math.floor((bucket + 1) * bucketSize) + 1,
+      n - 1
+    );
+
+    let avgX = 0;
+    let avgY = 0;
+    if (bucket === targetCount - 3) {
+      avgX = last.x;
+      avgY = last.y;
+    } else {
+      const nextEnd = Math.min(
+        Math.floor((bucket + 2) * bucketSize) + 1,
+        n - 1
+      );
+      let count = 0;
+      for (let j = currentEnd; j < nextEnd; j++) {
+        const np = numericPoints[j];
+        if (!np) continue;
+        avgX += np.x;
+        avgY += np.y;
+        count += 1;
+      }
+      if (count > 0) {
+        avgX /= count;
+        avgY /= count;
+      }
+    }
+
+    let maxArea = -1;
+    let chosen: NumericPoint = previous;
+    for (let j = currentStart; j < currentEnd; j++) {
+      const candidate = numericPoints[j];
+      if (!candidate) continue;
+      const area =
+        Math.abs(
+          (previous.x - avgX) * (candidate.y - previous.y) -
+            (previous.x - candidate.x) * (avgY - previous.y)
+        ) * 0.5;
+      if (area > maxArea) {
+        maxArea = area;
+        chosen = candidate;
+      }
+    }
+    sampledIndices.push(chosen.index);
+    previous = chosen;
+  }
+
+  sampledIndices.push(last.index);
+
+  return sampledIndices.map((index) => points[index] as LinePoint<X, Y>);
+}

--- a/front_end/src/utils/charts/lttb.ts
+++ b/front_end/src/utils/charts/lttb.ts
@@ -1,6 +1,59 @@
-import { Line, LinePoint } from "@/types/charts";
+import { Area, Line, LinePoint } from "@/types/charts";
 
 type NumericPoint = { index: number; x: number; y: number };
+
+export const FEED_CHART_TARGET_POINTS = 50;
+type PointLike = { x: unknown; y: unknown };
+
+export function downsampleLineSegments<X = number, Y = number | null>(
+  points: Line<X, Y>,
+  targetCount = FEED_CHART_TARGET_POINTS
+): Line<X, Y> {
+  return downsampleSegments(points, targetCount) as Line<X, Y>;
+}
+
+export function downsampleAreaSegments<X = number, Y = number | null>(
+  points: Area<X, Y>,
+  targetCount = FEED_CHART_TARGET_POINTS
+): Area<X, Y> {
+  return downsampleSegments(points, targetCount) as Area<X, Y>;
+}
+
+function downsampleSegments<P extends PointLike>(
+  points: P[],
+  targetCount: number
+): P[] {
+  if (targetCount < 3 || targetCount >= points.length) {
+    return points;
+  }
+
+  const sampled: P[] = [];
+  let segment: P[] = [];
+
+  const flushSegment = () => {
+    if (!segment.length) return;
+    sampled.push(...(lttb(segment as Line, targetCount) as P[]));
+    segment = [];
+  };
+
+  for (const point of points) {
+    if (
+      point.x != null &&
+      point.y != null &&
+      Number.isFinite(Number(point.x)) &&
+      Number.isFinite(Number(point.y))
+    ) {
+      segment.push(point);
+      continue;
+    }
+
+    flushSegment();
+    sampled.push(point);
+  }
+
+  flushSegment();
+  return sampled;
+}
 
 // Largest-Triangle-Three-Buckets downsampling.
 // Reference: Sveinn Steinarsson, "Downsampling Time Series for Visual Representation" (2013).

--- a/front_end/src/utils/charts/lttb.ts
+++ b/front_end/src/utils/charts/lttb.ts
@@ -1,59 +1,8 @@
-import { Area, Line, LinePoint } from "@/types/charts";
+import { Line, LinePoint } from "@/types/charts";
 
 type NumericPoint = { index: number; x: number; y: number };
 
 export const FEED_CHART_TARGET_POINTS = 50;
-type PointLike = { x: unknown; y: unknown };
-
-export function downsampleLineSegments<X = number, Y = number | null>(
-  points: Line<X, Y>,
-  targetCount = FEED_CHART_TARGET_POINTS
-): Line<X, Y> {
-  return downsampleSegments(points, targetCount) as Line<X, Y>;
-}
-
-export function downsampleAreaSegments<X = number, Y = number | null>(
-  points: Area<X, Y>,
-  targetCount = FEED_CHART_TARGET_POINTS
-): Area<X, Y> {
-  return downsampleSegments(points, targetCount) as Area<X, Y>;
-}
-
-function downsampleSegments<P extends PointLike>(
-  points: P[],
-  targetCount: number
-): P[] {
-  if (targetCount < 3 || targetCount >= points.length) {
-    return points;
-  }
-
-  const sampled: P[] = [];
-  let segment: P[] = [];
-
-  const flushSegment = () => {
-    if (!segment.length) return;
-    sampled.push(...(lttb(segment as Line, targetCount) as P[]));
-    segment = [];
-  };
-
-  for (const point of points) {
-    if (
-      point.x != null &&
-      point.y != null &&
-      Number.isFinite(Number(point.x)) &&
-      Number.isFinite(Number(point.y))
-    ) {
-      segment.push(point);
-      continue;
-    }
-
-    flushSegment();
-    sampled.push(point);
-  }
-
-  flushSegment();
-  return sampled;
-}
 
 // Largest-Triangle-Three-Buckets downsampling.
 // Reference: Sveinn Steinarsson, "Downsampling Time Series for Visual Representation" (2013).

--- a/front_end/src/utils/charts/step_reducer.ts
+++ b/front_end/src/utils/charts/step_reducer.ts
@@ -1,0 +1,92 @@
+import { Area, AreaPoint, Line, LinePoint } from "@/types/charts";
+
+type StepPoint = {
+  x: unknown;
+  y: unknown;
+  y0?: unknown;
+};
+
+export function reduceStepLineSegments<X = number, Y = number | null>(
+  points: Line<X, Y>
+): Line<X, Y> {
+  return reduceStepSegments(points, haveSameLineValue) as Line<X, Y>;
+}
+
+export function reduceStepAreaSegments<X = number, Y = number | null>(
+  points: Area<X, Y>
+): Area<X, Y> {
+  return reduceStepSegments(points, haveSameAreaValue) as Area<X, Y>;
+}
+
+function reduceStepSegments<P extends StepPoint>(
+  points: P[],
+  haveSameValue: (a: P, b: P) => boolean
+): P[] {
+  if (points.length < 3) {
+    return points;
+  }
+
+  const reduced: P[] = [];
+  let segment: P[] = [];
+
+  const flushSegment = () => {
+    if (!segment.length) return;
+    reduced.push(...reduceSegment(segment, haveSameValue));
+    segment = [];
+  };
+
+  for (const point of points) {
+    if (point.y == null) {
+      flushSegment();
+      reduced.push(point);
+      continue;
+    }
+
+    segment.push(point);
+  }
+
+  flushSegment();
+  return reduced.length < points.length ? reduced : points;
+}
+
+function reduceSegment<P extends StepPoint>(
+  segment: P[],
+  haveSameValue: (a: P, b: P) => boolean
+): P[] {
+  if (segment.length < 3) {
+    return segment;
+  }
+
+  const reduced: P[] = [];
+  for (let index = 0; index < segment.length; index++) {
+    const point = segment[index];
+    if (!point) continue;
+
+    const previous = segment[index - 1];
+    const next = segment[index + 1];
+    if (!previous || !next) {
+      reduced.push(point);
+      continue;
+    }
+
+    if (!haveSameValue(previous, point) || next.y == null) {
+      reduced.push(point);
+    }
+  }
+
+  return reduced;
+}
+
+function haveSameLineValue<X, Y>(
+  a: LinePoint<X, Y>,
+  b: LinePoint<X, Y>
+): boolean {
+  return Object.is(a.y, b.y);
+}
+
+function haveSameAreaValue<X, Y>(
+  a: AreaPoint<X, Y>,
+  b: AreaPoint<X, Y>
+): boolean {
+  return Object.is(a.y, b.y) && Object.is(a.y0, b.y0);
+}

--- a/front_end/src/utils/charts/step_reducer.ts
+++ b/front_end/src/utils/charts/step_reducer.ts
@@ -77,6 +77,36 @@ function reduceSegment<P extends StepPoint>(
   return reduced;
 }
 
+// Shared boundary-preserving keep-mask for stacked step series.
+// Returns a boolean[] over the shared timestamp grid: an index is kept if it is
+// an endpoint, or if ANY series changes value at that index vs the previous one.
+// Applying the same mask to every stacked series keeps them index/x-aligned
+// (so VictoryStack's per-x stacking stays correct) while remaining lossless for
+// stepAfter rendering - between kept indices every series holds a constant value.
+export function getSharedStepKeepMask(
+  series: ReadonlyArray<ReadonlyArray<number | null>>,
+  length: number
+): boolean[] {
+  const keep = new Array<boolean>(length).fill(false);
+  if (length === 0) {
+    return keep;
+  }
+
+  keep[0] = true;
+  keep[length - 1] = true;
+
+  for (let i = 1; i < length - 1; i++) {
+    for (const values of series) {
+      if (!Object.is(values[i] ?? null, values[i - 1] ?? null)) {
+        keep[i] = true;
+        break;
+      }
+    }
+  }
+
+  return keep;
+}
+
 function haveSameLineValue<X, Y>(
   a: LinePoint<X, Y>,
   b: LinePoint<X, Y>


### PR DESCRIPTION
### Summary

Related to #4937

Adds feed-only chart data reduction to reduce the amount of chart data rendered in feed previews while keeping full-resolution charts on question pages.

Implemented changes:

Added a local LTTB utility with tests for endpoint preservation, spike preservation, target sizing, and non-numeric/null handling. 

Applied LTTB only to feed continuous distribution curves: 

* MinifiedContinuousAreaChart 
* ContinuousAreaChart  

Added a boundary-preserving step reducer for feed timeline charts where LTTB could shift transition timestamps: 

* NumericTimeline 
* GroupChart 


Skipped discrete distributions, FanChart, bar-style TimeSeriesChart, and MultipleChoiceChart because their data shape or rendering model does not fit LTTB safely.

Performance notes:

* With Chrome CPU throttling set to `6x slowdown`, initial render improved from \~13s before to \~9s after in local testing.
* This should also provide a small rendering boost while scrolling through the virtualized feed, since eligible newly mounted feed charts have fewer points for Victory to process and render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Continuous area charts now support a display mode to optimize feed vs. question rendering.
  * Feed charts downsample dense trend lines and apply step-segment reduction to keep visuals readable.
  * Multiple-choice feed timelines preserve step alignment during downsampling.

* **Bug Fixes**
  * Improved downsampling and step reduction for series containing missing values while retaining important endpoints/peaks.
  * Chart data now updates correctly when the rendering mode changes.

* **Tests**
  * Expanded coverage for downsampling and step-reduction behaviors, including edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->