### PR TITLE
Update Text Label Colors for Multiple Choice Options

### DIFF
--- a/front_end/src/components/charts/multiple_choice_chart.tsx
+++ b/front_end/src/components/charts/multiple_choice_chart.tsx
@@ -59,6 +59,7 @@ import {
 } from "@/utils/charts/axis";
 import { findPreviousTimestamp } from "@/utils/charts/cursor";
 import { getSharedStepKeepMask } from "@/utils/charts/step_reducer";
+import { pickHighestContrastTextColor } from "@/utils/core/colors";
 import { truncateLabel } from "@/utils/formatters/string";
 import { scaleInternalLocation, unscaleNominalLocation } from "@/utils/math";
 
@@ -949,9 +950,7 @@ const ResolutionChip: FC<{
     ? METAC_COLORS.purple["800"].dark
     : METAC_COLORS.gray["0"].DEFAULT;
 
-  const chipTextColor = isDarkTheme
-    ? METAC_COLORS.purple["800"].dark
-    : METAC_COLORS.gray["0"].DEFAULT;
+  const chipTextColor = pickHighestContrastTextColor(color);
   const [textWidth, setTextWidth] = useState(0);
   const textRef = useRef<SVGTextElement>(null);
 


### PR DESCRIPTION
Resolves #4224

### Summary

Updates Multiple Choice chart label colors so text stays readable on colored option backgrounds.

Implemented changes:

* Changed Multiple Choice resolution chips to choose either light or dark text based on the actual chip background color.
* Reused the existing APCA contrast helper so future Multiple Choice palette changes do not require per-color text rules.

<img width="577" height="259" alt="image" src="https://github.com/user-attachments/assets/9a82235f-9fa8-495e-8e6f-55f93eb90dcd" />

<img width="582" height="236" alt="image" src="https://github.com/user-attachments/assets/da892d2a-9420-4534-bd4a-1e705c79b800" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart chip readability by automatically selecting a higher-contrast text color against the chip background.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->