### PR TITLE
content: labor hub copy updates for Jobs Monitor, Wages, Graduates

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -17,11 +17,11 @@ export const JOBS_INSIGHTS = {
   "2030": {
     positive: (
       <>
-        By 2030, <strong>nurses</strong>,{" "}
-        <strong>construction workers</strong>, and <strong>engineers</strong>{" "}
-        are expected to see the largest gains. Demand is rising, from an aging
-        population, and from data center and energy infrastructure buildouts,
-        while robotics is not yet expected to handle unstructured worksites.
+        By 2030, <strong>nurses</strong>, <strong>construction workers</strong>,
+        and <strong>engineers</strong> are expected to see the largest gains.
+        Demand is rising, from an aging population, and from data center and
+        energy infrastructure buildouts, while robotics is not yet expected to
+        handle unstructured worksites.
       </>
     ),
     negative: (
@@ -45,10 +45,10 @@ export const JOBS_INSIGHTS = {
     ),
     negative: (
       <>
-        By 2035, <strong>financial specialists</strong>,{" "}
-        <strong>sales</strong>, and <strong>law</strong> are expected to see
-        sharp staff reductions as AI takes over analysis, outreach, and research
-        work. <strong>Laborers and movers</strong> will also see reductions as
+        By 2035, <strong>financial specialists</strong>, <strong>sales</strong>,
+        and <strong>law</strong> are expected to see sharp staff reductions as
+        AI takes over analysis, outreach, and research work.{" "}
+        <strong>Laborers and movers</strong> will also see reductions as
         robotics automates work in controlled indoor environments.
       </>
     ),

--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -17,38 +17,39 @@ export const JOBS_INSIGHTS = {
   "2030": {
     positive: (
       <>
-        By 2030, roles in <strong>food service</strong>,{" "}
-        <strong>construction</strong>, and <strong>healthcare</strong> are
-        expected to grow due to demand for in-person service, infrastructure
-        buildouts, and an aging population that AI is unlikely to displace in
-        the short-term.
+        By 2030, <strong>nurses</strong>,{" "}
+        <strong>construction workers</strong>, and <strong>engineers</strong>{" "}
+        are expected to see the largest gains. Demand is rising, from an aging
+        population, and from data center and energy infrastructure buildouts,
+        while robotics is not yet expected to handle unstructured worksites.
       </>
     ),
     negative: (
       <>
         By 2030, <strong>software developers</strong>,{" "}
-        <strong>financial specialists</strong>, and{" "}
-        <strong>sales representatives</strong> are expected to see steep
-        declines, as AI takes over their core tasks.
+        <strong>financial specialists</strong>, and <strong>sales</strong> are
+        expected to see the largest declines as AI absorbs coding, rules-based
+        analysis, and outreach. Software development leads the drop, with rapid
+        AI adoption and no legal protections.
       </>
     ),
   },
   "2035": {
     positive: (
       <>
-        By 2035, <strong>nurses</strong>, <strong>physicians</strong>, and{" "}
-        <strong>engineers</strong> are expected to see the highest growth,
-        driven by hands-on needs that cannot be easily automated.
+        By 2035, <strong>nurses</strong> and <strong>physicians</strong> are
+        expected to see the highest growth, driven by high demand from an aging
+        population, while liability concerns and lack of trust in AI limit
+        automation.
       </>
     ),
     negative: (
       <>
         By 2035, <strong>financial specialists</strong>,{" "}
-        <strong>lawyers</strong>, and <strong>laborers and movers</strong> are
-        expected to see sharp staff reductions as AI and automation take over
-        large portions of financial analysis, legal research, and physical labor
-        tasks, while <strong>construction workers</strong> see little change as
-        robotics have yet to fully displace physical roles by this horizon.
+        <strong>sales</strong>, and <strong>law</strong> are expected to see
+        sharp staff reductions as AI takes over analysis, outreach, and research
+        work. <strong>Laborers and movers</strong> will also see reductions as
+        robotics automates work in controlled indoor environments.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -198,7 +198,7 @@ export default function LaborAutomationHubPage() {
               </span>
               , <strong>median wages are expected to grow.</strong> The workweek
               is also expected to become{" "}
-              <strong>about four hours shorter by 2035</strong> among all
+              <strong>about three hours shorter by 2035</strong> among all
               workers, while productivity grows.
             </ContentParagraph>
             <ContentParagraph>
@@ -453,22 +453,21 @@ export default function LaborAutomationHubPage() {
               <strong>more than doubled</strong> in 2035 compared to 2025.
             </ContentParagraph>
             <ContentParagraph>
-              The number of degrees awarded for STEM is expected to see only
-              minor change due to the long gestation time, while overall 4-year
-              degrees are expected to see a modest decline and humanities
-              degrees are expected to see a more substantial decline by 2035.
-              Trade schools and community colleges are expected to see
-              significant growth in degrees and certificates awarded by 2035.
+              Four-year degrees are expected to decline modestly by 2035, with
+              humanities falling substantially and STEM increasingly too, led by
+              computer science, while trade schools and community colleges see
+              significant growth in degrees and certificates awarded.
             </ContentParagraph>
           </DualPaneSectionLeft>
           <DualPaneSectionRight className="lg:mt-24 print:mt-12">
             <ContentParagraph small>
-              The rise of AI is threatening to accelerate an already-looming
-              decline in 4-year college enrollment, as fewer high school
-              graduates and shrinking job prospects for degree-holders could
-              combine to reshape the future of higher education. At the same
-              time, enrollment in community colleges and trade schools is
-              expected to increase.
+              Fewer Americans are expected to earn four-year degrees over the
+              next decade. Shrinking cohorts after the post-2007 birth drop and
+              years of falling enrollment drive the decline; AI compounds it by
+              making students doubt that degrees in automatable fields will lead
+              to jobs, though students already enrolled delay its effect until
+              after 2030. Computer science is expected to be hit hardest, while
+              humanities continue their long slide.
             </ContentParagraph>
             <FlippableMultiQuestionCard
               prefer="timeline"


### PR DESCRIPTION
Refreshes labor hub copy per #issue-5009:

- Jobs Monitor: rewrites the 2030 and 2035 positive/negative insight callouts.
- Hours, Pay, and Financial Well-Being: workweek shortens by ~three hours (was four) by 2035.
- Impact on the Next Generation of Workers: rewrites both the left and right graduates paragraphs to emphasize demographic drivers and computer science's outsized decline.

Closes #5009

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Content Updates**
  * Refined 2030 and 2035 job outlook messaging, updating which roles are expected to grow or decline and the drivers behind those trends, including clarifications around limits and impacts of automation and AI.
  * Updated the Wages section workweek reduction by 2035 to approximately three hours.
  * Revised Graduates/education insights to emphasize shrinking cohorts, enrollment changes, delayed effects beyond 2030, and field-specific differences (with computer science highlighted).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->