### PR TITLE
feat: link tournament scoring FAQ from unfinalized prize tooltip

### DIFF
--- a/front_end/src/app/(main)/(leaderboards)/leaderboard/components/prize_unfinalized_tooltip.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/leaderboard/components/prize_unfinalized_tooltip.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { FC } from "react";
 
@@ -12,7 +13,17 @@ const UnfinalizedPrizeTooltip: FC = () => {
         <Tooltip
           showDelayMs={200}
           placement={"right"}
-          tooltipContent={t("unfinalizedPrizeTooltip")}
+          tooltipContent={
+            <div>
+              <p className="m-0">{t("unfinalizedPrizeTooltip")}</p>
+              <Link
+                href="/help/scores-faq/#tournaments-section"
+                className="mt-2 inline-block text-blue-700 dark:text-blue-700-dark"
+              >
+                {t("learnMoreFAQ")}
+              </Link>
+            </div>
+          }
           className="absolute left-0 top-1/2 inline-flex -translate-y-1/2 items-center justify-center font-sans text-base leading-none"
           variant="light"
           tooltipClassName="font-sans text-center"


### PR DESCRIPTION
Adds a "Learn more in our FAQ" link underneath the "This tournament is ongoing…" text on the tournament leaderboard prize tooltip, deep-linking to `/help/scores-faq/#tournaments-section`.

Reuses the existing `learnMoreFAQ` i18n key (already translated in en/cs/pt/es/zh/zh-TW), following the pattern established by `medal_rank_info_tooltip.tsx`.

Resolves #2227

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the leaderboard prize tooltip to include a “learn more” link to the Scores FAQ for additional context.
  * Expanded the tooltip content to present the message in a more helpful, user-friendly format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->