### PR TITLE
Temporarily allow CSP eval and fix GA reports

### DIFF
--- a/front_end/src/utils/csp.ts
+++ b/front_end/src/utils/csp.ts
@@ -26,12 +26,14 @@ export function buildCsp(nonce: string): string {
 
   const sentryHost = getSentryHost(PUBLIC_FRONTEND_SENTRY_DSN);
 
-  // Next dev needs eval for source maps/react-refresh and WebSockets for HMR.
+  // Next dev needs WebSockets for HMR.
   const isDev = process.env.NODE_ENV !== "production";
+  // Temporary: allow eval while existing eval-based forecast code is being replaced.
+  const unsafeEval = " 'unsafe-eval'";
 
   const directives = [
     `default-src 'self'`,
-    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'unsafe-inline' https:${isDev ? " 'unsafe-eval'" : ""}`,
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'unsafe-inline' https:${unsafeEval}`,
     // React style={{}} props and user-authored <style> tags in markdown
     // require 'unsafe-inline' (accepted tradeoff, script-src stays strict)
     `style-src 'self' 'unsafe-inline'`,
@@ -47,7 +49,7 @@ export function buildCsp(nonce: string): string {
       isDev ? `ws: wss:` : "",
       PUBLIC_POSTHOG_BASE_URL,
       sentryHost ? `https://${sentryHost}` : `https://*.ingest.sentry.io`,
-      `https://www.google-analytics.com https://*.analytics.google.com`,
+      `https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://www.google.com`,
       // marketing pixel beacons
       `https://www.facebook.com https://px.ads.linkedin.com https://pixel-config.reddit.com`,
     ]


### PR DESCRIPTION
### Summary

Temporarily allows eval in the Report-Only CSP policy to stop known noisy eval reports from burning Sentry quota while the proper forecast-code fix is being prepared. Also allows confirmed Google Analytics collection endpoints reported from production.

Implemented changes:

* utils/csp.ts: temporarily adds 'unsafe-eval' to script-src so known eval usage no longer generates CSP Report-Only violations. 
* utils/csp.ts: expands connect-src to allow confirmed Google Analytics endpoints, including regional \*.google-analytics.com and www.google.com beacon requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security policy settings to support WebSocket development workflows.
  * Expanded approved analytics and Google domains for script loading.
  * Preserved reporting-only security policy behavior while improving compatibility with supported services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->