### PR TITLE
Extend Chart Interactivity (MC & Groups)

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/choices_options_dropdown.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/choices_options_dropdown.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { faCog } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
+import { useTranslations } from "next-intl";
+import { FC, useMemo } from "react";
+
+import Checkbox from "@/components/ui/checkbox";
+import { METAC_COLORS } from "@/constants/colors";
+import useAppTheme from "@/hooks/use_app_theme";
+import { ChoiceItem } from "@/types/choices";
+import cn from "@/utils/core/cn";
+
+type Props = {
+  choices: ChoiceItem[];
+  onChoiceChange: (choice: string, checked: boolean) => void;
+  onToggleAll: (checked: boolean) => void;
+};
+
+const ChoicesOptionsDropdown: FC<Props> = ({
+  choices,
+  onChoiceChange,
+  onToggleAll,
+}) => {
+  const t = useTranslations();
+  const { getThemeColor } = useAppTheme();
+  const neutralCheckboxColor = getThemeColor(METAC_COLORS.gray[500]);
+  const areAllSelected = useMemo(
+    () => choices.length > 0 && choices.every((choice) => choice.active),
+    [choices]
+  );
+
+  return (
+    <Popover className="relative">
+      {({ open }) => (
+        <>
+          <PopoverButton
+            aria-label={t("settings")}
+            className={cn(
+              "inline-flex h-6 w-6 items-center justify-center rounded-full border border-blue-400 bg-transparent p-0 text-blue-700 transition-colors hover:bg-gray-100 focus:outline-none active:bg-gray-200 dark:border-blue-400-dark dark:bg-transparent dark:text-blue-700-dark dark:hover:bg-gray-100-dark dark:active:bg-gray-200-dark",
+              {
+                "!bg-gray-200 hover:!bg-gray-200 active:!bg-gray-200 dark:!border-white dark:!bg-white dark:!text-blue-700 dark:hover:!bg-white dark:active:!bg-white":
+                  open,
+              }
+            )}
+          >
+            <FontAwesomeIcon icon={faCog} className="text-sm" />
+          </PopoverButton>
+          <PopoverPanel
+            anchor="bottom end"
+            className="z-[100] flex max-h-64 min-w-44 flex-col overflow-y-auto rounded border border-gray-500 bg-gray-0 p-1 text-sm shadow-lg [--anchor-gap:4px] dark:border-gray-500-dark dark:bg-gray-0-dark"
+          >
+            <Checkbox
+              checked={areAllSelected}
+              onChange={() => onToggleAll(!areAllSelected)}
+              label={t("selectAll")}
+              color={
+                areAllSelected
+                  ? getThemeColor(METAC_COLORS.blue[700])
+                  : neutralCheckboxColor
+              }
+              className="gap-2 p-1.5 capitalize"
+              isSolidIcon
+            />
+            {choices.map(({ choice, label, active, color }) => (
+              <Checkbox
+                key={choice}
+                checked={active}
+                onChange={(checked) => onChoiceChange(choice, checked)}
+                label={label || choice}
+                color={active ? getThemeColor(color) : neutralCheckboxColor}
+                className="gap-2 p-1.5 text-sm"
+                isSolidIcon
+              />
+            ))}
+          </PopoverPanel>
+        </>
+      )}
+    </Popover>
+  );
+};
+
+export default ChoicesOptionsDropdown;

--- a/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/multiple_choices_chart_view/index.tsx
@@ -1,7 +1,15 @@
 "use client";
 import { FloatingPortal } from "@floating-ui/react";
 import { useTranslations } from "next-intl";
-import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  FC,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { VictoryThemeDefinition } from "victory";
 
 import GroupChart from "@/components/charts/group_chart";
@@ -17,6 +25,7 @@ import { ForecastAvailability, QuestionType, Scaling } from "@/types/question";
 import cn from "@/utils/core/cn";
 import { buildChoicesWithOthers } from "@/utils/questions/choices";
 
+import ChoicesOptionsDropdown from "./choices_options_dropdown";
 import CompactLegendBar from "./compact_legend_bar";
 
 type Props = {
@@ -33,7 +42,7 @@ type Props = {
   isClosed?: boolean;
   hideCP?: boolean;
   cursorTimestamp?: number | null;
-  title?: string;
+  title?: ReactNode;
   yLabel?: string;
   questionType?: QuestionType;
   scaling?: Scaling;
@@ -181,6 +190,20 @@ const MultiChoicesChartView: FC<Props> = ({
     [choiceItems, onChoiceItemsUpdate]
   );
 
+  const handleToggleAll = useCallback(
+    (checked: boolean) => {
+      if (!isInteracted.current) isInteracted.current = true;
+      onChoiceItemsUpdate(
+        choiceItems.map((item) => ({
+          ...item,
+          active: checked,
+          highlighted: false,
+        }))
+      );
+    },
+    [choiceItems, onChoiceItemsUpdate]
+  );
+
   const chartChoiceItems = useMemo(
     () => (isMC ? buildChoicesWithOthers(choiceItems) : choiceItems),
     [isMC, choiceItems]
@@ -233,6 +256,14 @@ const MultiChoicesChartView: FC<Props> = ({
     attachRef,
     withHighlightArea,
     withHighlightEndpoint,
+    headerExtra:
+      !embedMode && choiceItems.length > 1 ? (
+        <ChoicesOptionsDropdown
+          choices={choiceItems}
+          onChoiceChange={handleChoiceChange}
+          onToggleAll={handleToggleAll}
+        />
+      ) : undefined,
   } as const;
 
   return (
@@ -269,6 +300,7 @@ const MultiChoicesChartView: FC<Props> = ({
               !!forecastAvailability?.cpRevealsOn
             }
             choiceItems={binaryChoiceItems}
+            chartTitle={!embedMode ? title : undefined}
             timelineMarkers={timelineMarkers}
             activeTimelineMarkerId={activeTimelineMarkerId}
             onTimelineMarkerEnter={onTimelineMarkerEnter}
@@ -292,7 +324,7 @@ const MultiChoicesChartView: FC<Props> = ({
           <MultipleChoiceChart
             {...commonChartProps}
             isEmbedded={embedMode}
-            chartTitle={!embedMode && !withLegend ? title : undefined}
+            chartTitle={!embedMode ? title : undefined}
             choiceItems={chartChoiceItems}
             headerLeft={
               withLegend ? (
@@ -318,6 +350,7 @@ const MultiChoicesChartView: FC<Props> = ({
             }
             cursorTimestamp={cursorTimestamp}
             choiceItems={choiceItems}
+            chartTitle={!embedMode ? title : undefined}
             timelineMarkers={timelineMarkers}
             activeTimelineMarkerId={activeTimelineMarkerId}
             onTimelineMarkerEnter={onTimelineMarkerEnter}

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/index.tsx
@@ -410,6 +410,7 @@ export const ConsumerShell: FC<{
                       fillHeight
                       innerChartPaddingX={40}
                       yearOnlyTicks
+                      withHeader
                     />
                   ) : (
                     <QuestionTimeline

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_group_chart.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/consumer_group_chart.tsx
@@ -14,6 +14,7 @@ type Props = {
   preselectedQuestionId?: number;
   chartHeight?: number;
   visibleQuestions?: QuestionWithNumericForecasts[];
+  reservedHeight?: number;
 };
 
 const ConsumerGroupChart: FC<Props> = ({
@@ -21,6 +22,7 @@ const ConsumerGroupChart: FC<Props> = ({
   preselectedQuestionId,
   chartHeight,
   visibleQuestions,
+  reservedHeight = 0,
 }) => {
   const {
     hoveredChoiceName,
@@ -40,7 +42,7 @@ const ConsumerGroupChart: FC<Props> = ({
   const CHART_HEADER_HEIGHT = 44;
   const effectiveChartHeight =
     chartAreaHeight > 0
-      ? Math.max(80, chartAreaHeight - CHART_HEADER_HEIGHT)
+      ? Math.max(80, chartAreaHeight - reservedHeight - CHART_HEADER_HEIGHT)
       : chartHeight;
 
   return (

--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/fan_graph_chart_panel.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/fan_graph_chart_panel.tsx
@@ -15,6 +15,8 @@ import { useListChartExpanded } from "./consumer_list_chart_shell";
 
 type ChartView = "fan" | "timeline";
 
+const TOGGLE_ROW_HEIGHT = 32;
+
 type Props = {
   post: GroupOfQuestionsPost<QuestionWithNumericForecasts>;
   preselectedQuestionId?: number;
@@ -66,44 +68,45 @@ const FanGraphChartPanel: FC<Props> = ({
       ))}
     </div>
   );
-
-  // Fan view toggle is in-flow (h-6 + mb-2 ≈ 32px); subtract from available height.
   const fanChartHeight =
     chartAreaHeight > 0
-      ? Math.max(100, chartAreaHeight - 32)
+      ? Math.max(100, chartAreaHeight - TOGGLE_ROW_HEIGHT)
       : isCompact
         ? 150
         : undefined;
 
   return (
-    <div className="grid grid-cols-1 grid-rows-1">
-      <div
-        className={cn(
-          "col-start-1 row-start-1",
-          activeView !== "fan" && "pointer-events-none invisible"
-        )}
-      >
-        <div className="mb-2 pl-2">{toggle}</div>
-        <FanChart
-          group={post.group_of_questions}
-          hideCP={hideCP}
-          withTooltip
-          height={fanChartHeight}
-        />
-      </div>
-      <div
-        className={cn(
-          "relative col-start-1 row-start-1",
-          activeView !== "timeline" && "pointer-events-none invisible"
-        )}
-      >
-        <div className="absolute left-2 top-0 z-10">{toggle}</div>
-        <ConsumerGroupChart
-          post={post}
-          preselectedQuestionId={preselectedQuestionId}
-          chartHeight={isCompact ? 150 : 220}
-          visibleQuestions={visibleQuestions}
-        />
+    <div>
+      <div className="mb-2">{toggle}</div>
+      <div className="grid grid-cols-1 grid-rows-1">
+        <div
+          className={cn(
+            "col-start-1 row-start-1",
+            activeView !== "fan" && "pointer-events-none invisible"
+          )}
+        >
+          <FanChart
+            group={post.group_of_questions}
+            hideCP={hideCP}
+            withTooltip
+            height={fanChartHeight}
+            alignPlotLeft
+          />
+        </div>
+        <div
+          className={cn(
+            "col-start-1 row-start-1",
+            activeView !== "timeline" && "pointer-events-none invisible"
+          )}
+        >
+          <ConsumerGroupChart
+            post={post}
+            preselectedQuestionId={preselectedQuestionId}
+            chartHeight={isCompact ? 150 : 220}
+            visibleQuestions={visibleQuestions}
+            reservedHeight={TOGGLE_ROW_HEIGHT}
+          />
+        </div>
       </div>
     </div>
   );

--- a/front_end/src/components/charts/fan_chart.tsx
+++ b/front_end/src/components/charts/fan_chart.tsx
@@ -98,6 +98,7 @@ type Props = {
   forFeedPage?: boolean;
   onLegendHeightChange?: (height: number) => void;
   externalHighlightedLabel?: string | null;
+  alignPlotLeft?: boolean;
 };
 
 type NormalizedFanDatum = {
@@ -129,6 +130,7 @@ const FanChart: FC<Props> = ({
   forFeedPage,
   onLegendHeightChange,
   externalHighlightedLabel,
+  alignPlotLeft = false,
 }) => {
   const effectiveVariant: FanChartVariant = variant ?? "default";
 
@@ -316,7 +318,9 @@ const FanChart: FC<Props> = ({
 
   const chartPadding = useMemo(() => {
     const p = v.padding(variantArgs);
-    if (!isEmbedded) return p;
+    if (!isEmbedded) {
+      return alignPlotLeft ? { ...p, left: 0 } : p;
+    }
 
     const safeRight = Math.max(
       typeof p.right === "number" ? p.right : 0,
@@ -329,7 +333,14 @@ const FanChart: FC<Props> = ({
       left: EMBED_SIDE_PAD,
       right: safeRight,
     };
-  }, [v, variantArgs, isEmbedded, effectiveMaxRightPadding, MIN_RIGHT_PADDING]);
+  }, [
+    v,
+    variantArgs,
+    isEmbedded,
+    alignPlotLeft,
+    effectiveMaxRightPadding,
+    MIN_RIGHT_PADDING,
+  ]);
 
   const bottomPadForPoints = v.padding(variantArgs).bottom;
 

--- a/front_end/src/components/charts/group_chart.tsx
+++ b/front_end/src/components/charts/group_chart.tsx
@@ -99,6 +99,8 @@ type Props = {
   forceShowLinePoints?: boolean;
   forFeedPage?: boolean;
   isEmbedded?: boolean;
+  chartTitle?: ReactNode;
+  headerExtra?: ReactNode;
   showCursorLabel?: boolean;
   fadeLinesOnHover?: boolean;
   timelineMarkers?: GroupTimelineMarker[];
@@ -143,6 +145,8 @@ const GroupChart: FC<Props> = ({
   forceShowLinePoints = false,
   forFeedPage,
   isEmbedded = false,
+  chartTitle,
+  headerExtra,
   showCursorLabel = true,
   fadeLinesOnHover = true,
   timelineMarkers,
@@ -364,7 +368,9 @@ const GroupChart: FC<Props> = ({
         height={height}
         zoom={withZoomPicker ? zoom : undefined}
         onZoomChange={setZoom}
+        chartTitle={chartTitle}
         headerLeft={headerLeft}
+        headerExtra={headerExtra}
       >
         {!!chartWidth && (
           <div

--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -101,8 +101,9 @@ type Props = {
   isEmbedded?: boolean;
   forecastAvailability?: ForecastAvailability;
   forFeedPage?: boolean;
-  chartTitle?: string;
+  chartTitle?: ReactNode;
   headerLeft?: ReactNode;
+  headerExtra?: ReactNode;
   animate?: object;
   leftPadding?: number;
 };
@@ -133,6 +134,7 @@ const MultipleChoiceChart: FC<Props> = ({
   forFeedPage,
   chartTitle,
   headerLeft,
+  headerExtra,
   animate,
   leftPadding = 0,
 }) => {
@@ -294,6 +296,7 @@ const MultipleChoiceChart: FC<Props> = ({
         onZoomChange={setZoom}
         chartTitle={chartTitle}
         headerLeft={headerLeft}
+        headerExtra={headerExtra}
       >
         {shouldDisplayChart && (
           <VictoryChart

--- a/front_end/src/components/charts/primitives/chart_container.tsx
+++ b/front_end/src/components/charts/primitives/chart_container.tsx
@@ -67,7 +67,20 @@ const ChartContainer = forwardRef<HTMLDivElement, PropsWithChildren<Props>>(
               )}
             >
               {!!headerLeft ? (
-                <div className="w-full min-w-0 md:flex-1">{headerLeft}</div>
+                <div className="flex w-full min-w-0 flex-col gap-1 md:flex-1">
+                  {!!chartTitle && (
+                    <div
+                      className={cn(
+                        isEmbed
+                          ? "text-xs text-gray-600 dark:text-gray-600-dark"
+                          : "text-xs font-normal text-blue-900 dark:text-gray-900-dark md:text-base"
+                      )}
+                    >
+                      {chartTitle}
+                    </div>
+                  )}
+                  {headerLeft}
+                </div>
               ) : !!chartTitle ? (
                 <div
                   className={cn(
@@ -82,42 +95,45 @@ const ChartContainer = forwardRef<HTMLDivElement, PropsWithChildren<Props>>(
               {(!!zoom || !!headerExtra) && (
                 <div
                   className={cn(
-                    "hidden items-center gap-2 self-end md:flex",
+                    "items-center gap-2 self-end",
+                    !!headerExtra ? "flex" : "hidden md:flex",
                     !!headerLeft ? "md:ml-auto" : "ml-auto"
                   )}
                 >
                   {!!zoom && (
-                    <TabGroup
-                      selectedIndex={selectedIndex}
-                      onChange={handleTabChange}
-                      manual
-                    >
-                      <TabList className="flex gap-0.5">
-                        {tabOptions.map((option) => (
-                          <Tab as={Fragment} key={option.value}>
-                            {({ selected, hover }) => (
-                              <button
-                                className={cn(
-                                  "ChartZoomButton rounded px-1 py-0.5 text-xs font-normal uppercase leading-4 text-gray-600 hover:text-blue-800 focus:outline-none dark:text-gray-600-dark hover:dark:text-blue-800-dark md:text-sm",
-                                  {
-                                    "text-gray-900 dark:text-gray-900-dark":
-                                      selected,
-                                  },
-                                  {
-                                    "bg-gray-300 dark:bg-gray-300-dark":
-                                      hover || selected,
-                                  },
-                                  isEmbed &&
-                                    "uppercase text-gray-600 dark:text-gray-600-dark md:text-xs"
-                                )}
-                              >
-                                {option.label}
-                              </button>
-                            )}
-                          </Tab>
-                        ))}
-                      </TabList>
-                    </TabGroup>
+                    <div className="hidden md:flex">
+                      <TabGroup
+                        selectedIndex={selectedIndex}
+                        onChange={handleTabChange}
+                        manual
+                      >
+                        <TabList className="flex gap-0.5">
+                          {tabOptions.map((option) => (
+                            <Tab as={Fragment} key={option.value}>
+                              {({ selected, hover }) => (
+                                <button
+                                  className={cn(
+                                    "ChartZoomButton rounded px-1 py-0.5 text-xs font-normal uppercase leading-4 text-gray-600 hover:text-blue-800 focus:outline-none dark:text-gray-600-dark hover:dark:text-blue-800-dark md:text-sm",
+                                    {
+                                      "text-gray-900 dark:text-gray-900-dark":
+                                        selected,
+                                    },
+                                    {
+                                      "bg-gray-300 dark:bg-gray-300-dark":
+                                        hover || selected,
+                                    },
+                                    isEmbed &&
+                                      "uppercase text-gray-600 dark:text-gray-600-dark md:text-xs"
+                                  )}
+                                >
+                                  {option.label}
+                                </button>
+                              )}
+                            </Tab>
+                          ))}
+                        </TabList>
+                      </TabGroup>
+                    </div>
                   )}
                   {headerExtra}
                 </div>

--- a/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/index.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/date_forecast_card/index.tsx
@@ -47,6 +47,7 @@ type Props = {
   fillHeight?: boolean;
   innerChartPaddingX?: number;
   yearOnlyTicks?: boolean;
+  withHeader?: boolean;
 };
 
 const TICK_LABEL_INDEXES = [0, 4, 8];
@@ -60,6 +61,7 @@ const DateForecastCard: FC<Props> = ({
   fillHeight = false,
   innerChartPaddingX = 0,
   yearOnlyTicks = false,
+  withHeader = false,
 }) => {
   const { questions } = questionsGroup;
   const locale = useLocale();
@@ -90,12 +92,27 @@ const DateForecastCard: FC<Props> = ({
   }
 
   return (
-    <>
+    <div
+      className={cn(
+        "relative flex w-full flex-col",
+        fillHeight && "min-h-0 flex-1"
+      )}
+    >
+      {withHeader && (
+        <div
+          className="mb-2.5 text-xs font-normal text-blue-900 dark:text-gray-900-dark md:mb-5 md:text-base"
+          style={{
+            paddingLeft: innerChartPaddingX || undefined,
+          }}
+        >
+          {t("forecastTimelineHeading")}
+        </div>
+      )}
       <div
         ref={chartContainerRef}
         className={cn(
           "DateForecastCard relative w-full",
-          fillHeight && "flex-1"
+          fillHeight && "min-h-0 flex-1"
         )}
       >
         {shouldDisplayChart && (
@@ -231,11 +248,11 @@ const DateForecastCard: FC<Props> = ({
         )}
       </div>
       {chartWidth && !isBigChartView && (
-        <div className="mt-4">
+        <div className="mt-4 shrink-0">
           <DateForecastCardTooltip points={points} />
         </div>
       )}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
Related to #4763

### Summary

Extends chart interactivity for multiple-choice and group questions: consumers and forecasters can now toggle individual options on/off and select all from a chart-header dropdown, and the "Forecast Timeline" title now renders consistently across consumer chart types.

Implemented changes:

* Added reusable `ChoicesOptionsDropdown`: per-option checkboxes + a single "Select all", theme-correct open state, `text-sm` options with wider checkbox:left_right_arrow:label gap.
* Wired it into `MultiChoicesChartView` via `headerExtra` for both consumer and forecaster views, with a `handleToggleAll` for select/deselect-all.
* Threaded `chartTitle`/`headerExtra` through `group_chart` and `multiple_choice_chart`, rendering the title above the legend in `chart_container` for one consistent header layout.
* Fixed "Forecast Timeline" title visibility for continuous, binary, MC, and date groups in consumer view.
* Fixed the left alignment issue of the "Timeline" tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a settings menu for multiple-choice charts so users can show/hide individual options or select all at once.
  * Improved chart headers to support richer content and extra controls.
  * Added a timeline header to date forecast cards in supported views.

* **Bug Fixes**
  * Adjusted chart layouts and spacing so headers, controls, and plots align more consistently.
  * Improved height handling in group and fan charts to better fit on-screen content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->