### PR TITLE
fix: labor hub commentary — Jobs Monitor 2030/2035 decline callouts

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -26,8 +26,9 @@ export const JOBS_INSIGHTS = {
     ),
     negative: (
       <>
-        By 2030, <strong>software developers</strong>, <strong>lawyers</strong>,
-        and <strong>financial specialists</strong> are expected to see steep
+        By 2030, <strong>software developers</strong>,{" "}
+        <strong>financial specialists</strong>, and{" "}
+        <strong>sales representatives</strong> are expected to see steep
         declines, as AI takes over their core tasks.
       </>
     ),
@@ -42,12 +43,12 @@ export const JOBS_INSIGHTS = {
     ),
     negative: (
       <>
-        By 2035, <strong>financial specialists</strong>, <strong>sales</strong>{" "}
-        and <strong>law</strong> are expected to see sharp staff reductions as
-        AI systems take over large portions of financial analysis, outreach, and
-        detailed research work, while <strong>construction workers</strong> see
-        little change as robotics have yet to fully displace physical roles by
-        this horizon.
+        By 2035, <strong>financial specialists</strong>,{" "}
+        <strong>lawyers</strong>, and <strong>laborers and movers</strong> are
+        expected to see sharp staff reductions as AI and automation take over
+        large portions of financial analysis, legal research, and physical labor
+        tasks, while <strong>construction workers</strong> see little change as
+        robotics have yet to fully displace physical roles by this horizon.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-07-08">Jul 8</time>
+              Commentary last updated: <time dateTime="2026-07-10">Jul 10</time>
             </div>
           </div>
         </div>

--- a/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
@@ -125,10 +125,10 @@ export async function KeyInsightsSection({
             </>
           ) : (
             <>
-              Financial specialists, lawyers and law clerks, and sales
-              representatives are all expected to see the largest decreases in
-              employment rates, while registered nurses, physicians, and
-              engineers are projected to grow.
+              Financial specialists, lawyers and law clerks, and laborers and
+              movers are all expected to see the largest decreases in employment
+              rates, while registered nurses, physicians, and engineers are
+              projected to grow.
             </>
           )}
         </KeyInsightItem>

--- a/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
@@ -125,10 +125,10 @@ export async function KeyInsightsSection({
             </>
           ) : (
             <>
-              Financial specialists, lawyers and law clerks, and laborers and
-              movers are all expected to see the largest decreases in employment
-              rates, while registered nurses, physicians, and engineers are
-              projected to grow.
+              Financial specialists, lawyers, and laborers and movers are all
+              expected to see the largest decreases in employment rates, while
+              registered nurses, physicians, and engineers are projected to
+              grow.
             </>
           )}
         </KeyInsightItem>


### PR DESCRIPTION
## Summary

Automated QA pass on `/labor-hub` cross-referencing chart data against commentary text. Found and fixed 2 misalignments in the Jobs Monitor's static decline callouts, where the named occupations no longer matched the actual top-3 decliners in the live forecast data (fetched 2026-07-10).

- **Jobs Monitor — 2030 decline callout** (`jobs_insights.tsx`)
  - Before: "By 2030, **software developers**, **lawyers**, and **financial specialists** are expected to see steep declines..."
  - Chart data: Software Developers (-7.6%), Financial Specialists (-6.4%), **Services Sales Representatives (-5.9%)**, Lawyers and Law Clerks (-5.7%). Sales representatives decline more than lawyers, so lawyers shouldn't be in the top 3.
  - After: "By 2030, **software developers**, **financial specialists**, and **sales representatives** are expected to see steep declines..."

- **Jobs Monitor — 2035 decline callout** (`jobs_insights.tsx`)
  - Before: "By 2035, **financial specialists**, **sales** and **law** are expected to see sharp staff reductions..."
  - Chart data: Financial Specialists (-15.2%), Lawyers and Law Clerks (-14.4%), **Laborers and Movers (-12.3%)**, Services Sales Representatives (-11.9%). Laborers and movers decline more than sales representatives, so sales shouldn't be in the top 3. This also matches the page's own dynamic "most vulnerable" computation (`getTopExtremeJobsForYear`), which already surfaces financial specialists, lawyers, and laborers and movers elsewhere on the page (Overview vulnerability chart, Key Insights).
  - After: "By 2035, **financial specialists**, **lawyers**, and **laborers and movers** are expected to see sharp staff reductions..."

- **Key Insights fallback copy** (`key_insights.tsx`, only rendered if the live data fetch fails)
  - Before: "Financial specialists, lawyers and law clerks, and sales representatives are all expected to see the largest decreases..."
  - After: "Financial specialists, lawyers and law clerks, and laborers and movers are all expected to see the largest decreases..." (matches the live-data-driven text shown in the normal case)

- Bumped "Commentary last updated" date in `hero.tsx` to today.

All other sections (Overall Employment, Wages, Graduates, Economy, State-Level View, Research comparison table) were checked and their commentary already matches the underlying chart data.

## Test plan

- [x] `npx prettier --write` on changed files
- [x] `npx eslint` on changed files — no errors
- [x] Verified new occupation rankings against live forecast data extracted from the site's SSR payload (Next.js RSC data), covering the default (2035) view plus 2027 and 2030 Jobs Monitor toggles


---
_Generated by [Claude Code](https://claude.ai/code/session_01QM6QwrNcUtFnb3omksvJ7J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Content Updates**
  * Updated the 2030 and 2035 job outlook commentary with revised role-specific projections, including replacing “lawyers” with “sales representatives” for 2030.
  * Rewrote the 2035 negative outlook to broaden affected roles and clarify expected impacts across financial analysis, legal research, and physical labor tasks.
  * Updated fallback “most and least vulnerable occupations” text to include laborers and movers in the largest-decrease group.
  * Refreshed the “Commentary last updated” timestamp to July 10, 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->