### PR TITLE
fix: labor hub commentary vs chart data mismatches

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -17,10 +17,10 @@ export const JOBS_INSIGHTS = {
   "2030": {
     positive: (
       <>
-        By 2030, roles in <strong>construction</strong> and{" "}
-        <strong>healthcare</strong> are expected to grow due to infrastructure
-        buildouts, an aging population, and legal restrictions unlikely to
-        change in the short-term.
+        By 2030, roles in <strong>design</strong>, <strong>construction</strong>
+        , and <strong>healthcare</strong> are expected to grow due to demand for
+        specialized human expertise, infrastructure buildouts, an aging
+        population, and legal restrictions unlikely to change in the short-term.
       </>
     ),
     negative: (
@@ -41,12 +41,12 @@ export const JOBS_INSIGHTS = {
     ),
     negative: (
       <>
-        By 2035, <strong>software</strong>, <strong>sales</strong> and{" "}
-        <strong>law</strong> are expected to see sharp staff reductions as AI
-        systems take over large portions of coding, outreach, and detailed
-        research work, while <strong>construction workers</strong> see modest
-        gains as robotics have yet to fully displace physical roles by this
-        horizon.
+        By 2035, <strong>financial specialists</strong>, <strong>sales</strong>{" "}
+        and <strong>law</strong> are expected to see sharp staff reductions as
+        AI systems take over large portions of financial analysis, outreach, and
+        detailed research work, while <strong>construction workers</strong> see
+        modest gains as robotics have yet to fully displace physical roles by
+        this horizon.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-06-30">Jun 30</time>
+              Commentary last updated: <time dateTime="2026-07-01">Jul 1</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated QA pass on the [Labor Automation Forecasting Hub](https://www.metaculus.com/labor-hub) cross-referencing chart data against the surrounding commentary text. Found and fixed two mismatches in the Jobs Monitor section's dynamic (per-year) copy:

| Section | Old text | Corrected text |
|---|---|---|
| Jobs Monitor — 2035 decline callout | "By 2035, **software**, sales and law are expected to see sharp staff reductions..." | "By 2035, **financial specialists**, sales and law are expected to see sharp staff reductions..." |
| Jobs Monitor — 2030 growth callout | "By 2030, roles in **construction** and healthcare are expected to grow..." | "By 2030, roles in **design**, construction, and healthcare are expected to grow..." |

**Why:**
- For the 2035 view, Financial Specialists (-5.3%) and Janitors and Cleaners (-5.2%) both decline more than Software Developers (-4.7%), so naming "software" as one of the three sharpest decliners doesn't match the chart's ranking. The page's own "Key Insights" section already correctly names Lawyers and Law Clerks, Services Sales Representatives, and Financial Specialists as the largest decliners — this brings the Jobs Monitor callout in line with that.
- For the 2030 view, Designers (+5.3%) is actually the second-highest-growth occupation, ahead of Construction Workers (+3.9%), but wasn't mentioned in the growth callout naming "construction and healthcare."

Also bumped the "Commentary last updated" date.

Only the commentary copy in `jobs_insights.tsx` and the date in `hero.tsx` were changed — no chart data, component structure, or unrelated code was touched.

## Test plan
- [x] `bunx eslint` on changed files — no errors
- [x] `bunx tsc --noEmit` — no errors
- [x] `bunx prettier --write` on changed files
- [x] Verified new percentages/rankings against the live page's rendered chart data (2027/2030/2035 toggle states) via browser inspection

🤖 Generated with automated commentary QA


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vn44hoAxQykGLoFwuQug3J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Refreshed labor market insight copy for 2030 and 2035, updating the highlighted roles and trends shown to users.
  * Adjusted the “Commentary last updated” date in the hero section to Jul 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->