### PR TITLE
feat(futureeval): add Summer 2026 to carousel and link to actual tournaments

### DIFF
--- a/front_end/src/app/(futureeval)/futureeval/components/futureeval-tournaments.tsx
+++ b/front_end/src/app/(futureeval)/futureeval/components/futureeval-tournaments.tsx
@@ -15,39 +15,45 @@ import { FE_COLORS, FE_TYPOGRAPHY } from "../theme";
 const FutureEvalTournaments: React.FC = () => {
   const CARDS_DATA = [
     {
-      title: "Spring 2026",
-      href: "/aib/2026/spring",
-      imgUrl: "https://cdn.metaculus.com/hires-spring.webp",
+      title: "Summer 2026",
+      href: "/tournament/summer-futureeval-2026/",
+      imgUrl: "https://cdn.metaculus.com/cover-summer_5fNCoRW.webp",
       prize: "$58,000",
       isLive: true,
     },
     {
+      title: "Spring 2026",
+      href: "/tournament/spring-aib-2026/",
+      imgUrl: "https://cdn.metaculus.com/hires-spring.webp",
+      prize: "$58,000",
+    },
+    {
       title: "Fall 2025",
-      href: "/aib/2025/fall",
+      href: "/tournament/fall-aib-2025/",
       imgUrl: "https://cdn.metaculus.com/aib-q3.webp",
       prize: "$58,000",
     },
     {
       title: "Q2 2025",
-      href: "/aib/2025/q2",
+      href: "/tournament/aibq2/",
       imgUrl: "https://cdn.metaculus.com/aib-q2.webp",
       prize: "$30,000",
     },
     {
       title: "Q1 2025",
-      href: "/aib/2025/q1",
+      href: "/tournament/aibq1/",
       imgUrl: "https://cdn.metaculus.com/2025-q1.webp",
       prize: "$30,000",
     },
     {
       title: "Q4 2024",
-      href: "/aib/2024/q4",
+      href: "/tournament/aibq4/",
       imgUrl: "https://cdn.metaculus.com/hires-q4.webp",
       prize: "$30,000",
     },
     {
       title: "Q3 2024",
-      href: "/aib/2024/q3",
+      href: "/tournament/aibq3/",
       imgUrl: "https://cdn.metaculus.com/hires-bw.webp",
       prize: "$30,000",
     },


### PR DESCRIPTION
Closes #4998.

## Summary

- Add Summer 2026 as the leading, live card in the FutureEval tournaments carousel, using the summer cover image from the tournament.
- Move `isLive` off Spring 2026 since Summer is the new live season.
- Point every carousel card at its actual `/tournament/<slug>/` page instead of the `/aib/*` archive pages.

## Notes for reviewers

- `aibq2` and `aibq3` are confirmed from `serviceConfig.ts` and `docs/openapi.yml` respectively; `aibq1` and `aibq4` follow the same convention but are worth a quick click-through.
- Prize for Summer 2026 is set to $58,000 matching the Spring 2026 season; adjust if different.
- I did not touch the `/aib/*` pager/page-views since no Summer 2026 archive page exists yet.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new live “Summer 2026” tournament entry.
  * Updated tournament links and images to newer tournament pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->