### PR TITLE
fix: reglue whitespace between ] and ( in translated markdown links

### DIFF
--- a/utils/translation.py
+++ b/utils/translation.py
@@ -4,6 +4,7 @@ import hashlib
 import html
 import json
 import logging
+import re
 from datetime import datetime
 import time
 
@@ -110,6 +111,11 @@ async def agoogle_translate_text(source_language, target_language, text):
                 # See the comment above with the new lines
                 output = output.replace("<br>", "\n")
                 output = html.unescape(output)
+                # Google Translate (in its default HTML mode) frequently inserts
+                # whitespace between the `]` and `(` of markdown inline links,
+                # e.g. `[text](url)` -> `[text] (url)`, which breaks link parsing
+                # in the frontend markdown renderer. Reglue that seam.
+                output = re.sub(r"\]\s+\(", "](", output)
                 return output
             else:
                 error = await response.text()


### PR DESCRIPTION
## Summary

Google Translate (running in its default HTML mode, because `mimeType` is mis-set as an HTTP header rather than a JSON body field) frequently inserts whitespace between the `]` and `(` of markdown inline links, turning `[text](url)` into `[text] (url)`. CommonMark requires no whitespace between `]` and `(`, so the frontend renders them as literal text plus a bare URL — no clickable link. This is visible on Spanish-first questions like #/35557.

This is the minimal "fix #2" from the investigation on issue #2299: after `html.unescape()`, run `re.sub(r"\]\\\s+\(", "](", output)` to reglue the seam. It does not address other markdown mangling or the underlying misplaced `mimeType` header — those are left for the longer-term refactor.

Fixes #2299

## Test plan

- [ ] Re-translate a Spanish-first question with inline markdown links (e.g. /35557) and confirm the English version renders anchors instead of literal `[text] (url)`.
- [ ] Sanity-check that plain parenthesized phrases unrelated to markdown are unaffected (the regex only matches `]` followed by whitespace followed by `(`).

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translated text cleanup to preserve Markdown inline links.
  * Removed extra whitespace that could appear between link text and URLs, so links remain properly formatted after translation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->