### PR TITLE
fix: labor hub commentary — correct 2035 Jobs Monitor claim about laborers

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -44,8 +44,9 @@ export const JOBS_INSIGHTS = {
         By 2035, <strong>software</strong>, <strong>sales</strong> and{" "}
         <strong>law</strong> are expected to see sharp staff reductions as AI
         systems take over large portions of coding, outreach, and detailed
-        research work, while <strong>laborers</strong> see modest gains as
-        robotics have yet to fully displace physical roles by this horizon.
+        research work, while <strong>construction workers</strong> see modest
+        gains as robotics have yet to fully displace physical roles by this
+        horizon.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-26">Jun 26</time>
+              Commentary last updated: <time dateTime="2026-06-29">Jun 29</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- **Section:** Jobs Monitor — 2035 negative insight card
- **Issue:** The insight said "laborers see modest gains as robotics have yet to fully displace physical roles by this horizon." Forecast data shows Laborers and Movers at **−1.7%** by 2035 (a decline), while Construction Workers are at **+1.2%** (modest gains).
- **Fix:** Replaced `<strong>laborers</strong>` with `<strong>construction workers</strong>` in `jobs_insights.tsx`
- **Also:** Updated "Commentary last updated" date in `hero.tsx` from Jun 26 → Jun 29

## Files changed

- `front_end/src/app/(main)/labor-hub/jobs_insights.tsx` — 2035 negative insight text corrected
- `front_end/src/app/(main)/labor-hub/sections/hero.tsx` — commentary date bumped

## Test plan

- [ ] Visit `/labor-hub`, click the **2035** button in the Jobs Monitor section
- [ ] Verify the negative insight card now reads "construction workers" instead of "laborers"
- [ ] Confirm "Commentary last updated: Jun 29" appears in the hero section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCSo2MJetJS8cRarnMphZW

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCSo2MJetJS8cRarnMphZW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated wording in the labor insights content to use “construction workers” and emphasized the phrase for readability.
  * Refreshed the “Commentary last updated” date in the Forecasts: Live callout to Jun 29.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->