### PR TITLE
fix: labor hub commentary — correct 2035 jobs monitor claim about laborers

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -44,8 +44,9 @@ export const JOBS_INSIGHTS = {
         By 2035, <strong>software</strong>, <strong>sales</strong> and{" "}
         <strong>law</strong> are expected to see sharp staff reductions as AI
         systems take over large portions of coding, outreach, and detailed
-        research work, while <strong>laborers</strong> see modest gains as
-        robotics have yet to fully displace physical roles by this horizon.
+        research work, while <strong>construction workers</strong> see modest
+        gains as robotics have yet to fully displace physical roles by this
+        horizon.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-26">Jun 26</time>
+              Commentary last updated: <time dateTime="2026-06-28">Jun 28</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated commentary audit against the 2035 forecast chart data identified one misalignment in the Jobs Monitor section.

## Fix

**Section:** Jobs Monitor — 2035 commentary (negative insight)

**Old text:**
> By 2035, software, sales and law are expected to see sharp staff reductions as AI systems take over large portions of coding, outreach, and detailed research work, while **laborers** see modest gains as robotics have yet to fully displace physical roles by this horizon.

**Chart data contradicting it:**
- Laborers and Movers 2035 forecast: **−1.7%** (a decline, not gains)
- Construction Workers 2035 forecast: **+1.2%** (modest gains)

**New text:**
> By 2035, software, sales and law are expected to see sharp staff reductions as AI systems take over large portions of coding, outreach, and detailed research work, while **construction workers** see modest gains as robotics have yet to fully displace physical roles by this horizon.

Also bumps the "Commentary last updated" date from Jun 26 → Jun 28.

## Files changed

- `front_end/src/app/(main)/labor-hub/jobs_insights.tsx` — fixed "laborers" → "construction workers" in 2035 negative insight
- `front_end/src/app/(main)/labor-hub/sections/hero.tsx` — updated commentary date to Jun 28


---
_Generated by [Claude Code](https://claude.ai/code/session_01WY2AQf83WSzMdXAyzsEhiS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Refined the 2035 labor market outlook text to use clearer role-specific wording.
  * Updated the “Commentary last updated” date shown in the Labor Hub hero section to Jun 28.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->