### PR TITLE
Markdown editor: links are omitted in table element

### DIFF
--- a/front_end/src/components/markdown_editor/plugins/link/index.tsx
+++ b/front_end/src/components/markdown_editor/plugins/link/index.tsx
@@ -5,6 +5,8 @@ import {
   addComposerChild$,
   addExportVisitor$,
   addImportVisitor$,
+  addNestedEditorChild$,
+  addTableCellEditorChild$,
   addLexicalNode$,
   realmPlugin,
 } from "@mdxeditor/editor";
@@ -50,18 +52,22 @@ export const linkPlugin = realmPlugin<{
     const withUgcLinks = Boolean(params?.withUgcLinks);
 
     const MdastLinkVisitor = createMdastLinkVisitor(withUgcLinks);
+    const LinkPlugins = () => (
+      <>
+        <LexicalLinkPlugin {...linkPluginProps} />
+        {disableAutoLink ? null : <LexicalAutoLinkPlugin />}
+      </>
+    );
+
     realm.pubIn({
       [addActivePlugin$]: "link",
       [addImportVisitor$]: MdastLinkVisitor,
       [addLexicalNode$]: [LinkNode, AutoLinkNode],
       [addExportVisitor$]: LexicalLinkVisitor,
       [disableAutoLink$]: disableAutoLink,
-      [addComposerChild$]: () => (
-        <>
-          <LexicalLinkPlugin {...linkPluginProps} />
-          {disableAutoLink ? null : <LexicalAutoLinkPlugin />}
-        </>
-      ),
+      [addComposerChild$]: LinkPlugins,
+      [addNestedEditorChild$]: LinkPlugins,
+      [addTableCellEditorChild$]: LinkPlugins,
     });
   },
 });


### PR DESCRIPTION
Resolves #4971

### Summary

Fixes hyperlink support inside markdown editor table cells by wiring the existing link plugin into nested editor contexts.

Implemented changes:

* Registered the custom markdown `linkPlugin` with table cell editors via `addTableCellEditorChild$`.
* Also registered it with generic nested editors via `addNestedEditorChild$` to match upstream `@mdxeditor/editor` link plugin behavior.
* Reused the same `LexicalLinkPlugin` / `LexicalAutoLinkPlugin` component for root, nested, and table-cell editors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Link editing and auto-linking now work consistently across more rich-text editor contexts, including nested editors and table cells.
  * Improved link plugin behavior so the same link tools are available wherever the editor is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->