### PR TITLE
Configure CSP Policies

### DIFF
--- a/front_end/src/app/(api)/api/csp-report/route.ts
+++ b/front_end/src/app/(api)/api/csp-report/route.ts
@@ -1,0 +1,232 @@
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * Receives CSP violation reports (see buildCsp in @/utils/csp).
+ * Accepts both the legacy report-uri format (application/csp-report) and the
+ * Reporting API format (application/reports+json).
+ */
+
+// The endpoint is necessarily unauthenticated (browsers POST reports
+// anonymously), so both the request and its content are attacker-controlled.
+// Bound everything: body size, reports per request, bytes forwarded to Sentry.
+const REPORT_CONTENT_TYPES = [
+  "application/csp-report",
+  "application/reports+json",
+];
+const MAX_BODY_BYTES = 64 * 1024;
+const MAX_REPORTS_PER_REQUEST = 20;
+const MAX_FORWARDED_REPORT_CHARS = 4096;
+
+// Bound CSP report forwarding to protect Sentry quota. Dedupe is keyed by
+// (effective directive, blocked origin), with a per-process global cap.
+const DEDUPE_WINDOW_MS = 5 * 60_000;
+const GLOBAL_WINDOW_MS = 60_000;
+const MAX_FORWARDED_PER_WINDOW = 30;
+const MAX_TRACKED_KEYS = 1000;
+
+type SeenEntry = { windowStart: number; suppressed: number };
+const seenViolations = new Map<string, SeenEntry>();
+
+let globalWindowStart = 0;
+let forwardedInWindow = 0;
+
+/**
+ * Returns whether this violation should be forwarded to Sentry, and how many
+ * identical ones were suppressed since it was last forwarded.
+ */
+function shouldForward(
+  key: string,
+  now: number
+): { forward: boolean; suppressed: number } {
+  if (now - globalWindowStart >= GLOBAL_WINDOW_MS) {
+    globalWindowStart = now;
+    forwardedInWindow = 0;
+  }
+  if (forwardedInWindow >= MAX_FORWARDED_PER_WINDOW) {
+    return { forward: false, suppressed: 0 };
+  }
+
+  const entry = seenViolations.get(key);
+  if (entry && now - entry.windowStart < DEDUPE_WINDOW_MS) {
+    entry.suppressed += 1;
+    return { forward: false, suppressed: 0 };
+  }
+
+  if (seenViolations.size >= MAX_TRACKED_KEYS) {
+    for (const [k, v] of seenViolations) {
+      if (now - v.windowStart >= DEDUPE_WINDOW_MS) {
+        seenViolations.delete(k);
+      }
+    }
+    if (seenViolations.size >= MAX_TRACKED_KEYS) {
+      seenViolations.clear();
+    }
+  }
+
+  seenViolations.set(key, { windowStart: now, suppressed: 0 });
+  forwardedInWindow += 1;
+  return { forward: true, suppressed: entry?.suppressed ?? 0 };
+}
+
+// Scripts injected by browser extensions violate the policy but are not
+// actionable - drop them to keep Sentry noise-free
+const IGNORED_SCHEMES = [
+  "chrome-extension",
+  "moz-extension",
+  "safari-extension",
+  "safari-web-extension",
+  "ms-browser-extension",
+];
+
+type CspViolation = {
+  directive: string;
+  blockedUri: string;
+  documentUri: string;
+  sourceFile: string;
+  raw: Record<string, unknown>;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * Reads the request body, enforcing MAX_BODY_BYTES. Returns null when the
+ * body is missing or oversized.
+ */
+async function readBodyCapped(request: Request): Promise<string | null> {
+  // Fast reject on the header when present; it may legitimately be absent
+  // (proxies re-encoding H2 bodies as chunked), so its absence is fine -
+  // the capped stream read below is the actual enforcement
+  const contentLengthHeader = request.headers.get("content-length");
+  if (contentLengthHeader) {
+    const contentLength = Number(contentLengthHeader);
+    if (!Number.isFinite(contentLength) || contentLength > MAX_BODY_BYTES) {
+      return null;
+    }
+  }
+
+  // Content-Length can be understated by a hostile client, so enforce the
+  // cap while reading regardless
+  const reader = request.body?.getReader();
+  if (!reader) return null;
+
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    received += value.byteLength;
+    if (received > MAX_BODY_BYTES) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function normalizeReports(payload: unknown): CspViolation[] {
+  // Reporting API: [{ type: "csp-violation", body: {...} }, ...]
+  if (Array.isArray(payload)) {
+    return payload.slice(0, MAX_REPORTS_PER_REQUEST).flatMap((report) => {
+      const record = asRecord(report);
+      const body = asRecord(record?.body);
+      if (record?.type !== "csp-violation" || !body) return [];
+      return [
+        {
+          directive: str(body.effectiveDirective),
+          blockedUri: str(body.blockedURL),
+          documentUri: str(body.documentURL),
+          sourceFile: str(body.sourceFile),
+          raw: body,
+        },
+      ];
+    });
+  }
+
+  // Legacy report-uri: { "csp-report": {...} }
+  const body = asRecord(asRecord(payload)?.["csp-report"]);
+  if (!body) return [];
+  return [
+    {
+      directive: str(body["effective-directive"] || body["violated-directive"]),
+      blockedUri: str(body["blocked-uri"]),
+      documentUri: str(body["document-uri"]),
+      sourceFile: str(body["source-file"]),
+      raw: body,
+    },
+  ];
+}
+
+function isExtensionNoise(violation: CspViolation): boolean {
+  return IGNORED_SCHEMES.some(
+    (scheme) =>
+      violation.blockedUri.startsWith(scheme) ||
+      violation.sourceFile.startsWith(scheme)
+  );
+}
+
+// Strip paths/queries so Sentry groups violations by origin instead of
+// creating an issue per URL
+function toOrigin(uri: string): string {
+  try {
+    return new URL(uri).origin;
+  } catch {
+    return uri; // keyword values: "inline", "eval", "data", ...
+  }
+}
+
+export async function POST(request: Request) {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!REPORT_CONTENT_TYPES.some((type) => contentType.includes(type))) {
+    return new Response(null, { status: 415 });
+  }
+
+  const body = await readBodyCapped(request);
+  if (body === null) {
+    return new Response(null, { status: 413 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return new Response(null, { status: 400 });
+  }
+
+  const now = Date.now();
+  for (const violation of normalizeReports(payload)) {
+    if (isExtensionNoise(violation)) continue;
+
+    const blockedOrigin = toOrigin(violation.blockedUri);
+    const { forward, suppressed } = shouldForward(
+      `${violation.directive}|${blockedOrigin}`,
+      now
+    );
+    if (!forward) continue;
+
+    Sentry.captureMessage(
+      `CSP violation: ${violation.directive} blocked ${blockedOrigin}`,
+      {
+        level: "warning",
+        fingerprint: ["csp-violation", violation.directive, blockedOrigin],
+        extra: {
+          report: JSON.stringify(violation.raw).slice(
+            0,
+            MAX_FORWARDED_REPORT_CHARS
+          ),
+          suppressed_since_last_forward: suppressed,
+        },
+      }
+    );
+  }
+
+  return new Response(null, { status: 204 });
+}

--- a/front_end/src/app/layout.tsx
+++ b/front_end/src/app/layout.tsx
@@ -2,7 +2,7 @@ import { config } from "@fortawesome/fontawesome-svg-core";
 import "@fortawesome/fontawesome-svg-core/styles.css";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import type { Metadata } from "next";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import Script from "next/script";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
@@ -92,6 +92,7 @@ export default async function RootLayout({
   const cookieStore = await cookies();
   const csrfToken = cookieStore.get(CSRF_COOKIE_NAME)?.value || null;
   const feedLayoutCookie = cookieStore.get(FEED_LAYOUT_COOKIE)?.value;
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
 
   return (
     <html
@@ -102,7 +103,7 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <head>
-        <PublicSettingsScript publicSettings={publicSettings} />
+        <PublicSettingsScript publicSettings={publicSettings} nonce={nonce} />
         {/* Set default consent mode before GA loads */}
         <Script id="default-consent" strategy="beforeInteractive">
           {`
@@ -123,7 +124,7 @@ export default async function RootLayout({
             <PolyfillProvider>
               <CSPostHogProvider locale={locale}>
                 <AuthProvider user={user} locale={locale} csrfToken={csrfToken}>
-                  <AppThemeProvider>
+                  <AppThemeProvider nonce={nonce}>
                     <NextIntlClientProvider messages={messages}>
                       <PublicSettingsProvider settings={publicSettings}>
                         <ModalProvider>

--- a/front_end/src/components/public_settings_script.tsx
+++ b/front_end/src/components/public_settings_script.tsx
@@ -7,13 +7,16 @@ export const PUBLIC_SETTINGS_KEY = "PUBLIC_SETTINGS";
 
 type Props = {
   publicSettings: PublicSettings;
+  // Raw <script>, so next/script cannot attach the CSP nonce for us.
+  nonce?: string;
 };
 
-const PublicSettingsScript: FC<Props> = ({ publicSettings }) => {
+const PublicSettingsScript: FC<Props> = ({ publicSettings, nonce }) => {
   noStore(); // opt into dynamic rendering
 
   return (
     <script
+      nonce={nonce}
       dangerouslySetInnerHTML={{
         __html: `
         window['${PUBLIC_SETTINGS_KEY}'] = ${JSON.stringify(publicSettings)};

--- a/front_end/src/components/theme_provider.tsx
+++ b/front_end/src/components/theme_provider.tsx
@@ -31,7 +31,13 @@ const BlockCrossTabThemeSync: FC = () => {
 
 const ALLOWED: AppTheme[] = Object.values(AppTheme);
 
-const AppThemeProvided: FC<PropsWithChildren> = ({ children }) => {
+type Props = PropsWithChildren<{
+  // CSP nonce for the pre-hydration inline script next-themes injects;
+  // passed from the server layout since client code can't read next/headers
+  nonce?: string;
+}>;
+
+const AppThemeProvided: FC<Props> = ({ children, nonce }) => {
   const params = useSearchParams();
   const raw = params.get(ENFORCED_THEME_PARAM);
 
@@ -45,6 +51,7 @@ const AppThemeProvided: FC<PropsWithChildren> = ({ children }) => {
       defaultTheme="system"
       enableSystem
       forcedTheme={themeParam}
+      nonce={nonce}
     >
       <BlockCrossTabThemeSync />
       <InnerTheme>{children}</InnerTheme>

--- a/front_end/src/proxy.ts
+++ b/front_end/src/proxy.ts
@@ -10,6 +10,7 @@ import {
 import { getAlphaTokenSession } from "@/services/session";
 import { getAlphaAccessToken } from "@/utils/alpha_access";
 import { ApiError } from "@/utils/core/errors";
+import { applyCspHeaders, buildCsp } from "@/utils/csp";
 import { getPublicSettings } from "@/utils/public_settings.server";
 
 /**
@@ -70,7 +71,15 @@ export async function proxy(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set("x-url", request.url);
 
+  const nonce = btoa(crypto.randomUUID());
+  const cspHeader = buildCsp(nonce);
+  requestHeaders.set("x-nonce", nonce);
+  // Next.js reads the nonce from this request header to tag its own scripts
+  // (next/script, framework chunks) - it checks the report-only variant too
+  requestHeaders.set("Content-Security-Policy-Report-Only", cspHeader);
+
   const response = NextResponse.next({ request: { headers: requestHeaders } });
+  applyCspHeaders(response, cspHeader);
   const responseAuth = new AuthCookieManager(response.cookies);
 
   let hasSession = false;
@@ -106,7 +115,15 @@ export async function proxy(request: NextRequest) {
       !pathname.startsWith("/accounts/") &&
       !hasSession
     ) {
-      return NextResponse.rewrite(new URL("/not-found/", request.url));
+      const rewriteResponse = NextResponse.rewrite(
+        new URL("/not-found/", request.url),
+        { request: { headers: requestHeaders } }
+      );
+      applyCspHeaders(rewriteResponse, cspHeader);
+      response.cookies.getAll().forEach((cookie) => {
+        rewriteResponse.cookies.set(cookie);
+      });
+      return rewriteResponse;
     }
   }
 

--- a/front_end/src/utils/csp.ts
+++ b/front_end/src/utils/csp.ts
@@ -1,0 +1,80 @@
+import "server-only";
+import { NextResponse } from "next/server";
+
+import { getPublicSettings } from "@/utils/public_settings.server";
+
+export const CSP_REPORT_URI = "/api/csp-report/";
+
+function getSentryHost(dsn: string): string | null {
+  try {
+    return new URL(dsn).host;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Nonce-based strict CSP, currently deployed in Report-Only mode.
+ *
+ * 'unsafe-inline' and https: in script-src are fallbacks for old browsers
+ * without nonce/strict-dynamic support; browsers that support nonces ignore
+ * them.
+ */
+export function buildCsp(nonce: string): string {
+  const { PUBLIC_POSTHOG_BASE_URL, PUBLIC_FRONTEND_SENTRY_DSN } =
+    getPublicSettings();
+
+  const sentryHost = getSentryHost(PUBLIC_FRONTEND_SENTRY_DSN);
+
+  // Next dev needs eval for source maps/react-refresh and WebSockets for HMR.
+  const isDev = process.env.NODE_ENV !== "production";
+
+  const directives = [
+    `default-src 'self'`,
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'unsafe-inline' https:${isDev ? " 'unsafe-eval'" : ""}`,
+    // React style={{}} props and user-authored <style> tags in markdown
+    // require 'unsafe-inline' (accepted tradeoff, script-src stays strict)
+    `style-src 'self' 'unsafe-inline'`,
+    // https: because user markdown supports <img> from arbitrary external
+    // hosts (documented in /help/markdown/) - image injection is an accepted
+    // low-risk tradeoff, script-src stays strict
+    `img-src 'self' https: data: blob:`,
+    // /cup page video hosted on the CDN
+    `media-src 'self' https://cdn.metaculus.com`,
+    `font-src 'self'`,
+    [
+      `connect-src 'self'`,
+      isDev ? `ws: wss:` : "",
+      PUBLIC_POSTHOG_BASE_URL,
+      sentryHost ? `https://${sentryHost}` : `https://*.ingest.sentry.io`,
+      `https://www.google-analytics.com https://*.analytics.google.com`,
+      // marketing pixel beacons
+      `https://www.facebook.com https://px.ads.linkedin.com`,
+    ]
+      .filter(Boolean)
+      .join(" "),
+    [
+      // www.metaculus.com - question embeds in markdown, cross-origin on
+      // non-prod hosts; challenges.cloudflare.com - Turnstile captcha
+      `frame-src 'self' https://www.metaculus.com https://challenges.cloudflare.com`,
+      // documented markdown iframe allowlist (see /help/markdown/)
+      `https://afdc.energy.gov https://data.worldbank.org https://fred.stlouisfed.org https://ourworldindata.org https://www.eia.gov`,
+    ].join(" "),
+    `frame-ancestors 'self'`,
+    `base-uri 'self'`,
+    `form-action 'self'`,
+    `object-src 'none'`,
+    `report-uri ${CSP_REPORT_URI}`,
+    `report-to csp-endpoint`,
+  ];
+
+  return directives.join("; ");
+}
+
+export function applyCspHeaders(response: NextResponse, csp: string): void {
+  response.headers.set("Content-Security-Policy-Report-Only", csp);
+  response.headers.set(
+    "Reporting-Endpoints",
+    `csp-endpoint="${CSP_REPORT_URI}"`
+  );
+}


### PR DESCRIPTION
Related to #3576

https://app.notion.com/p/metaculus/CSP-Security-Headers-Scoping-3416aaf4f101815eb05ec91bec95efd6

### Summary

Adds a nonce-based CSP rollout in Report-Only mode so we can monitor policy violations safely before enforcing CSP.

Implemented changes:

* Added CSP builder and Report-Only header wiring in the Next proxy.
* Generated per-request nonces and propagated them to Next scripts, PublicSettingsScript, and next-themes.
* Added /api/csp-report to normalize browser violation reports, filter extension noise, and forward grouped reports to Sentry.
* Added lightweight dedupe/global caps for CSP reports to protect Sentry quota.
* Defined initial CSP directives for scripts, styles, images, media, connections, frames, and reporting based on current frontend usage and documented markdown embeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a stricter, nonce-based Content Security Policy in **report-only** mode, with automatic nonce injection for public settings and theme initialization.
  * Introduced CSP violation reporting that supports multiple payload formats and normalizes events for monitoring.

* **Bug Fixes**
  * Reduced noisy alerts by filtering extension-related CSP violations.
  * Added request size limits and per-report deduplication/rate controls to prevent overwhelming monitoring.

* **Security**
  * Improved CSP reporting coverage by propagating CSP headers to rewritten unauthenticated responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->