### PR TITLE
fix: labor hub commentary drift vs current forecast data (Jul 6)

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -17,10 +17,11 @@ export const JOBS_INSIGHTS = {
   "2030": {
     positive: (
       <>
-        By 2030, roles in <strong>design</strong>, <strong>construction</strong>
-        , and <strong>healthcare</strong> are expected to grow due to demand for
-        specialized human expertise, infrastructure buildouts, an aging
-        population, and legal restrictions unlikely to change in the short-term.
+        By 2030, roles in <strong>food service</strong>,{" "}
+        <strong>construction</strong>, and <strong>healthcare</strong> are
+        expected to grow due to demand for in-person service, infrastructure
+        buildouts, and an aging population that AI is unlikely to displace in
+        the short-term.
       </>
     ),
     negative: (
@@ -34,8 +35,8 @@ export const JOBS_INSIGHTS = {
   "2035": {
     positive: (
       <>
-        By 2035, <strong>nurses</strong>, <strong>restaurant servers</strong>,
-        and <strong>physicians</strong> are expected to see the highest growth,
+        By 2035, <strong>nurses</strong>, <strong>physicians</strong>, and{" "}
+        <strong>law enforcement</strong> are expected to see the highest growth,
         driven by hands-on needs that cannot be easily automated.
       </>
     ),

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-07-04">Jul 4</time>
+              Commentary last updated: <time dateTime="2026-07-06">Jul 6</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated audit of the [Labor Automation Forecasting Hub](https://www.metaculus.com/labor-hub) found two Jobs Monitor commentary claims that no longer match the underlying (continuously-updating) forecast data. Fixed both and bumped the "Commentary last updated" date.

| Section | Before | After |
|---|---|---|
| Jobs Monitor — 2035 growth insight | "By 2035, **nurses**, **restaurant servers**, and **physicians** are expected to see the highest growth..." | "By 2035, **nurses**, **physicians**, and **law enforcement** are expected to see the highest growth..." |
| Jobs Monitor — 2030 growth insight | "By 2030, roles in **design**, **construction**, and **healthcare** are expected to grow..." | "By 2030, roles in **food service**, **construction**, and **healthcare** are expected to grow..." |

**Why:**
- **2035 growth insight:** Restaurant Servers is currently the *lowest*-ranked of the five tracked 2035 growth occupations (+2.8%), behind Nurses (+13.0%), Physicians (+5.1%), and Law Enforcement (+3.6%). The page's own dynamically-generated "Key Insights" panel independently confirms the correct top three are nurses, physicians, and law enforcement — directly contradicting the hardcoded Jobs Monitor copy.
- **2030 growth insight:** Designers has fallen to +1.1% for 2030, now behind Construction Workers (+4.1%) and Restaurant Servers (+3.1%), so "design" is no longer one of the top growth categories for that year.

Only the commentary text was changed — no chart data, component structure, or unrelated code was touched.

## Test plan
- [x] `prettier --write` on changed files
- [x] `eslint` on changed files (no errors)
- [x] Verified new occupation names/rankings against the live page's raw data (RSC payload) and its own dynamic Key Insights summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01G3MD8EWcPAG5mrfdL3yKhh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Refreshed the Labor Hub insights text for the 2030 and 2035 positive outlooks, including updated highlighted roles and clearer wording.
  * Updated the “Commentary last updated” date in the hero section to reflect the latest revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->