### PR TITLE
fix: reminder input accepts date only and blocks duplicates

### DIFF
--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -495,6 +495,7 @@
   "reminderErrorPercentLifetimeRequired": "Please set a percent of lifetime",
   "reminderErrorPercentLifetimeCannotHappen": "This would result in no notification, please select a lower value",
   "reminderErrorPercentLifetimeWouldNotRepeat": "This would result in no repetition. Consider switching to \"Doesn't Repeat\"",
+  "reminderErrorDuplicateDate": "This date is already selected. Please choose a different date.",
   "reminderNotePlaceholder": "Write yourself a note...",
   "reminderCPChangesDescription1": "Notify me when the forecast changes by more than 10%",
   "reminderCPChangesDescription2": "For continuous questions, this is measured by a <a href=\"https://en.wikipedia.org/wiki/Kolmogorov–Smirnov_test\">Kolmogorov–Smirnov test</a>.",

--- a/front_end/src/components/post_subscribe/subscribe_button/utils.ts
+++ b/front_end/src/components/post_subscribe/subscribe_button/utils.ts
@@ -25,7 +25,7 @@ export const getDefaultSubscriptionProps = () =>
           next_trigger_datetime: formatInTimeZone(
             addWeeks(new Date(), 1),
             "UTC",
-            "yyyy-MM-dd'T'HH:mm:ss'Z'"
+            "yyyy-MM-dd'T'00:00:00'Z'"
           ),
           recurrence_interval: "",
         },

--- a/front_end/src/components/post_subscribe/subscription_types_customisation/subscription_specific_time.tsx
+++ b/front_end/src/components/post_subscribe/subscription_types_customisation/subscription_specific_time.tsx
@@ -1,12 +1,12 @@
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { addWeeks } from "date-fns";
+import { addDays, addWeeks } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
 import { useLocale, useTranslations } from "next-intl";
 import { FC, useMemo } from "react";
 
 import Button from "@/components/ui/button";
-import DatetimeUtc from "@/components/ui/datetime_utc";
+import { Input } from "@/components/ui/form_field";
 import { SelectOption } from "@/components/ui/listbox";
 import Select from "@/components/ui/select";
 import {
@@ -17,6 +17,10 @@ import {
 import { formatDate } from "@/utils/formatters/date";
 
 import { SubscriptionSectionProps } from "./types";
+
+const getUtcDate = (iso: string): string => (iso ? iso.slice(0, 10) : "");
+
+const toUtcMidnight = (date: string): string => `${date}T00:00:00Z`;
 
 const SubscriptionSectionSpecificTime: FC<
   SubscriptionSectionProps<
@@ -39,19 +43,30 @@ const SubscriptionSectionSpecificTime: FC<
     [t]
   );
 
-  const currentDateTime = useMemo(
-    () => formatInTimeZone(new Date(), "UTC", "yyyy-MM-dd'T'HH:mm:ss'Z'"),
+  const today = useMemo(
+    () => formatInTimeZone(new Date(), "UTC", "yyyy-MM-dd"),
     []
   );
 
+  const selectedDates = useMemo(
+    () =>
+      subscription.subscriptions.map((sub) =>
+        getUtcDate(sub.next_trigger_datetime)
+      ),
+    [subscription.subscriptions]
+  );
+
   const handleAddSubscription = () => {
+    const taken = new Set(selectedDates.filter(Boolean));
+    let candidateDate = addWeeks(new Date(), 1);
+    let candidate = formatInTimeZone(candidateDate, "UTC", "yyyy-MM-dd");
+    while (taken.has(candidate) || candidate < today) {
+      candidateDate = addDays(candidateDate, 1);
+      candidate = formatInTimeZone(candidateDate, "UTC", "yyyy-MM-dd");
+    }
     const newSubscription: PostSubscriptionSpecificTime = {
       type: PostSubscriptionType.SPECIFIC_TIME,
-      next_trigger_datetime: formatInTimeZone(
-        addWeeks(new Date(), 1),
-        "UTC",
-        "yyyy-MM-dd'T'HH:mm:ss'Z'"
-      ),
+      next_trigger_datetime: toUtcMidnight(candidate),
       recurrence_interval: "",
     };
     onChange("subscriptions", [...subscription.subscriptions, newSubscription]);
@@ -64,35 +79,53 @@ const SubscriptionSectionSpecificTime: FC<
     onChange("subscriptions", newSubscriptions);
   };
 
+  const handleDateChange = (index: number, dateValue: string) => {
+    onChange(
+      "next_trigger_datetime",
+      dateValue ? toUtcMidnight(dateValue) : "",
+      index
+    );
+  };
+
   return (
     <div>
       <p>{t("reminderDateDescription")}: </p>
       {subscription.subscriptions.map((sub, index) => {
+        const currentDate = getUtcDate(sub.next_trigger_datetime);
+        const isDuplicate =
+          !!currentDate &&
+          selectedDates.findIndex((d) => d === currentDate) !== index;
         return (
-          <div key={index} className="mt-1 flex">
-            <DatetimeUtc
-              min={currentDateTime}
-              onChange={(dt) =>
-                onChange("next_trigger_datetime", dt ?? "", index)
-              }
-              defaultValue={sub.next_trigger_datetime}
-              className="max-w-[190px] !rounded-none"
-            />
-            <Select
-              defaultValue={sub.recurrence_interval}
-              onChange={(e) =>
-                onChange("recurrence_interval", e.target.value, index)
-              }
-              options={options}
-              className="ml-2 border-0"
-            />
-            <Button
-              variant="text"
-              className="ml-auto"
-              onClick={() => handleRemoveSubscription(index)}
-            >
-              <FontAwesomeIcon icon={faXmark} />
-            </Button>
+          <div key={index} className="mt-1">
+            <div className="flex">
+              <Input
+                type="date"
+                min={today}
+                value={currentDate}
+                onChange={(e) => handleDateChange(index, e.target.value)}
+                className="max-w-[190px] !rounded-none"
+              />
+              <Select
+                defaultValue={sub.recurrence_interval}
+                onChange={(e) =>
+                  onChange("recurrence_interval", e.target.value, index)
+                }
+                options={options}
+                className="ml-2 border-0"
+              />
+              <Button
+                variant="text"
+                className="ml-auto"
+                onClick={() => handleRemoveSubscription(index)}
+              >
+                <FontAwesomeIcon icon={faXmark} />
+              </Button>
+            </div>
+            {isDuplicate && (
+              <p className="mt-1 text-xs text-red-500 dark:text-red-500-dark">
+                {t("reminderErrorDuplicateDate")}
+              </p>
+            )}
           </div>
         );
       })}


### PR DESCRIPTION
Closes #1666.

## Summary
- Switch the "Specific time" reminder input from datetime-local to a date-only input, since email batching makes the chosen time-of-day meaningless. Selections are stored as UTC midnight.
- Disable past dates via the input's `min` attribute.
- Add a per-row duplicate-date check with an inline error message (native date input has no API to disable individual days, so this is the "next best" fallback). "Add another" also seeds new rows with the first unused date.
- Update the default subscription helper to emit midnight UTC and add a new translation string.

## Test plan
- [x] Open a question, follow it, enable "Specific time" and verify the input only accepts a date.
- [x] Confirm the date picker disallows past dates.
- [x] Click "Add another" repeatedly and verify new rows get fresh dates.
- [x] Manually set two rows to the same date and verify the inline error appears on the duplicate row.
- [x] Save and reload to confirm round-tripping.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reminder scheduling now uses a date-only picker for “specific time” subscriptions, making date selection simpler.
  * Added support for automatically suggesting the next available reminder date when adding another entry.

* **Bug Fixes**
  * Improved date handling so reminder dates are normalized consistently across time zones.
  * Duplicate reminder dates are now detected more reliably, with a clearer error shown when the same date is selected twice.
  * Default reminder timing now uses midnight for date-based reminders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->