### PR TITLE
fix: labor hub commentary — correct Key Insights fallback occupations (Jun 30)

### DIFF
--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-29">Jun 29</time>
+              Commentary last updated: <time dateTime="2026-06-30">Jun 30</time>
             </div>
           </div>
         </div>

--- a/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
@@ -125,10 +125,10 @@ export async function KeyInsightsSection({
             </>
           ) : (
             <>
-              Software developers, lawyers and law clerks, and laborers and
-              material movers are all expected to see the largest decreases in
-              employment rates, while registered nurses, K-12 teachers, and
-              restaurant servers are projected to grow.
+              Software developers, lawyers and law clerks, and sales
+              representatives are all expected to see the largest decreases in
+              employment rates, while registered nurses, restaurant servers, and
+              physicians are projected to grow.
             </>
           )}
         </KeyInsightItem>


### PR DESCRIPTION
## Summary

- **Key Insights fallback — most-declining list**: replaced "laborers and material movers" with "sales representatives" as the 3rd largest-decrease occupation. Forecast data shows laborers at only −1.7% by 2035, while sales representatives are at −12.6% — far more severe and consistent with the Jobs Monitor 2035 negative callout that groups software, sales, and law as the sharp-decline occupations.

- **Key Insights fallback — growing list**: replaced "K-12 teachers" with "physicians" as the 3rd highest-growth occupation. The research section consistently describes teachers as expected to see "mild decline", and the 2035 Jobs Monitor positive callout has named physicians (+7.3%) as the 3rd-most-growing occupation (after nurses #1 and restaurant servers at +9.6% #2) since the Jun 25 update.

- **Commentary last-updated date** bumped to Jun 30.

## Context

The fallback text in `key_insights.tsx` is shown only when the API is unavailable and the dynamic `getTopExtremeJobsForYear` result is empty. It had not been updated since initial development, diverging from multiple rounds of commentary fixes applied to `jobs_insights.tsx` and `research.tsx` since Jun 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fk7TNkYE6PeWJmrMgeagm1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fk7TNkYE6PeWJmrMgeagm1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the “Commentary last updated” date in the Labor Hub hero section to reflect the latest day.
  * Refreshed the “Most and least vulnerable occupations” insight text with updated example occupations and wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->