### PR TITLE
Update Timeline display logic for Closed Tournaments in Tournaments Hub

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -1947,6 +1947,7 @@
   "tournamentsTypeIndex": "Index",
   "tournamentsTypeQuestionSeries": "Série otázek",
   "tournamentTimelineClosed": "Čekající vyřešení",
+  "tournamentTimelinePendingWinners": "Čeká se na vyhlášení vítězů",
   "questionsPreviouslyPredicted": "{count, plural, =1 {# otázka} other {# otázek}} dříve předpovězených",
   "includeMyForecastAtTheTime": "Zahrnout mou předpověď v daném čase <strong>({forecast})</strong>",
   "tournamentsInfoTitle": "Jsme <predmarket>nepredikční trh</predmarket>. Můžete se účastnit zdarma a vyhrát peněžní ceny za přesnost.",

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -2049,6 +2049,7 @@
   "tournamentTimelineStarts": "Starts {when}",
   "tournamentTimelineEnds": "Ends {when}",
   "tournamentTimelineClosed": "Pending resolutions",
+  "tournamentTimelinePendingWinners": "Pending winners announcement",
   "tournamentTimelineAllResolved": "All questions resolved",
   "tournamentRelativeSoon": "soon",
   "tournamentRelativeUnderMinute": "in under a minute",

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -1946,6 +1946,7 @@
   "tournamentsTypeIndex": "Índice",
   "tournamentsTypeQuestionSeries": "Serie de Preguntas",
   "tournamentTimelineClosed": "Resoluciones pendientes",
+  "tournamentTimelinePendingWinners": "Anuncio de ganadores pendiente",
   "questionsPreviouslyPredicted": "{count, plural, =1 {# pregunta} other {# preguntas}} previamente previstas",
   "includeMyForecastAtTheTime": "Incluir mi predicción en ese momento <strong>({forecast})</strong>",
   "tournamentsInfoTitle": "Nosotros <predmarket>no somos un mercado de predicciones</predmarket>. Puedes participar gratis y ganar premios en efectivo por ser preciso.",

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -1944,6 +1944,7 @@
   "tournamentsTypeIndex": "Índice",
   "tournamentsTypeQuestionSeries": "Série de Perguntas",
   "tournamentTimelineClosed": "Resoluções pendentes",
+  "tournamentTimelinePendingWinners": "Anúncio de vencedores pendente",
   "questionsPreviouslyPredicted": "{count, plural, =1 {# pergunta} other {# perguntas}} previamente previstas",
   "includeMyForecastAtTheTime": "Incluir minha previsão no momento <strong>({forecast})</strong>",
   "tournamentsInfoTitle": "Nós <predmarket>não somos um mercado de previsões</predmarket>. Você pode participar gratuitamente e ganhar prêmios em dinheiro por ser preciso.",

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -1943,6 +1943,7 @@
   "tournamentsTypeIndex": "指數",
   "tournamentsTypeQuestionSeries": "問答系列",
   "tournamentTimelineClosed": "待处理的决议",
+  "tournamentTimelinePendingWinners": "待公布得獎者",
   "questionsPreviouslyPredicted": "先前預測的{count, plural, =1 {# 個問題} other {# 個問題}}",
   "includeMyForecastAtTheTime": "包括我當時的預測 <strong>({forecast})</strong>",
   "dismiss": "關閉",

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -1948,6 +1948,7 @@
   "tournamentsTypeIndex": "索引",
   "tournamentsTypeQuestionSeries": "问题系列",
   "tournamentTimelineClosed": "待定決議",
+  "tournamentTimelinePendingWinners": "待公布获奖者",
   "questionsPreviouslyPredicted": "之前预测的{count, plural, =1 {# 个问题} other {# 个问题}}",
   "includeMyForecastAtTheTime": "包含我当时的预测 <strong>({forecast})</strong>",
   "tournamentsInfoTitle": "我们<predmarket>不是一个预测市场</predmarket>。您可以免费参与，并因精准的预测赢得现金奖品。",

--- a/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/live_tournament_card.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/live_tournament_card.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { faList, faUsers } from "@fortawesome/free-solid-svg-icons";
+import {
+  faHourglassHalf,
+  faList,
+  faUsers,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslations } from "next-intl";
 import React, { useMemo } from "react";
@@ -132,14 +136,7 @@ function TournamentTimelineBar({
     return <ActiveMiniBar nowTs={now} startTs={startTs} endTs={closedTs} />;
   }
 
-  return (
-    <ClosedMiniBar
-      nowTs={now}
-      isResolved={isResolved}
-      closeDate={closeDate ?? null}
-      timeline={timeline}
-    />
-  );
+  return <ClosedStatus isResolved={isResolved} />;
 }
 
 function ActiveMiniBar({
@@ -192,80 +189,16 @@ function ActiveMiniBar({
   );
 }
 
-function ClosedMiniBar({
-  nowTs,
-  isResolved,
-  timeline,
-  closeDate,
-}: {
-  nowTs: number | null;
-  isResolved: boolean;
-  timeline: TournamentTimeline | null;
-  closeDate: string | null;
-}) {
+function ClosedStatus({ isResolved }: { isResolved: boolean }) {
   const t = useTranslations();
   const label = isResolved
-    ? t("tournamentTimelineAllResolved")
+    ? t("tournamentTimelinePendingWinners")
     : t("tournamentTimelineClosed");
-  let progress = isResolved ? 50 : 0;
-
-  if (nowTs != null) {
-    const resolvedTs = pickResolveTs(nowTs, timeline);
-    const winnersTs = pickWinnersTs(resolvedTs, closeDate);
-
-    if (resolvedTs && nowTs >= resolvedTs) progress = 50;
-    if (winnersTs && nowTs >= winnersTs) progress = 100;
-    if (isResolved) progress = Math.max(progress, 50);
-  }
 
   return (
-    <div>
-      <p className="my-0 hidden text-[10px] font-normal text-blue-700 dark:text-blue-700-dark lg:block">
-        {label}
-      </p>
-
-      <div className="relative mt-2 h-1 w-full rounded-full bg-blue-400 dark:bg-blue-400-dark">
-        <div
-          className="absolute inset-y-0 left-0 rounded-full bg-blue-700 dark:bg-blue-700-dark"
-          style={{ width: `${progress}%` }}
-        />
-
-        <ClosedChip left="0%" active />
-        <ClosedChip left="50%" active={progress >= 50} />
-        <ClosedChip left="100%" active={progress >= 100} />
-      </div>
-    </div>
-  );
-}
-
-function ClosedChip({
-  left,
-  active,
-}: {
-  left: "0%" | "50%" | "100%";
-  active: boolean;
-}) {
-  return (
-    <div
-      className={cn(
-        "absolute top-1/2 z-10 h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full p-[3px]",
-        active
-          ? "bg-blue-700 dark:bg-blue-700-dark"
-          : "bg-blue-400 dark:bg-blue-400-dark"
-      )}
-      style={{
-        left:
-          left === "0%" ? "5px" : left === "100%" ? "calc(100% - 5px)" : left,
-      }}
-    >
-      <div
-        className={cn(
-          "h-full w-full rounded-full",
-          active
-            ? "bg-olive-400 dark:bg-olive-400-dark"
-            : "bg-blue-400 dark:bg-blue-400-dark"
-        )}
-      />
+    <div className="flex items-center justify-center gap-1.5 text-gray-700 dark:text-gray-700-dark">
+      <FontAwesomeIcon icon={faHourglassHalf} className="text-[10px]" />
+      <p className="my-0 text-[10px] font-normal">{label}</p>
     </div>
   );
 }
@@ -274,26 +207,6 @@ function clamp01(x: number) {
   return Math.max(0, Math.min(1, x));
 }
 
-function pickResolveTs(nowTs: number, timeline: TournamentTimeline | null) {
-  const scheduled = safeTs(timeline?.latest_scheduled_resolve_time);
-  const actual = safeTs(timeline?.latest_actual_resolve_time);
-  const isAllResolved = Boolean(timeline?.all_questions_resolved);
-  let effectiveScheduled = scheduled;
-  if (effectiveScheduled && nowTs >= effectiveScheduled && !isAllResolved) {
-    effectiveScheduled = nowTs + ONE_DAY_MS;
-  }
-
-  return (isAllResolved ? actual : null) ?? effectiveScheduled ?? null;
-}
-
-function pickWinnersTs(resolvedTs: number | null, closeDate: string | null) {
-  const closeTs = safeTs(closeDate);
-  if (closeTs) return closeTs;
-  return resolvedTs ? resolvedTs + TWO_WEEKS_MS : null;
-}
-
-const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-const TWO_WEEKS_MS = 14 * ONE_DAY_MS;
 const JUST_STARTED_MS = 36 * 60 * 60 * 1000;
 
 export default LiveTournamentCard;


### PR DESCRIPTION
Resolves #4023

### Summary

Hides the timeline bar for closed tournaments in the Tournaments Hub and replaces it with a short descriptive status text alongside an hourglass icon, so closed tournaments no longer look like they're earlier in time than open ones.

Implemented changes:

* Changed the tournament card's display logic so that when a tournament is closed (`all_questions_closed` and past its forecasting/close date), it no longer renders the `ClosedMiniBar` timeline with progress chips.
* Added a new `ClosedStatus` component that renders an `faHourglassHalf` icon next to a short status label instead of the timeline: **"Pending resolutions"** when questions aren't all resolved, or **"Pending winners announcement"** once all questions are resolved.
* Removed the now-unused closed-timeline machinery (`ClosedMiniBar`, `ClosedChip`, `pickResolveTs`/`pickWinnersTs` helpers, and the `ONE_DAY_MS`/`TWO_WEEKS_MS` constants); open/ongoing tournaments keep the existing `ActiveMiniBar` timeline.
* Added the new `tournamentTimelinePendingWinners` translation key across all six message files (`en`, `es`, `cs`, `pt`, `zh`, `zh-TW`), reusing the existing `tournamentTimelineClosed` key for the "Pending resolutions" state.

<img width="246" height="228" alt="image" src="https://github.com/user-attachments/assets/948bcfd3-43b5-48f4-ab9d-95dd28c78680" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “pending winners announcement” status to tournament timelines.
* **Localization**
  * Updated tournament timeline text across multiple languages (English, Spanish, Portuguese, Czech, and Chinese variants).
* **UI Improvements**
  * Simplified the closed-tournament timeline display to use a clearer status label with an hourglass indicator when results are not yet available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->