### PR TITLE
fix: hide "In Review" box when filtering own authored questions

### DIFF
--- a/front_end/src/components/posts_feed/paginated_feed.tsx
+++ b/front_end/src/components/posts_feed/paginated_feed.tsx
@@ -306,6 +306,13 @@ const PaginatedPostsFeed: FC<Props> = ({
   const isFeedLayoutReady = layout !== "grid" || mounted;
   const isConsumerView =
     !user || user.interface_type === InterfaceType.ConsumerView;
+  const usernamesFilter = queryFilters.usernames;
+  const isFilteringOwnAuthored =
+    !!user?.username &&
+    (usernamesFilter === user.username ||
+      (Array.isArray(usernamesFilter) &&
+        usernamesFilter.length === 1 &&
+        usernamesFilter[0] === user.username));
 
   return (
     <>
@@ -313,7 +320,8 @@ const PaginatedPostsFeed: FC<Props> = ({
         {queryFilters.statuses &&
           queryFilters.statuses === "pending" &&
           !isCommunity &&
-          !PUBLIC_MINIMAL_UI && <InReviewBox />}
+          !PUBLIC_MINIMAL_UI &&
+          !isFilteringOwnAuthored && <InReviewBox />}
         {!isPending && !visiblePosts.length && (
           <>
             {isCommunity ? (


### PR DESCRIPTION
## Summary

When a user filters the feed by their own username along with the "In Review" (`status=pending`) status, they're viewing their own pending questions — not looking for other authors' questions to review — so the "Participate in the review process" prompt is irrelevant and is now hidden in that case.

Fixes #1776

## Test plan

- [x] Visit `/questions/?for_main_feed=false&usernames=<your-username>&status=pending` while logged in — box is hidden.
- [x] Visit `/questions/?status=pending` (no username filter) — box still shows.
- [x] Visit `/questions/?usernames=<some-other-user>&status=pending` — box still shows.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The feed no longer shows the review/pending box when viewing posts filtered to your own account.
  * Pending-status UI now appears only in relevant feed views, reducing confusion in personalized filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->