### PR TITLE
Some questions have wrong padding on distribution charts in embeds / images

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_continuous_resolution_chip.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_view/forecaster_question_view/question_header/question_header_continuous_resolution_chip.tsx
@@ -28,6 +28,7 @@ const QuestionHeaderContinuousResolutionChip: FC<Props> = ({
   const continuousAreaChartData = getContinuousAreaChartData({
     question,
     isClosed: question.status === QuestionStatus.CLOSED,
+    isResolved: question.status === QuestionStatus.RESOLVED,
   });
 
   const isEmbed = useIsEmbedMode();

--- a/front_end/src/components/charts/minified_continuous_area_chart.tsx
+++ b/front_end/src/components/charts/minified_continuous_area_chart.tsx
@@ -222,7 +222,12 @@ const MinifiedContinuousAreaChart: FC<Props> = ({
       : null;
 
   const horizontalPadding = useMemo(() => {
-    if (alignChartTabs || question.type === QuestionType.Discrete) {
+    const needsDiscreteLabelPadding =
+      question.type === QuestionType.Discrete &&
+      !hideLabels &&
+      !minMaxLabelsOnly;
+
+    if (alignChartTabs || needsDiscreteLabelPadding) {
       const labels = yScale.ticks.map((tick) => yScale.tickFormat(tick));
       const longestLabelLength = Math.max(
         ...labels.map((label) => label.length)
@@ -233,7 +238,7 @@ const MinifiedContinuousAreaChart: FC<Props> = ({
     }
 
     return HORIZONTAL_PADDING;
-  }, [yScale, question.type, alignChartTabs]);
+  }, [yScale, question.type, alignChartTabs, hideLabels, minMaxLabelsOnly]);
 
   const barWidth = useMemo(() => {
     if (question.type !== QuestionType.Discrete) {


### PR DESCRIPTION
Resolves #4983

### Summary

Fixes squeezed distribution charts in resolved discrete embeds/images.

Implemented changes:

* Adjusted discrete mini chart padding so hidden labels no longer reserve extra horizontal space.
* Passed resolved state into the resolution chip chart data for correct resolved styling.
* Checked other embed chart types/statuses and didn’t find the same padding issue

<img width="794" height="412" alt="image" src="https://github.com/user-attachments/assets/f9c642fc-a112-49d0-bfde-5170f05134c5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolved-state handling in continuous resolution charts so they correctly reflect when a question is resolved.
  * Refined continuous chart spacing for discrete questions to improve readability of labels and tabs.
  * Updated chart layout calculations so padding adjusts immediately when label visibility settings change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->