### PR TITLE
Show full subquestion title on hover in consumer group cards

### DIFF
--- a/front_end/src/components/consumer_post_card/group_forecast_card/forecast_choice_bar.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/forecast_choice_bar.tsx
@@ -4,6 +4,7 @@ import { isNil } from "lodash";
 import { useTranslations } from "next-intl";
 import { FC } from "react";
 
+import TruncatedTextTooltip from "@/components/truncated_text_tooltip";
 import { METAC_COLORS } from "@/constants/colors";
 import useAppTheme from "@/hooks/use_app_theme";
 import useMounted from "@/hooks/use_mounted";
@@ -80,7 +81,13 @@ const ForecastChoiceBar: FC<Props> = ({
         }
       )}
     >
-      <span className="z-10 line-clamp-1 max-w-[85%]">{choiceLabel}</span>
+      <div className="z-10 flex max-w-[85%] overflow-hidden">
+        <TruncatedTextTooltip
+          text={choiceLabel}
+          className="line-clamp-1"
+          variant="light"
+        />
+      </div>
       <span
         className={cn("z-10 text-nowrap", {
           "text-xs font-normal text-gray-700 opacity-50 dark:text-gray-700-dark":


### PR DESCRIPTION
Closes #4927 

## Context
In the Consumer View of a question group, each subquestion renders as a row (`ForecastChoiceBar`) with the title on the left and the CP/value (e.g. "Hidden") on the right. Long titles were truncated with `line-clamp-1` with no way for a consumer to read the full title.

## Change
Wrap the title in the existing `TruncatedTextTooltip`, which detects overflow and shows the tooltip **only when the title is actually truncated** (no hover state when it already fits), and handles tap-to-reveal on touch, focus, ARIA, and dark mode. Follows the precedent in the sibling continuous-group accordion (`group_forecast_accordion_item.tsx`). The fix lives in the shared `ForecastChoiceBar`, so it covers the percentage, numeric, and date consumer group cards. No new user-facing strings.

## Verification
- Hover a truncated title → full title in tooltip; title that fits → no tooltip
- Tap on touch → tooltip reveals
- Colored progress fill and right-aligned CP value still render correctly; title not overlapping the value
- Title still clamps to one line with ellipsis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved how forecast choice labels are displayed, adding a cleaner truncated view with hover tooltips for easier reading of longer text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->