### PR TITLE
Fix Consumer Views prediction input overlay

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/action_buttons/question_predict_button.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/consumer_question_view/action_buttons/question_predict_button.tsx
@@ -66,7 +66,7 @@ const QuestionPredictButton: React.FC<Props> = ({ post, className }) => {
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
           label={post.question?.title ?? ""}
-          className="!h-[calc(100vh-200px)] w-full max-w-2xl"
+          className="max-h-[calc(100vh-200px)] w-full max-w-2xl"
         >
           <ForecastMaker
             post={post}

--- a/front_end/src/components/embed_modal.tsx
+++ b/front_end/src/components/embed_modal.tsx
@@ -12,6 +12,7 @@ import {
   CHART_TYPE_PARAM,
 } from "@/constants/global_search_params";
 import { ContinuousQuestionTypes } from "@/constants/questions";
+import { useBreakpoint } from "@/hooks/tailwind";
 import useAppTheme from "@/hooks/use_app_theme";
 import { EmbedChartType, TimelineChartZoomOption } from "@/types/charts";
 import { QuestionType } from "@/types/question";
@@ -41,6 +42,7 @@ const EmbedModal: FC<Props> = ({
   questionType,
 }) => {
   const t = useTranslations();
+  const isDesktop = useBreakpoint("sm");
   const { theme: appTheme } = useAppTheme();
 
   const [embedTheme, setEmbedTheme] = useState<AppTheme>(appTheme);
@@ -71,7 +73,18 @@ const EmbedModal: FC<Props> = ({
     ContinuousQuestionTypes.some((type) => type === questionType);
 
   return (
-    <BaseModal label={t("embedThisPage")} isOpen={isOpen} onClose={onClose}>
+    <BaseModal
+      label={t("embedThisPage")}
+      isOpen={isOpen}
+      onClose={onClose}
+      isImmersive={!isDesktop}
+      withCloseButton
+      className={
+        !isDesktop
+          ? "max-w-none rounded-none"
+          : "sm:!my-16 sm:max-h-[min(880px,calc(100svh-8rem))]"
+      }
+    >
       <div className="max-w-2xl">
         <p className="text-base leading-tight">{t("embedCodeSnippet")}</p>
         <div>


### PR DESCRIPTION
Resolves #4838

### Summary

Fixes consumer-view modal overlays so prediction and embed flows no longer take excessive vertical space or conflict with the navbar/header.

Implemented changes:

* Constrained prediction modal height to fit content instead of forcing a tall viewport-sized panel.
* Updated embed modal mobile behavior to use the existing immersive modal layout below the navbar.
* Added desktop spacing and max-height constraints for embed modal instead of relying on a z-index override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved modal behavior across screen sizes, with better desktop and mobile sizing.
  * Added a close button to the embedded modal for easier dismissal.

* **Bug Fixes**
  * Adjusted modal height constraints on desktop to better fit the viewport and avoid awkward overflow.
  * Refined mobile modal presentation for a more immersive full-screen experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->