### PR TITLE
feat: allow users to delete their own comments (#2083)

### DIFF
--- a/comments/views/common.py
+++ b/comments/views/common.py
@@ -112,7 +112,6 @@ def comments_list_api_view(request: Request):
 
 
 @api_view(["POST"])
-@permission_classes([IsAuthenticated])
 def comment_delete_api_view(request: Request, pk: int):
     comment = get_object_or_404(Comment, pk=pk)
 

--- a/comments/views/common.py
+++ b/comments/views/common.py
@@ -112,9 +112,12 @@ def comments_list_api_view(request: Request):
 
 
 @api_view(["POST"])
-@permission_classes([IsAdminUser])
+@permission_classes([IsAuthenticated])
 def comment_delete_api_view(request: Request, pk: int):
     comment = get_object_or_404(Comment, pk=pk)
+
+    if comment.author_id != request.user.id and not request.user.is_staff:
+        raise PermissionDenied("You do not have permission to delete this comment.")
 
     soft_delete_comment(comment)
 

--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -108,6 +108,8 @@
   "commentsReadGuidelines": "Přečtěte si naše pokyny",
   "commentsLearnMarkdown": "Přečtěte si více o našem Markdownu",
   "commentDeleted": "Komentář smazán",
+  "deleteCommentConfirmTitle": "Smazat komentář?",
+  "deleteCommentConfirmDescription": "Tento komentář bude odstraněn. Tuto akci nelze vrátit zpět.",
   "commentsReportCommentHeading": "Nahlásit komentář",
   "commentsReportCommentDescription": "Je na komentáři něco v nepořádku? Dejte nám o tom vědět náhlašením komentáře.",
   "commentsReportSpam": "Náhlásit jako spam",

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -274,6 +274,8 @@
   "commentsReadGuidelines": "Read our guidelines",
   "commentsLearnMarkdown": "Learn about our Markdown",
   "commentDeleted": "Comment deleted",
+  "deleteCommentConfirmTitle": "Delete comment?",
+  "deleteCommentConfirmDescription": "This comment will be removed. This can't be undone.",
   "commentsReportCommentHeading": "Report this comment",
   "commentsReportCommentDescription": "Is there something wrong with this comment? Please help us keep our community great by reporting it.",
   "commentsReportSpam": "Report as spam",

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -108,6 +108,8 @@
   "commentsReadGuidelines": "Lee nuestras directrices",
   "commentsLearnMarkdown": "Aprende sobre nuestro Markdown",
   "commentDeleted": "Comentario eliminado",
+  "deleteCommentConfirmTitle": "¿Eliminar comentario?",
+  "deleteCommentConfirmDescription": "Este comentario se eliminará. Esta acción no se puede deshacer.",
   "commentsReportCommentHeading": "Reportar este comentario",
   "commentsReportCommentDescription": "¿Hay algo mal con este comentario? Ayúdanos a mantener nuestra comunidad en buen estado reportándolo.",
   "commentsReportSpam": "Reportar como spam",

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -128,6 +128,8 @@
   "commentsReadGuidelines": "Leia nossas diretrizes",
   "commentsLearnMarkdown": "Aprenda sobre nosso Markdown",
   "commentDeleted": "Comentário excluído",
+  "deleteCommentConfirmTitle": "Excluir comentário?",
+  "deleteCommentConfirmDescription": "Este comentário será removido. Esta ação não pode ser desfeita.",
   "commentsReportCommentHeading": "Denunciar este comentário",
   "commentsReportCommentDescription": "Há algo errado com este comentário? Ajude-nos a manter nossa comunidade ótima relatando-o.",
   "commentsReportSpam": "Denunciar como spam",

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -146,6 +146,8 @@
   "commentsReadGuidelines": "閱讀我們的指導方針",
   "commentsLearnMarkdown": "了解我們的 Markdown",
   "commentDeleted": "評論已刪除",
+  "deleteCommentConfirmTitle": "刪除評論？",
+  "deleteCommentConfirmDescription": "此評論將被刪除。此操作無法復原。",
   "commentsReportCommentHeading": "舉報此評論",
   "commentsReportCommentDescription": "這條評論有問題嗎？請幫助我們保持社群的優質，舉報它。",
   "commentsReportSpam": "舉報為垃圾郵件",

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -106,6 +106,8 @@
   "commentsReadGuidelines": "閱讀我們的指南",
   "commentsLearnMarkdown": "學習我們的 Markdown",
   "commentDeleted": "評論已刪除",
+  "deleteCommentConfirmTitle": "删除评论？",
+  "deleteCommentConfirmDescription": "该评论将被删除。此操作无法撤销。",
   "commentsReportCommentHeading": "舉報這條評論",
   "commentsReportCommentDescription": "這條評論有問題嗎？請通過舉報來幫助我們保持社區的優良氣。",
   "commentsReportSpam": "舉報為垃圾信息",

--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -30,6 +30,7 @@ import { CommentDate } from "@/components/comment_feed/comment_date";
 import CommentEditor from "@/components/comment_feed/comment_editor";
 import CommentReportModal from "@/components/comment_feed/comment_report_modal";
 import CommentVoter from "@/components/comment_feed/comment_voter";
+import ConfirmModal from "@/components/confirm_modal";
 import { Admin } from "@/components/icons/admin";
 import { Moderator } from "@/components/icons/moderator";
 import MarkdownEditor from "@/components/markdown_editor";
@@ -299,6 +300,7 @@ const Comment: FC<CommentProps> = ({
     comment.included_forecast
   );
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { ref, width } = useContainerSize<HTMLDivElement>();
   const { PUBLIC_MINIMAL_UI } = usePublicSettings();
   const { user } = useAuth();
@@ -636,6 +638,16 @@ const Comment: FC<CommentProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [comment.id]);
 
+  const handleDeleteComment = async () => {
+    const response = await softDeleteComment(comment.id);
+
+    if (response && "errors" in response) {
+      console.error("Error deleting comment:", response.errors);
+    } else {
+      setIsDeleted(true);
+    }
+  };
+
   const menuItems: MenuItemProps[] = [
     {
       hidden: !(user?.id === comment.author.id) || !!user?.is_bot,
@@ -682,19 +694,10 @@ const Comment: FC<CommentProps> = ({
       onClick: () => setIsReportModalOpen(true),
     },
     {
-      hidden: !user?.is_staff,
+      hidden: !(isCommentAuthor || user?.is_staff),
       id: "delete",
       name: t("delete"),
-      onClick: async () => {
-        //setDeleteModalOpen(true),
-        const response = await softDeleteComment(comment.id);
-
-        if (response && "errors" in response) {
-          console.error("Error deleting comment:", response.errors);
-        } else {
-          setIsDeleted(true);
-        }
-      },
+      onClick: () => setIsDeleteModalOpen(true),
     },
     {
       hidden: !user?.is_staff,
@@ -1176,6 +1179,14 @@ const Comment: FC<CommentProps> = ({
         comment={comment}
         isOpen={isReportModalOpen}
         onClose={() => setIsReportModalOpen(false)}
+      />
+      <ConfirmModal
+        isOpen={isDeleteModalOpen}
+        onCloseModal={() => setIsDeleteModalOpen(false)}
+        title={t("deleteCommentConfirmTitle")}
+        description={t("deleteCommentConfirmDescription")}
+        actionText={t("delete")}
+        onConfirm={handleDeleteComment}
       />
     </div>
   );

--- a/front_end/src/components/comment_feed/comment.tsx
+++ b/front_end/src/components/comment_feed/comment.tsx
@@ -30,7 +30,6 @@ import { CommentDate } from "@/components/comment_feed/comment_date";
 import CommentEditor from "@/components/comment_feed/comment_editor";
 import CommentReportModal from "@/components/comment_feed/comment_report_modal";
 import CommentVoter from "@/components/comment_feed/comment_voter";
-import ConfirmModal from "@/components/confirm_modal";
 import { Admin } from "@/components/icons/admin";
 import { Moderator } from "@/components/icons/moderator";
 import MarkdownEditor from "@/components/markdown_editor";
@@ -41,6 +40,7 @@ import Checkbox from "@/components/ui/checkbox";
 import DropdownMenu, { MenuItemProps } from "@/components/ui/dropdown_menu";
 import { userTagPattern } from "@/constants/comments";
 import { useAuth } from "@/contexts/auth_context";
+import { useModal } from "@/contexts/modal_context";
 import { usePublicSettings } from "@/contexts/public_settings_context";
 import { useCommentDraft } from "@/hooks/use_comment_draft";
 import useContainerSize from "@/hooks/use_container_size";
@@ -300,10 +300,10 @@ const Comment: FC<CommentProps> = ({
     comment.included_forecast
   );
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { ref, width } = useContainerSize<HTMLDivElement>();
   const { PUBLIC_MINIMAL_UI } = usePublicSettings();
   const { user } = useAuth();
+  const { setCurrentModal } = useModal();
   const scrollTo = useScrollTo();
   const userCanPredict = postData && canPredictQuestion(postData, user);
   const userForecast =
@@ -697,7 +697,16 @@ const Comment: FC<CommentProps> = ({
       hidden: !(isCommentAuthor || user?.is_staff),
       id: "delete",
       name: t("delete"),
-      onClick: () => setIsDeleteModalOpen(true),
+      onClick: () =>
+        setCurrentModal({
+          type: "confirm",
+          data: {
+            title: t("deleteCommentConfirmTitle"),
+            description: t("deleteCommentConfirmDescription"),
+            actionText: t("delete"),
+            onConfirm: handleDeleteComment,
+          },
+        }),
     },
     {
       hidden: !user?.is_staff,
@@ -1179,14 +1188,6 @@ const Comment: FC<CommentProps> = ({
         comment={comment}
         isOpen={isReportModalOpen}
         onClose={() => setIsReportModalOpen(false)}
-      />
-      <ConfirmModal
-        isOpen={isDeleteModalOpen}
-        onCloseModal={() => setIsDeleteModalOpen(false)}
-        title={t("deleteCommentConfirmTitle")}
-        description={t("deleteCommentConfirmDescription")}
-        actionText={t("delete")}
-        onConfirm={handleDeleteComment}
       />
     </div>
   );

--- a/tests/unit/test_comments/test_views.py
+++ b/tests/unit/test_comments/test_views.py
@@ -238,6 +238,58 @@ def test_upvote_own_comment(user1, user2, user2_client, user1_client):
     assert response.status_code == 200
 
 
+class TestCommentDelete:
+    def test_author_can_delete_own_comment(self, user1, user1_client):
+        post = factory_post(author=user1)
+        comment = factory_comment(author=user1, on_post=post)
+
+        response = user1_client.post(
+            reverse("comment-delete", kwargs={"pk": comment.pk})
+        )
+
+        assert response.status_code == 200
+        comment.refresh_from_db()
+        assert comment.is_soft_deleted is True
+
+    def test_non_author_cannot_delete(self, user1, user2_client):
+        post = factory_post(author=user1)
+        comment = factory_comment(author=user1, on_post=post)
+
+        response = user2_client.post(
+            reverse("comment-delete", kwargs={"pk": comment.pk})
+        )
+
+        assert response.status_code == 403
+        comment.refresh_from_db()
+        assert comment.is_soft_deleted is False
+
+    def test_staff_can_delete_any_comment(self, user1, user_admin, user_admin_client):
+        user_admin.is_staff = True
+        user_admin.save(update_fields=["is_staff"])
+        post = factory_post(author=user1)
+        comment = factory_comment(author=user1, on_post=post)
+
+        response = user_admin_client.post(
+            reverse("comment-delete", kwargs={"pk": comment.pk})
+        )
+
+        assert response.status_code == 200
+        comment.refresh_from_db()
+        assert comment.is_soft_deleted is True
+
+    def test_anonymous_cannot_delete(self, user1, anon_client):
+        post = factory_post(author=user1)
+        comment = factory_comment(author=user1, on_post=post)
+
+        response = anon_client.post(
+            reverse("comment-delete", kwargs={"pk": comment.pk})
+        )
+
+        assert response.status_code in (401, 403)
+        comment.refresh_from_db()
+        assert comment.is_soft_deleted is False
+
+
 class TestCommentCreation:
     url = reverse("comment-create")
 


### PR DESCRIPTION
## Summary

Lets users soft-delete their own comments without pestering a moderator, and routes all deletions (author and staff) through a confirmation modal. Addresses the delete half of #2083.

Previously the "Delete" action existed only for staff and deleted instantly with no confirmation.

## Scope note

Issue #2083 also requested a public ↔ private toggle. That half is intentionally not included here: private comments are deprecated (replaced by "Private Notes") and are filtered out of the feed for everyone — including the author — with no UI to view or restore them, so a naive "Make private" would make a comment vanish even for its author. We shipped delete-only by decision; the private/public toggle can be revisited separately. Please don't auto-close #2083 as fully resolved.

## Changes

**Backend** — `comments/views/common.py`
- `comment_delete_api_view` changed from `IsAdminUser` to `IsAuthenticated` + an author-or-staff check (returns 403 otherwise).
- Reuses the existing `soft_delete_comment` service, so threads with replies keep their "deleted" placeholder and comment counts stay correct.

**Frontend** — `front_end/src/components/comment_feed/comment.tsx`
- The "Delete" menu item is now shown to the comment author (in addition to staff).
- Clicking "Delete" (for author or staff) opens a `ConfirmModal` instead of deleting immediately.

**i18n** — `deleteCommentConfirmTitle` / `deleteCommentConfirmDescription` added to all six message files (en, es, cs, pt, zh, zh-TW).

## Tests

New `TestCommentDelete` in `tests/unit/test_comments/test_views.py`: author → 200 (soft-deleted); non-author non-staff → 403; staff → 200; anonymous → 401/403.

## Verification

- `pytest tests/unit/test_comments/test_views.py` → 32 passed
- `ruff format` / `ruff check` → clean
- `bun run lint` → 0 errors; `tsc` → 0; `bun run build` → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a delete-confirmation dialog when removing comments.
  * Updated comment deletion permissions to allow comment authors and staff to delete comments (instead of admin-only).
* **Bug Fixes**
  * Reduced accidental deletions by switching to a confirmation-based delete flow.
* **Documentation**
  * Added comment-deletion confirmation title and description text to multiple languages.
* **Tests**
  * Added unit tests covering author, staff, non-author, and anonymous delete behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->