### PR TITLE
Defer feed chart rendering

### DIFF
--- a/front_end/src/components/consumer_post_card/consumer_question_tile/index.tsx
+++ b/front_end/src/components/consumer_post_card/consumer_question_tile/index.tsx
@@ -2,6 +2,7 @@ import { FC } from "react";
 
 import { getContinuousAreaChartData } from "@/components/charts/continuous_area_chart";
 import MinifiedContinuousAreaChart from "@/components/charts/minified_continuous_area_chart";
+import useDeferredRender from "@/hooks/use_deferred_render";
 import { QuestionStatus } from "@/types/post";
 import { QuestionType, QuestionWithForecasts } from "@/types/question";
 import { getQuestionForecastAvailability } from "@/utils/questions/forecastAvailability";
@@ -10,10 +11,16 @@ import ConsumerBinaryTile from "./consumer_binary_tile";
 import ConsumerContinuousTile from "./consumer_continuous_tile";
 type Props = {
   question: QuestionWithForecasts;
+  forFeedPage?: boolean;
 };
 
-const ConsumerQuestionTile: FC<Props> = ({ question }) => {
+const FEED_CHART_HEIGHT = 50;
+
+const ConsumerQuestionTile: FC<Props> = ({ question, forFeedPage = false }) => {
   const forecastAvailability = getQuestionForecastAvailability(question);
+  // Defer the chart mount until idle on the feed; render immediately elsewhere
+  // (question-page sidebar, homepage, comment previews).
+  const shouldRenderFeedChart = useDeferredRender(forFeedPage, question.id);
 
   // Hide chart if no forecasts or CP not yet revealed
   const shouldHideChart =
@@ -41,15 +48,18 @@ const ConsumerQuestionTile: FC<Props> = ({ question }) => {
             question={question}
             forecastAvailability={forecastAvailability}
           />
-          {!shouldHideChart && (
-            <MinifiedContinuousAreaChart
-              question={question}
-              data={continuousAreaChartData}
-              height={50}
-              forceTickCount={2}
-              variant="feed"
-            />
-          )}
+          {!shouldHideChart &&
+            (shouldRenderFeedChart ? (
+              <MinifiedContinuousAreaChart
+                question={question}
+                data={continuousAreaChartData}
+                height={FEED_CHART_HEIGHT}
+                forceTickCount={2}
+                variant="feed"
+              />
+            ) : (
+              <div style={{ height: FEED_CHART_HEIGHT }} />
+            ))}
         </div>
       );
     default:

--- a/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/index.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/index.tsx
@@ -19,6 +19,7 @@ import { METAC_COLORS } from "@/constants/colors";
 import { useHideCP } from "@/contexts/cp_context";
 import useAppTheme from "@/hooks/use_app_theme";
 import useContainerSize from "@/hooks/use_container_size";
+import useDeferredRender from "@/hooks/use_deferred_render";
 import { ChoiceItem } from "@/types/choices";
 import { PostGroupOfQuestions, PostWithForecasts } from "@/types/post";
 import {
@@ -48,6 +49,7 @@ type Props = {
   innerChartPaddingX?: number;
   yearOnlyTicks?: boolean;
   withHeader?: boolean;
+  forFeedPage?: boolean;
 };
 
 const TICK_LABEL_INDEXES = [0, 4, 8];
@@ -62,11 +64,13 @@ const DateForecastCard: FC<Props> = ({
   innerChartPaddingX = 0,
   yearOnlyTicks = false,
   withHeader = false,
+  forFeedPage = false,
 }) => {
   const { questions } = questionsGroup;
   const locale = useLocale();
   const t = useTranslations();
   const { hideCP } = useHideCP();
+  const shouldRenderFeedChart = useDeferredRender(forFeedPage, post.id);
   const { theme, getThemeColor } = useAppTheme();
   const chartTheme = theme === "dark" ? darkTheme : lightTheme;
   const {
@@ -114,8 +118,9 @@ const DateForecastCard: FC<Props> = ({
           "DateForecastCard relative w-full",
           fillHeight && "min-h-0 flex-1"
         )}
+        style={forFeedPage ? { minHeight: chartHeight } : undefined}
       >
-        {shouldDisplayChart && (
+        {shouldDisplayChart && !(forFeedPage && !shouldRenderFeedChart) && (
           <VictoryChart
             width={chartWidth}
             height={chartHeight}

--- a/front_end/src/components/consumer_post_card/group_forecast_card/index.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/index.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 
 import { useHideCP } from "@/contexts/cp_context";
+import useDeferredRender from "@/hooks/use_deferred_render";
 import { GroupOfQuestionsGraphType, PostWithForecasts } from "@/types/post";
 import { QuestionType } from "@/types/question";
 import { getGroupForecastAvailability } from "@/utils/questions/forecastAvailability";
@@ -22,6 +23,8 @@ type Props = {
   forFeedPage?: boolean;
 };
 
+const FEED_TIME_SERIES_CHART_HEIGHT = 130;
+
 const GroupForecastCard: FC<Props> = ({
   post,
   compact,
@@ -41,16 +44,25 @@ const GroupForecastCard: FC<Props> = ({
     (forecastAvailability &&
       (forecastAvailability.isEmpty || !!forecastAvailability.cpRevealsOn));
 
+  const shouldRenderFeedTimeSeries = useDeferredRender(!!forFeedPage, post.id);
+
   if (
     post.group_of_questions?.graph_type === GroupOfQuestionsGraphType.FanGraph
   ) {
+    if (shouldHideChart) {
+      return null;
+    }
+
+    if (forFeedPage && !shouldRenderFeedTimeSeries) {
+      return <div style={{ minHeight: FEED_TIME_SERIES_CHART_HEIGHT }} />;
+    }
+
     const sortedQuestions = sortGroupPredictionOptions(
       post.group_of_questions?.questions,
       post.group_of_questions
     );
 
-    // Don't render TimeSeriesChart if should hide chart
-    return shouldHideChart ? null : (
+    return (
       <TimeSeriesChart questions={sortedQuestions} forFeedPage={forFeedPage} />
     );
   }
@@ -92,7 +104,11 @@ const GroupForecastCard: FC<Props> = ({
       );
     }
     return (
-      <DateForecastCard post={post} questionsGroup={post.group_of_questions} />
+      <DateForecastCard
+        post={post}
+        questionsGroup={post.group_of_questions}
+        forFeedPage={forFeedPage}
+      />
     );
   }
 

--- a/front_end/src/components/consumer_post_card/index.tsx
+++ b/front_end/src/components/consumer_post_card/index.tsx
@@ -51,7 +51,10 @@ const ConsumerPostCard: FC<Props> = ({
       >
         <HideCPProvider post={post}>
           {isQuestionPost(post) && !isMultipleChoicePost(post) && (
-            <ConsumerQuestionTile question={post.question} />
+            <ConsumerQuestionTile
+              question={post.question}
+              forFeedPage={forFeedPage}
+            />
           )}
 
           {(isGroupOfQuestionsPost(post) || isMultipleChoicePost(post)) && (

--- a/front_end/src/components/post_card/multiple_choice_tile/index.tsx
+++ b/front_end/src/components/post_card/multiple_choice_tile/index.tsx
@@ -19,6 +19,7 @@ import { ContinuousQuestionTypes } from "@/constants/questions";
 import { useAuth } from "@/contexts/auth_context";
 import useChartTooltip from "@/hooks/use_chart_tooltip";
 import useContainerSize from "@/hooks/use_container_size";
+import useDeferredRender from "@/hooks/use_deferred_render";
 import { ForecastPayload } from "@/services/api/questions/questions.server";
 import { TickFormat, TimelineChartZoomOption } from "@/types/charts";
 import { ChoiceItem } from "@/types/choices";
@@ -169,6 +170,11 @@ export const MultipleChoiceTile: FC<ContinuousMultipleChoiceTileProps> = ({
     chartHeight ??
     (forFeedPage ? CHART_HEIGHT : Math.max(height, CHART_HEIGHT));
 
+  const shouldRenderFeedChart = useDeferredRender(
+    forFeedPage,
+    question?.id ?? group?.id
+  );
+
   return (
     <div className="w-full @container">
       <div
@@ -231,7 +237,7 @@ export const MultipleChoiceTile: FC<ContinuousMultipleChoiceTileProps> = ({
               {...(enableTooltip ? getReferenceProps() : {})}
               className="relative"
             >
-              {isNil(group) ? (
+              {forFeedPage && !shouldRenderFeedChart ? null : isNil(group) ? (
                 <MultipleChoiceChart
                   timestamps={timestamps}
                   actualCloseTime={actualCloseTime}
@@ -248,7 +254,7 @@ export const MultipleChoiceTile: FC<ContinuousMultipleChoiceTileProps> = ({
                   isEmbedded={isEmbed}
                   onCursorChange={onCursorChange}
                   attachRef={attachRef}
-                  forFeedPage
+                  forFeedPage={forFeedPage}
                   onCursorActiveChange={onCursorActiveChange}
                 />
               ) : (
@@ -271,7 +277,7 @@ export const MultipleChoiceTile: FC<ContinuousMultipleChoiceTileProps> = ({
                   forceShowLinePoints={!isEmbed}
                   attachRef={attachRef}
                   isEmbedded={isEmbed}
-                  forFeedPage
+                  forFeedPage={forFeedPage}
                 />
               )}
             </div>
@@ -319,6 +325,8 @@ export const FanGraphTile: FC<FanGraphTileProps> = ({
     chartHeight ??
     (forFeedPage ? CHART_HEIGHT : Math.max(height, CHART_HEIGHT));
 
+  const shouldRenderFeedChart = useDeferredRender(forFeedPage, group.id);
+
   return (
     <div className="w-full @container">
       <div
@@ -357,15 +365,17 @@ export const FanGraphTile: FC<FanGraphTileProps> = ({
               forFeedPage ? { minHeight: effectiveChartHeight } : undefined
             }
           >
-            <FanChart
-              group={group}
-              height={effectiveChartHeight}
-              pointSize={9}
-              hideCP={hideCP}
-              withTooltip={false}
-              optionsLimit={optionsLimit}
-              forFeedPage
-            />
+            {forFeedPage && !shouldRenderFeedChart ? null : (
+              <FanChart
+                group={group}
+                height={effectiveChartHeight}
+                pointSize={9}
+                hideCP={hideCP}
+                withTooltip={false}
+                optionsLimit={optionsLimit}
+                forFeedPage={forFeedPage}
+              />
+            )}
           </div>
         )}
       </div>

--- a/front_end/src/components/post_card/question_tile/question_continuous_tile.tsx
+++ b/front_end/src/components/post_card/question_tile/question_continuous_tile.tsx
@@ -18,6 +18,7 @@ import PredictionContinuousInfo from "@/components/post_card/question_tile/predi
 import useCardReaffirmContext from "@/components/post_card/reaffirm_context";
 import { useAuth } from "@/contexts/auth_context";
 import { useHideCP } from "@/contexts/cp_context";
+import useDeferredRender from "@/hooks/use_deferred_render";
 import { TimelineChartZoomOption } from "@/types/charts";
 import { QuestionStatus } from "@/types/post";
 import {
@@ -56,6 +57,16 @@ const QuestionContinuousTile: FC<Props> = ({
 
   const { hideCP } = useHideCP();
   const { user } = useAuth();
+
+  const shouldRenderFeedChart = useDeferredRender(forFeedPage, question.id);
+  // Defer the heavy Victory chart mount on the feed; reserve its height so the
+  // placeholder doesn't shift layout when the real chart swaps in.
+  const renderDeferrableChart = (chart: React.ReactNode) =>
+    forFeedPage && !shouldRenderFeedChart ? (
+      <div style={{ height: HEIGHT }} />
+    ) : (
+      chart
+    );
 
   const continuousAreaChartData = getContinuousAreaChartData({
     question,
@@ -150,31 +161,33 @@ const QuestionContinuousTile: FC<Props> = ({
         </div>
         {showChart && (
           <div className="relative min-h-12 w-2/3 min-w-24 flex-1 overflow-visible">
-            <NumericTimeline
-              nonInteractive={true}
-              aggregation={
-                question.aggregations[question.default_aggregation_method]
-              }
-              myForecasts={question.my_forecasts}
-              height={HEIGHT}
-              questionType={question.type}
-              actualCloseTime={getPostDrivenTime(question.actual_close_time)}
-              scaling={question.scaling}
-              defaultZoom={defaultChartZoom}
-              resolution={question.resolution}
-              resolveTime={question.actual_resolve_time}
-              hideCP={hideCP}
-              isEmptyDomain={
-                !!forecastAvailability?.isEmpty ||
-                !!forecastAvailability?.cpRevealsOn
-              }
-              openTime={getPostDrivenTime(question.open_time)}
-              unit={question.unit}
-              tickFontSize={9}
-              questionStatus={question.status}
-              forecastAvailability={forecastAvailability}
-              forFeedPage={forFeedPage}
-            />
+            {renderDeferrableChart(
+              <NumericTimeline
+                nonInteractive={true}
+                aggregation={
+                  question.aggregations[question.default_aggregation_method]
+                }
+                myForecasts={question.my_forecasts}
+                height={HEIGHT}
+                questionType={question.type}
+                actualCloseTime={getPostDrivenTime(question.actual_close_time)}
+                scaling={question.scaling}
+                defaultZoom={defaultChartZoom}
+                resolution={question.resolution}
+                resolveTime={question.actual_resolve_time}
+                hideCP={hideCP}
+                isEmptyDomain={
+                  !!forecastAvailability?.isEmpty ||
+                  !!forecastAvailability?.cpRevealsOn
+                }
+                openTime={getPostDrivenTime(question.open_time)}
+                unit={question.unit}
+                tickFontSize={9}
+                questionStatus={question.status}
+                forecastAvailability={forecastAvailability}
+                forFeedPage={forFeedPage}
+              />
+            )}
           </div>
         )}
       </div>
@@ -218,16 +231,18 @@ const QuestionContinuousTile: FC<Props> = ({
           {/* Full-width chart background - overlapping with negative margin */}
           {showChart && (
             <div className="relative z-10 -mt-8 flex w-full flex-col overflow-visible">
-              <ContinuousAreaChart
-                data={continuousAreaChartData}
-                height={HEIGHT}
-                question={question}
-                hideCP={hideCP}
-                hideYAxis={question.type === QuestionType.Discrete}
-                forceTickCount={3}
-                variant={forFeedPage ? "feed" : "question"}
-                centerOOBResolution
-              />
+              {renderDeferrableChart(
+                <ContinuousAreaChart
+                  data={continuousAreaChartData}
+                  height={HEIGHT}
+                  question={question}
+                  hideCP={hideCP}
+                  hideYAxis={question.type === QuestionType.Discrete}
+                  forceTickCount={3}
+                  variant={forFeedPage ? "feed" : "question"}
+                  centerOOBResolution
+                />
+              )}
               <ForecastAvailabilityChartOverflow
                 forecastAvailability={forecastAvailability}
                 className="pl-3 text-xs @[550px]:text-sm"
@@ -253,16 +268,18 @@ const QuestionContinuousTile: FC<Props> = ({
           </div>
           {showChart && (
             <div className="relative h-24 w-2/3 min-w-24 flex-1 overflow-visible">
-              <ContinuousAreaChart
-                data={continuousAreaChartData}
-                height={HEIGHT}
-                question={question}
-                hideCP={hideCP}
-                hideYAxis={question.type === QuestionType.Discrete}
-                forceTickCount={3}
-                variant={forFeedPage ? "feed" : "question"}
-                centerOOBResolution
-              />
+              {renderDeferrableChart(
+                <ContinuousAreaChart
+                  data={continuousAreaChartData}
+                  height={HEIGHT}
+                  question={question}
+                  hideCP={hideCP}
+                  hideYAxis={question.type === QuestionType.Discrete}
+                  forceTickCount={3}
+                  variant={forFeedPage ? "feed" : "question"}
+                  centerOOBResolution
+                />
+              )}
               <ForecastAvailabilityChartOverflow
                 forecastAvailability={forecastAvailability}
                 className="pl-3 text-xs @[550px]:text-sm"
@@ -292,16 +309,18 @@ const QuestionContinuousTile: FC<Props> = ({
       {/* Chart below CP values */}
       {showChart && (
         <div className="relative w-full overflow-visible">
-          <ContinuousAreaChart
-            data={continuousAreaChartData}
-            height={HEIGHT}
-            question={question}
-            hideCP={hideCP}
-            hideYAxis={question.type === QuestionType.Discrete}
-            forceTickCount={3}
-            variant={forFeedPage ? "feed" : "question"}
-            centerOOBResolution
-          />
+          {renderDeferrableChart(
+            <ContinuousAreaChart
+              data={continuousAreaChartData}
+              height={HEIGHT}
+              question={question}
+              hideCP={hideCP}
+              hideYAxis={question.type === QuestionType.Discrete}
+              forceTickCount={3}
+              variant={forFeedPage ? "feed" : "question"}
+              centerOOBResolution
+            />
+          )}
           <ForecastAvailabilityChartOverflow
             forecastAvailability={forecastAvailability}
             className="pl-3 text-xs text-gray-700 dark:text-gray-700-dark md:text-sm"

--- a/front_end/src/hooks/use_deferred_render.ts
+++ b/front_end/src/hooks/use_deferred_render.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+
+type WindowWithIdleCallback = Window & {
+  requestIdleCallback?: (
+    callback: () => void,
+    options?: { timeout: number }
+  ) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+// Defers expensive rendering until the browser is idle. Returns true
+// synchronously when `enabled` is false, and re-defers when `resetKey` changes.
+export default function useDeferredRender(
+  enabled: boolean,
+  resetKey?: unknown
+): boolean {
+  const [readyKey, setReadyKey] = useState<{ value: unknown } | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const win = window as WindowWithIdleCallback;
+    let timeoutId: number | undefined;
+    let idleCallbackId: number | undefined;
+
+    const markReady = () => setReadyKey({ value: resetKey });
+
+    if (win.requestIdleCallback) {
+      idleCallbackId = win.requestIdleCallback(markReady, { timeout: 1200 });
+    } else {
+      timeoutId = window.setTimeout(markReady, 150);
+    }
+
+    return () => {
+      if (idleCallbackId !== undefined && win.cancelIdleCallback) {
+        win.cancelIdleCallback(idleCallbackId);
+      }
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [enabled, resetKey]);
+
+  return !enabled || (readyKey !== null && Object.is(readyKey.value, resetKey));
+}


### PR DESCRIPTION
Related to #4937

### Summary

Adds deferred feed chart rendering so feed cards can paint content before mounting expensive Victory charts.

Implemented changes:

* Added reusable useDeferredRender hook that schedules expensive rendering during browser idle time, with a timeout fallback.
* Deferred chart mounts in consumer feed cards, including continuous question previews, grouped TimeSeriesChart, and date forecast charts.
* Deferred chart mounts in forecaster feed cards, including continuous/numeric timelines, multiple-choice charts, and fan charts.

Performance notes:

With Chrome CPU throttling at 4x slowdown, the post-response client-side render phase improved from \~10s before to \~6s after in local testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved feed-page performance by deferring heavy chart rendering until the browser is idle.
  * Added placeholder areas to maintain stable card layouts while charts load.
* **Bug Fixes**
  * Reduced layout shifting and visual jank in feed views with continuous, multiple choice, and fan/date forecast charts.
  * Kept non-feed views and unaffected question types behaving as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->