### PR TITLE
fix: labor hub commentary — Jobs Monitor 2030 decline callout

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -26,9 +26,9 @@ export const JOBS_INSIGHTS = {
     ),
     negative: (
       <>
-        By 2030, <strong>software developers</strong>,{" "}
-        <strong>sales representatives</strong>, and <strong>lawyers</strong> are
-        expected to see steep declines, as AI takes over their core tasks.
+        By 2030, <strong>software developers</strong>, <strong>lawyers</strong>,
+        and <strong>financial specialists</strong> are expected to see steep
+        declines, as AI takes over their core tasks.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-07-07">Jul 7</time>
+              Commentary last updated: <time dateTime="2026-07-08">Jul 8</time>
             </div>
           </div>
         </div>

--- a/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
@@ -125,10 +125,10 @@ export async function KeyInsightsSection({
             </>
           ) : (
             <>
-              Software developers, lawyers and law clerks, and sales
+              Financial specialists, lawyers and law clerks, and sales
               representatives are all expected to see the largest decreases in
-              employment rates, while registered nurses, restaurant servers, and
-              physicians are projected to grow.
+              employment rates, while registered nurses, physicians, and
+              engineers are projected to grow.
             </>
           )}
         </KeyInsightItem>


### PR DESCRIPTION
## Summary

Automated QA pass over `/labor-hub`, cross-referencing chart/table data (including the Jobs Monitor's 2027/2030/2035 tabs) against the surrounding commentary text. Found and fixed two stale-copy issues where a named occupation no longer matched the underlying forecast data.

### Fixes

**Jobs Monitor — "by 2030" decline callout** (`jobs_insights.tsx`)
- Before: *"By 2030, **software developers**, **sales representatives**, and **lawyers** are expected to see steep declines..."*
- After: *"By 2030, **software developers**, **lawyers**, and **financial specialists** are expected to see steep declines..."*
- Why: For 2030, Financial Specialists (-6.1%) decline more than Sales Representatives (-5.9%), so Sales Representatives isn't actually one of the top-3 decliners for that year.

**Key Insights — fallback copy** (`sections/key_insights.tsx`, only rendered if the live forecast data fails to load)
- Before: *"Software developers, lawyers and law clerks, and sales representatives are all expected to see the largest decreases in employment rates, while registered nurses, restaurant servers, and physicians are projected to grow."*
- After: *"Financial specialists, lawyers and law clerks, and sales representatives are all expected to see the largest decreases in employment rates, while registered nurses, physicians, and engineers are projected to grow."*
- Why: This static fallback text is meant to mirror the 2035 extremes. The actual top-3 decliners for 2035 are Financial Specialists, Lawyers, and Sales Representatives (not Software Developers), and the top-3 growers are Nurses, Physicians, and Engineers (not Restaurant Servers, which is the smallest 2035 gain).

Also bumped the "Commentary last updated" date (`sections/hero.tsx`).

Only commentary text was changed — no chart data, component structure, or unrelated code was touched.

## Test plan
- [x] `bun run eslint` on the changed files — no errors
- [x] `bun run tsc --noEmit` — no errors in the labor-hub area
- [x] `bun run prettier --write` on the changed files
- [x] Verified the new occupation rankings against the live Jobs Monitor dataset (2027/2030/2035 values) fetched from metaculus.com/labor-hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7P8dH6EVB7Mm8TnQd6XkJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7P8dH6EVB7Mm8TnQd6XkJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated labor market insight copy to reflect revised occupation forecasts and list formatting.
  * Adjusted fallback insight text for more current “largest decreases” and “projected to grow” examples.
  * Refreshed the displayed “Commentary last updated” date to Jul 8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->