### PR TITLE
fix: labor hub commentary vs current forecast data (Jul 4)

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -45,7 +45,7 @@ export const JOBS_INSIGHTS = {
         and <strong>law</strong> are expected to see sharp staff reductions as
         AI systems take over large portions of financial analysis, outreach, and
         detailed research work, while <strong>construction workers</strong> see
-        modest gains as robotics have yet to fully displace physical roles by
+        little change as robotics have yet to fully displace physical roles by
         this horizon.
       </>
     ),

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-07-01">Jul 1</time>
+              Commentary last updated: <time dateTime="2026-07-04">Jul 4</time>
             </div>
           </div>
         </div>

--- a/front_end/src/app/(main)/labor-hub/sections/research.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/research.tsx
@@ -70,13 +70,12 @@ export function ResearchSection({
             rated as low exposure due to the high physical nature of the work,
             but forecasters anticipate that robotic capabilities will begin to
             displace more of these roles by 2035. Forecasters do expect that the
-            high exposure and vulnerability of lawyers, sales representatives,
-            and software developers will translate to significant employment
-            reductions in these fields over the next decade, while financial
-            specialists are expected to see only modest declines. These
-            forecasts provide important context to our understanding of
-            workforce prospects by quantifying the predicted impact of AI on
-            employment levels.
+            high exposure and vulnerability of lawyers, financial specialists,
+            sales representatives, and software developers will translate to
+            significant employment reductions in these fields over the next
+            decade. These forecasts provide important context to our
+            understanding of workforce prospects by quantifying the predicted
+            impact of AI on employment levels.
           </ContentParagraph>
         </div>
 


### PR DESCRIPTION
## Summary

Automated QA pass on the [Labor Automation Forecasting Hub](https://www.metaculus.com/labor-hub), cross-referencing chart/table data against the surrounding commentary text. Found and fixed two misalignments where commentary described the forecast direction/magnitude incorrectly relative to the current live data.

### Fix 1 — Jobs Monitor, 2035 insight (`jobs_insights.tsx`)

- **Old text:** "...while **construction workers** see **modest gains** as robotics have yet to fully displace physical roles by this horizon."
- **Chart data:** Construction Workers forecast for 2035 is **-0.27%** (a slight decline, not a gain).
- **New text:** "...while **construction workers** see **little change** as robotics have yet to fully displace physical roles by this horizon."

### Fix 2 — Research section (`research.tsx`)

- **Old text:** "...the high exposure and vulnerability of lawyers, sales representatives, and software developers will translate to significant employment reductions in these fields over the next decade, **while financial specialists are expected to see only modest declines**."
- **Chart data (2035 forecast):** Lawyers -12.5%, **Financial Specialists -11.9%**, Sales Representatives -10.6%, Software Developers -7.8%. Financial specialists' decline is now nearly as steep as lawyers' and steeper than both sales representatives' and software developers', contradicting the "only modest declines" framing.
- **New text:** Folded financial specialists into the significant-decline group: "...the high exposure and vulnerability of lawyers, financial specialists, sales representatives, and software developers will translate to significant employment reductions in these fields over the next decade."

### Also

- Bumped "Commentary last updated" from Jul 1 → Jul 4.

Other sections (Overview, Wages, Graduates, Economy, State-Level, and the Jobs Monitor 2027/2030 views) were checked against the live forecast data and found consistent — no changes made there.

## Test plan

- [ ] Visit `/labor-hub` and confirm the Jobs Monitor 2035 negative insight reads "little change" for construction workers
- [ ] Confirm the Research section no longer singles out financial specialists as a "modest decline" exception
- [ ] Confirm "Commentary last updated: Jul 4" shows in the hero

https://claude.ai/code/session_018nbFQSd93szrPpqwrz1ke9


---
_Generated by [Claude Code](https://claude.ai/code/session_018nbFQSd93szrPpqwrz1ke9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined forecast copy in Labor Hub for clearer, more consistent outlook language.
  * Updated the “Commentary last updated” timestamp to reflect the latest revision.
  * Adjusted the research narrative to include financial specialists in the list of roles expected to face significant employment declines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->