### PR TITLE
Wrong dates are used on tournament tiles

### DIFF
--- a/front_end/src/components/promo_tiles/tile_status_row.tsx
+++ b/front_end/src/components/promo_tiles/tile_status_row.tsx
@@ -83,8 +83,8 @@ function getScheduledCloseTime(
   const rawCloseTime =
     rule === FeedTileRule.ALL_QUESTIONS_RESOLVED && projectResolutionDate
       ? projectResolutionDate
-      : project.close_date ??
-        project.forecasting_end_date ??
+      : project.forecasting_end_date ??
+        project.close_date ??
         project.start_date;
   const rawCloseTs = safeTs(rawCloseTime) ?? Date.now() + 1000;
   return new Date(Math.max(rawCloseTs, Date.now() + 1000)).toISOString();
@@ -102,7 +102,7 @@ function getStatusLabel(
   } = {}
 ): ReactNode | null {
   const now = Date.now();
-  const closeTs = safeTs(project.close_date);
+  const closeTs = safeTs(project.forecasting_end_date ?? project.close_date);
   const startTs = safeTs(project.start_date);
   const resolveTs = safeTs(projectResolutionDate);
 


### PR DESCRIPTION
Resolves #4994

### Summary

Fixes tournament tiles to use the forecasting end date instead of the close date.

Implemented changes:

* Use `forecasting_end_date` before `close_date` for the tile “Closes in …” label.
* Use the same date for the tile status icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling and status label logic to prioritize the forecasted end date when available, using the close date only as a fallback.
  * “Closed,” “closing,” and “resolving” labels now reflect the most relevant timestamp more accurately, reducing cases where the status could appear based on the less appropriate date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->