### PR TITLE
Sentry issue on Invalid response status code 204

### DIFF
--- a/front_end/src/app/(api)/api-proxy/[...path]/route.ts
+++ b/front_end/src/app/(api)/api-proxy/[...path]/route.ts
@@ -10,6 +10,11 @@ import {
 import { getAlphaTokenSession } from "@/services/session";
 import { getPublicSettings } from "@/utils/public_settings.server";
 
+// Statuses that must not include a response body (Fetch spec "null body status").
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+// Body-related headers that are meaningless once the body is dropped.
+const NULL_BODY_HEADERS = new Set(["content-length", "content-type"]);
+
 export async function GET(request: NextRequest) {
   return handleProxyRequest(request, "GET");
 }
@@ -120,10 +125,18 @@ async function handleProxyRequest(request: NextRequest, method: string) {
     }
   }
 
-  const responseData = await response.blob();
+  // Per the Fetch spec these statuses must not carry a body; passing one to
+  // the Response constructor throws a TypeError.
+  const isNullBodyStatus = NULL_BODY_STATUSES.has(response.status);
+
+  const responseData = isNullBodyStatus ? null : await response.blob();
   const responseHeaders: HeadersInit = {};
   response.headers.forEach((value, key) => {
     const lowerKey = key.toLowerCase();
+
+    if (isNullBodyStatus && NULL_BODY_HEADERS.has(lowerKey)) {
+      return;
+    }
 
     if (lowerKey === "content-disposition") {
       responseHeaders[lowerKey] = processContentDispositionHeader(value);


### PR DESCRIPTION
### Summary


Fixes a [Sentry issue](https://metaculus.sentry.io/issues/7578226966/?alert_rule_id=16645909&alert_type=issue&environment=prod&notification_uuid=92c3d1fa-6833-4933-ba13-944f79219c78&project=4507883273125888) where the Next.js API proxy crashed with `Response constructor: Invalid response status code 204` when proxying `GET /api-proxy/auth/verify_token/`.

Debugging notes:

- The upstream Django `auth/verify_token/` endpoint intentionally returns `204 No Content` for successful token verification, so the backend response is valid.
- The crash happened in the frontend API proxy while wrapping the upstream response into a `NextResponse`.
- The proxy was reading every upstream response with `await response.blob()`. For `204`, that creates an empty `Blob`, but Fetch/Undici still treats it as a body.
- `204`, `205`, and `304` responses must not include a body, so constructing `NextResponse` with status `204` and an empty `Blob` throws.

Implemented changes:

- Added explicit handling for null-body statuses: `204`, `205`, and `304`.
- Passes `null` to `NextResponse` for those statuses instead of an empty `Blob`.
- Removes body-related headers like `content-length` and `content-type` for null-body responses.
- Preserves normal proxy behavior for all other responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API proxy handling for “no body” HTTP status codes (e.g., 204/205/304), preventing response construction errors.
  * Filtered out body-related headers when the upstream response has no body, improving compatibility and correctness of forwarded responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->