### PR TITLE
Confusing withdrawal message when question close < withdrawal date

### DIFF
--- a/front_end/src/components/forecast_maker/forecast_expiration.tsx
+++ b/front_end/src/components/forecast_maker/forecast_expiration.tsx
@@ -271,7 +271,8 @@ const getPresetLabel = (
 export const useExpirationModalState = (
   questionDuration: number,
   lastForecast: UserForecast | undefined,
-  isPrePrediction?: boolean
+  isPrePrediction?: boolean,
+  scheduledCloseTime?: string
 ) => {
   const [isForecastExpirationModalOpen, setIsForecastExpirationModalOpen] =
     useState(false);
@@ -343,7 +344,12 @@ export const useExpirationModalState = (
 
   let previousForecastExpiration = undefined;
 
-  if (lastForecast?.end_time) {
+  const withdrawalHappensAfterQuestionCloses =
+    !!lastForecast?.end_time &&
+    !!scheduledCloseTime &&
+    lastForecast.end_time * 1000 > new Date(scheduledCloseTime).getTime();
+
+  if (lastForecast?.end_time && !withdrawalHappensAfterQuestionCloses) {
     const lastForecastExpiryDate = new Date((lastForecast.end_time - 1) * 1000); //make this one second earlier, to avoid having 0 seconds as expiration delta
     const previousForecastIsExpired = lastForecastExpiryDate <= new Date();
 

--- a/front_end/src/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
+++ b/front_end/src/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_binary.tsx
@@ -118,13 +118,15 @@ const ForecastMakerConditionalBinary: FC<Props> = ({
   const questionYesExpirationState = useExpirationModalState(
     questionYesDuration,
     question_yes.my_forecasts?.latest,
-    isQuestionPrePrediction(question_yes)
+    isQuestionPrePrediction(question_yes),
+    question_yes.scheduled_close_time
   );
 
   const questionNoExpirationState = useExpirationModalState(
     questionNoDuration,
     question_no.my_forecasts?.latest,
-    isQuestionPrePrediction(question_no)
+    isQuestionPrePrediction(question_no),
+    question_no.scheduled_close_time
   );
 
   const questionDuration =

--- a/front_end/src/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_continuous.tsx
+++ b/front_end/src/components/forecast_maker/forecast_maker_conditional/forecast_maker_conditional_continuous.tsx
@@ -131,13 +131,15 @@ const ForecastMakerConditionalContinuous: FC<Props> = ({
   const questionYesExpirationState = useExpirationModalState(
     questionYesDuration,
     question_yes.my_forecasts?.latest,
-    isQuestionPrePrediction(question_yes)
+    isQuestionPrePrediction(question_yes),
+    question_yes.scheduled_close_time
   );
 
   const questionNoExpirationState = useExpirationModalState(
     questionNoDuration,
     question_no.my_forecasts?.latest,
-    isQuestionPrePrediction(question_no)
+    isQuestionPrePrediction(question_no),
+    question_no.scheduled_close_time
   );
 
   const [questionOptions, setQuestionOptions] = useState<

--- a/front_end/src/components/forecast_maker/forecast_maker_group/continuous_input_wrapper.tsx
+++ b/front_end/src/components/forecast_maker/forecast_maker_group/continuous_input_wrapper.tsx
@@ -260,7 +260,8 @@ const ContinuousInputWrapper: FC<PropsWithChildren<Props>> = ({
   } = useExpirationModalState(
     questionDuration,
     option.question.my_forecasts?.latest,
-    isQuestionPrePrediction(option.question)
+    isQuestionPrePrediction(option.question),
+    option.question.scheduled_close_time
   );
 
   useEffect(() => {

--- a/front_end/src/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
+++ b/front_end/src/components/forecast_maker/forecast_maker_group/forecast_maker_group_binary.tsx
@@ -153,7 +153,8 @@ const ForecastMakerGroupBinary: FC<Props> = ({
   const expirationState = useExpirationModalState(
     averageQuestionDuration,
     firstOpenQuestion?.my_forecasts?.latest, // Use first open question as reference
-    allQuestionsUpcoming
+    allQuestionsUpcoming,
+    firstOpenQuestion?.scheduled_close_time
   );
 
   const {

--- a/front_end/src/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
+++ b/front_end/src/components/forecast_maker/forecast_maker_question/forecast_maker_binary.tsx
@@ -101,7 +101,8 @@ const ForecastMakerBinary: FC<Props> = ({
   } = useExpirationModalState(
     questionDuration,
     question.my_forecasts?.latest,
-    isQuestionPrePrediction(question)
+    isQuestionPrePrediction(question),
+    question.scheduled_close_time
   );
 
   const [submitError, setSubmitError] = useState<ErrorResponse>();

--- a/front_end/src/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
+++ b/front_end/src/components/forecast_maker/forecast_maker_question/forecast_maker_continuous.tsx
@@ -250,7 +250,8 @@ const ForecastMakerContinuous: FC<Props> = ({
   } = useExpirationModalState(
     questionDuration,
     question.my_forecasts?.latest,
-    isQuestionPrePrediction(question)
+    isQuestionPrePrediction(question),
+    question.scheduled_close_time
   );
 
   const handlePredictSubmit = async (

--- a/front_end/src/components/forecast_maker/forecast_maker_question/forecast_maker_multiple_choice.tsx
+++ b/front_end/src/components/forecast_maker/forecast_maker_question/forecast_maker_multiple_choice.tsx
@@ -197,7 +197,8 @@ const ForecastMakerMultipleChoice: FC<Props> = ({
   const expirationState = useExpirationModalState(
     questionDuration,
     question.my_forecasts?.latest,
-    isQuestionPrePrediction(question)
+    isQuestionPrePrediction(question),
+    question.scheduled_close_time
   );
 
   const {


### PR DESCRIPTION
### Summary

Hides the withdrawal countdown message when the forecast would be withdrawn after the question closes.

Implemented changes:

* Changed forecast expiration state to compare the forecast withdrawal time against the question scheduled close time.
* Stopped returning `previousForecastExpiration` when `lastForecast.end_time` is later than `scheduled_close_time`, so `Your prediction will be withdrawn in...` is not rendered for that case.
* Updated all forecast maker variants to pass the question close time into the shared expiration state hook.

<img width="617" height="727" alt="image" src="https://github.com/user-attachments/assets/1c6cfcdf-1b83-4d9f-a3a0-b577cef9db8f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Forecast expiration details now account for each question’s scheduled close time, preventing expiration information from appearing when a withdrawal occurs after the question has closed.
  * Updated the forecast-making experience across binary, continuous, multiple choice, and group flows so the expiration modal state consistently uses the latest close-time information for accurate timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->