### PR TITLE
fix: labor hub commentary - financial specialists forecast direction

### DIFF
--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-25">Jun 25</time>
+              Commentary last updated: <time dateTime="2026-06-26">Jun 26</time>
             </div>
           </div>
         </div>

--- a/front_end/src/app/(main)/labor-hub/sections/research.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/research.tsx
@@ -73,10 +73,10 @@ export function ResearchSection({
             high exposure and vulnerability of lawyers, sales representatives,
             and software developers will translate to significant employment
             reductions in these fields over the next decade, while financial
-            specialists are expected to see only modest growth. These forecasts
-            provide important context to our understanding of workforce
-            prospects by quantifying the predicted impact of AI on employment
-            levels.
+            specialists are expected to see only modest declines. These
+            forecasts provide important context to our understanding of
+            workforce prospects by quantifying the predicted impact of AI on
+            employment levels.
           </ContentParagraph>
         </div>
 


### PR DESCRIPTION
## Summary

Automated commentary audit of the Labor Hub page found one misalignment between chart forecast data and surrounding text.

**Research section** (`sections/research.tsx`):
- **Before:** "while financial specialists are expected to see only modest **growth**"
- **After:** "while financial specialists are expected to see only modest **declines**"

The Financial Specialists forecast shows declines of -0.4% by 2030 and -1.7% by 2035 — both negative values — making "growth" a direct contradiction of the forecast data.

Also bumped the "Commentary last updated" date in `hero.tsx` from Jun 25 to Jun 26.

## Test plan

- [ ] Verify the Research section paragraph reads correctly on the Labor Hub page
- [ ] Confirm "Commentary last updated" shows Jun 26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZF4MPh1B1z5gjy5Sc57x2

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZF4MPh1B1z5gjy5Sc57x2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed the “Commentary last updated” date in the labor hub’s live forecasts area.
  * Adjusted the labor research summary text to reflect a slightly weaker outlook for specialists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->