### PR TITLE
fix: histogram tooltip shows weighted share, not a forecaster count

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -1613,6 +1613,7 @@
   "info": "Informace o otázce",
   "hiddenUntil": "Skryto do",
   "forecastersWithCount": "<strong>{count_formatted}</strong> {count, plural, =1 {předpověď} other {předpovědi}}",
+  "histogramBinShare": "{share} váhy předpovědí",
   "unreadWithTotalCountXs": "<purple>(<strong>{unread_count_formatted}</strong>)</purple> <strong>{total_count_formatted}</strong>",
   "unreadWithTotalCount": "<purple>(<strong>{unread_count_formatted}</strong> nepřečtených)</purple> <strong>{total_count_formatted}</strong> celkem",
   "totalCommentsCount": "<strong>{total_count_formatted}</strong> {total_count, plural, =0 {komentářů} =1 {komentář} other {komentáře}}",

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -389,6 +389,7 @@
   "unreadWithTotalCount": "<purple>(<strong>{unread_count_formatted}</strong> unread)</purple> <strong>{total_count_formatted}</strong> total",
   "unreadWithTotalCountXs": "<purple>(<strong>{unread_count_formatted}</strong>)</purple> <strong>{total_count_formatted}</strong>",
   "forecastersWithCount": "<strong>{count_formatted}</strong> {count, plural, =1 {forecaster} other {forecasters}}",
+  "histogramBinShare": "{share} weight of forecasts",
   "or": "or",
   "signupInviteUsers": "Invite Users",
   "signupInviteUsersDescription": "Enter the email addresses of users you would like to invite, separated by newlines. They will receive an invitation to sign up by email.",

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -1612,6 +1612,7 @@
   "info": "Información de la Pregunta",
   "hiddenUntil": "Oculto hasta",
   "forecastersWithCount": "<strong>{count_formatted}</strong> {count, plural, =1 {pronosticador} other {pronosticadores}}",
+  "histogramBinShare": "{share} del peso de los pronósticos",
   "unreadWithTotalCountXs": "<purple>(<strong>{unread_count_formatted}</strong>)</purple> <strong>{total_count_formatted}</strong>",
   "unreadWithTotalCount": "<purple>(<strong>{unread_count_formatted}</strong> sin leer)</purple> <strong>{total_count_formatted}</strong> en total",
   "totalCommentsCount": "<strong>{total_count_formatted}</strong> {total_count, plural, =0 {comentarios} =1 {comentario} other {comentarios}}",

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -1610,6 +1610,7 @@
   "info": "Informações da pergunta",
   "hiddenUntil": "Oculto até",
   "forecastersWithCount": "<strong>{count_formatted}</strong> {count, plural, =1 {previsor} other {previsores}}",
+  "histogramBinShare": "{share} do peso das previsões",
   "unreadWithTotalCountXs": "<purple>(<strong>{unread_count_formatted}</strong>)</purple> <strong>{total_count_formatted}</strong>",
   "unreadWithTotalCount": "<purple>(<strong>{unread_count_formatted}</strong> não lida)</purple> <strong>{total_count_formatted}</strong> no total",
   "totalCommentsCount": "<strong>{total_count_formatted}</strong> {total_count, plural, =0 {comentários} =1 {comentário} other {comentários}}",

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -1517,6 +1517,7 @@
   "info": "問題資訊",
   "hiddenUntil": "隱藏至",
   "forecastersWithCount": "<strong>{count_formatted}</strong> 位{count, plural, =1 {預測者} other {預測者}}",
+  "histogramBinShare": "占預測權重的 {share}",
   "unreadWithTotalCountXs": "<purple>(<strong>{unread_count_formatted}</strong>)</purple> <strong>{total_count_formatted}</strong>",
   "unreadWithTotalCount": "<purple>（<strong>{unread_count_formatted}</strong> 未讀）</purple> <strong>{total_count_formatted}</strong> 總計",
   "totalCommentsCount": "<strong>{total_count_formatted}</strong> {total_count, plural, =0 {則評論} =1 {則評論} other {則評論}}",

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -1614,6 +1614,7 @@
   "info": "问题信息",
   "hiddenUntil": "隐藏至",
   "forecastersWithCount": "<strong>{count_formatted}</strong> {count, plural, =1 {预报员} other {预报员}}",
+  "histogramBinShare": "占预测权重的 {share}",
   "unreadWithTotalCountXs": "<purple>(<strong>{unread_count_formatted}</strong>)</purple> <strong>{total_count_formatted}</strong>",
   "unreadWithTotalCount": "<purple>(<strong>{unread_count_formatted}</strong> 未读)</purple> <strong>{total_count_formatted}</strong> 总计",
   "totalCommentsCount": "<strong>{total_count_formatted}</strong> 条评论",

--- a/front_end/src/app/(main)/aggregation-explorer/components/histogram_drawer.tsx
+++ b/front_end/src/app/(main)/aggregation-explorer/components/histogram_drawer.tsx
@@ -46,9 +46,6 @@ const HistogramDrawer: FC<Props> = ({
           median={median}
           mean={mean}
           questionStatus={questionData.status}
-          totalForecasters={
-            activeAggregation.history[timestampIndex]?.forecaster_count
-          }
           height={75}
         />
       )

--- a/front_end/src/app/(main)/questions/[id]/components/download_question_data_modal/export_charts/renderer/chart_content.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/download_question_data_modal/export_charts/renderer/chart_content.tsx
@@ -135,7 +135,6 @@ function renderChart(
             median={median}
             mean={mean}
             questionStatus={question.status as unknown as QuestionStatus}
-            totalForecasters={agg.latest?.forecaster_count}
             onChartReady={onChartReady}
           />
         </div>

--- a/front_end/src/components/charts/histogram.tsx
+++ b/front_end/src/components/charts/histogram.tsx
@@ -380,7 +380,7 @@ const Histogram: React.FC<HistogramProps> = ({
               <div className="text-lg font-normal tabular-nums">
                 {`${hoveredBin}-${hoveredBin}.9%`}
               </div>
-              <div className="mx-auto max-w-[7.5rem] text-balance tabular-nums text-blue-300 dark:text-blue-300-dark">
+              <div className="mx-auto max-w-[7.5rem] text-balance tabular-nums leading-tight text-blue-300 dark:text-blue-300-dark">
                 {t("histogramBinShare", { share: shareLabel })}
               </div>
             </div>

--- a/front_end/src/components/charts/histogram.tsx
+++ b/front_end/src/components/charts/histogram.tsx
@@ -20,7 +20,6 @@ import {
 } from "victory";
 import type { CallbackArgs } from "victory-core";
 
-import RichText from "@/components/rich_text";
 import { CHART_DASH } from "@/constants/chart_dash";
 import { CHART_STROKE_WIDTH } from "@/constants/chart_stroke";
 import { darkTheme, lightTheme } from "@/constants/chart_theme";
@@ -45,7 +44,6 @@ type HistogramProps = {
   median: number | null | undefined;
   mean: number | null | undefined;
   questionStatus?: QuestionStatus;
-  totalForecasters?: number;
   height?: number;
   onChartReady?: () => void;
 };
@@ -55,7 +53,6 @@ const Histogram: React.FC<HistogramProps> = ({
   median,
   mean,
   questionStatus,
-  totalForecasters,
   height,
   onChartReady,
 }) => {
@@ -178,13 +175,16 @@ const Histogram: React.FC<HistogramProps> = ({
     [binValues]
   );
   const hoveredValue = hoveredBin === null ? 0 : binValues[hoveredBin] ?? 0;
-  // y values are recency-weighted sums, so a bin's forecaster count is
-  // estimated from its share of the total weight
-  const hoveredCount = !hoveredValue
-    ? 0
-    : totalForecasters && totalWeight
-      ? Math.max(1, Math.round((hoveredValue / totalWeight) * totalForecasters))
-      : Math.max(1, Math.round(hoveredValue));
+  // Bars are recency-weighted, so a bin can't be expressed as a raw forecaster
+  // count; show its share of the total weight instead.
+  const sharePct = totalWeight > 0 ? (hoveredValue / totalWeight) * 100 : 0;
+  // never read "0%" for a non-empty bin (those still render a marker)
+  const shareLabel =
+    sharePct === 0
+      ? "0%"
+      : sharePct < 0.1
+        ? "<0.1%"
+        : `${sharePct.toFixed(1)}%`;
   const showTooltip = isActive && hoveredBin !== null;
 
   const isBinHovered = useCallback(
@@ -380,19 +380,8 @@ const Histogram: React.FC<HistogramProps> = ({
               <div className="text-lg font-normal tabular-nums">
                 {`${hoveredBin}-${hoveredBin}.9%`}
               </div>
-              <div className="tabular-nums text-blue-300 dark:text-blue-300-dark">
-                <RichText>
-                  {(tags) => (
-                    <>
-                      {t.rich("forecastersWithCount", {
-                        count: hoveredCount,
-                        count_formatted:
-                          hoveredCount === 0 ? "0" : `~${hoveredCount}`,
-                        ...tags,
-                      })}
-                    </>
-                  )}
-                </RichText>
+              <div className="mx-auto max-w-[7.5rem] text-balance tabular-nums text-blue-300 dark:text-blue-300-dark">
+                {t("histogramBinShare", { share: shareLabel })}
               </div>
             </div>
           </div>

--- a/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
+++ b/front_end/src/components/detailed_question_card/detailed_question_card/continuous_chart_card.tsx
@@ -466,9 +466,6 @@ const DetailedContinuousChartCard: FC<Props> = ({
               median={median}
               mean={mean}
               questionStatus={question.status}
-              totalForecasters={
-                aggregationLatest?.forecaster_count ?? nrForecasters
-              }
             />
           )}
         </div>


### PR DESCRIPTION
## What

A user in a real-money tournament reported the histogram showing "33–33.9% · ~1 forecaster" when they had counted several users entering 0.33 in the downloaded CSV, which sparked a bot/manipulation suspicion.

Investigation (read-only DB queries against the reported question) confirmed this was **not a computation bug** but a **misleading label**:

- The histogram is **recency-weighted** — a bin's value is a sum of weights, not a headcount. At the reported moment the histogram weights summed to ~14.4 across ~63 forecasters, so the old tooltip's `(bin_weight / total_weight) × forecaster_count` *redistributed* the forecaster count across bins by weight share. That rounds older/low-weight bins down to ~1 and inflates recent ones — it looks like a precise headcount but isn't.
- It's a **current snapshot** of each forecaster's latest active prediction, whereas the CSV is **all-time history** plus **bots** (excluded from the aggregation). Those are fundamentally different quantities.

## Change (frontend-only; bars unchanged)

Replace the tooltip's "~N forecasters" line with the bin's **share of total forecast weight**, which is honest about what the recency-weighted bar actually represents:

- Typical bin → "16.1% weight of forecasts"
- Empty bin → "0% weight of forecasts" (tooltip still shown on every bin)
- Sub-0.1% bin → "<0.1% weight of forecasts" (so a tiny-but-present bin never reads "0%")

The word "weight" is intentional (technically precise). When the line would grow too wide it wraps after "weight" via `text-wrap: balance` + a max-width, giving:

```
16.1% weight
of forecasts
```

Also removes the now-unused `totalForecasters` prop from the three call sites and adds a `histogramBinShare` key to all six locale files. The histogram bars remain recency-weighted (unchanged), still mirroring the CP.

## Verification

- `tsc`, `eslint` (only the pre-existing `react-hooks/refs` warning), and `prettier` pass.
- Live-checked the reported question's Histogram tab: hovering the 0.33 bin reads "33–33.9% · 2.0% weight of forecasts" (matching the DB share exactly), a tall bin reads "16.1% weight of forecasts", empty bins read "0% weight of forecasts", and a tiny bin reads "<0.1% weight of forecasts". A probe with the tooltip's exact CSS confirms the share line wraps to two lines breaking after "weight" (line 1 "16.1% weight" = 79px, line 2 "of forecasts" = 68px). Bars visually unchanged; light and dark modes both render.

## Note for support

The histogram is a recency-weighted current snapshot that excludes bots, so it will never match the all-time CSV. If we ever want a true per-bin headcount, that needs a backend change to compute/serve an unweighted histogram — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new localized label for histogram bin hover tooltips across supported languages.

* **Bug Fixes**
  * Updated histogram hover details to display each bin’s share of total weight (with special handling for very small/zero values) instead of an estimated forecaster count.

* **Improvements**
  * Improved consistency so the histogram is shown with the same data/tooltip behavior across the app and export views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->