### PR TITLE
Question Approval Modal: change default CP reveal to `now + 3 days`

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/components/post_approval_modal.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/post_approval_modal.tsx
@@ -73,7 +73,7 @@ const PostApprovalModal: FC<{
     cp_reveal_time:
       initial_cp_reveal_time ??
       formatInTimeZone(
-        addDays(new Date(), 5),
+        addDays(new Date(), 3),
         "UTC",
         "yyyy-MM-dd'T'HH:mm:ss'Z'"
       ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default approval reveal time so new approvals now initialize to 3 days from the current date instead of 5 when no prior value is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->