### PR TITLE
fix: labor hub commentary — Jobs Monitor callouts drift again

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -18,10 +18,10 @@ export const JOBS_INSIGHTS = {
     positive: (
       <>
         By 2030, <strong>nurses</strong>, <strong>construction workers</strong>,
-        and <strong>engineers</strong> are expected to see the largest gains.
-        Demand is rising, from an aging population, and from data center and
-        energy infrastructure buildouts, while robotics is not yet expected to
-        handle unstructured worksites.
+        and <strong>restaurant servers</strong> are expected to see the largest
+        gains, driven by an aging population, infrastructure buildouts, and
+        continued demand for in-person service that AI is unlikely to displace
+        in the short term.
       </>
     ),
     negative: (
@@ -45,11 +45,13 @@ export const JOBS_INSIGHTS = {
     ),
     negative: (
       <>
-        By 2035, <strong>financial specialists</strong>, <strong>sales</strong>,
-        and <strong>law</strong> are expected to see sharp staff reductions as
-        AI takes over analysis, outreach, and research work.{" "}
-        <strong>Laborers and movers</strong> will also see reductions as
-        robotics automates work in controlled indoor environments.
+        By 2035, <strong>financial specialists</strong>,{" "}
+        <strong>lawyers and law clerks</strong>, and{" "}
+        <strong>laborers and movers</strong> are expected to see sharp staff
+        reductions as AI takes over analysis and research work while robotics
+        automates tasks in controlled indoor environments.{" "}
+        <strong>Sales representatives</strong> will also see reductions as AI
+        automates outreach and client work.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-07-10">Jul 10</time>
+              Commentary last updated: <time dateTime="2026-07-13">Jul 13</time>
             </div>
           </div>
         </div>

--- a/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/key_insights.tsx
@@ -127,8 +127,8 @@ export async function KeyInsightsSection({
             <>
               Financial specialists, lawyers, and laborers and movers are all
               expected to see the largest decreases in employment rates, while
-              registered nurses, physicians, and engineers are projected to
-              grow.
+              registered nurses, physicians, and law enforcement are projected
+              to grow.
             </>
           )}
         </KeyInsightItem>


### PR DESCRIPTION
## Summary

Automated QA pass over the [Labor Automation Forecasting Hub](https://www.metaculus.com/labor-hub) comparing chart/table data against the static commentary copy. Found that the Jobs Monitor callouts have drifted from the live forecast data again — the same class of issue #5007 fixed, reintroduced by the #5011 copy refresh.

- **Jobs Monitor — 2030 growth callout**: named `nurses, construction workers, and engineers` as the largest gainers → **restaurant servers** now grow more than engineers, so engineers shouldn't be in the top 3. Now reads `nurses, construction workers, and restaurant servers`.
- **Jobs Monitor — 2035 decline callout**: named `financial specialists, sales, and law` as the sharpest decliners → **laborers and movers** now decline more than sales representatives, so sales shouldn't be in the top 3. Now reads `financial specialists, lawyers and law clerks, and laborers and movers`, with sales representatives moved to a secondary sentence.
- **Key Insights no-data fallback copy**: same stale `engineers` reference in the growth list → replaced with `law enforcement` to match the current top-3 gainers, consistent with the decline list already shown there.
- Bumped the "Commentary last updated" date to Jul 13.

Only copy was changed — no chart data, component structure, or unrelated code was touched. No detailed percentages were added to the commentary, consistent with existing style.

## Test plan

- [x] `prettier --check` on changed files
- [x] `eslint` on changed files
- [x] Verified new top-3 rankings against the live RSC-embedded forecast data for each year (2027/2030/2035)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YZCN4nSi4fWwttmxurU1RG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Refined labor market outlook narratives for 2030 and 2035, including updated occupation trends.
  * Updated fallback insights to highlight law enforcement, registered nurses, and physicians among projected growth areas.
  * Refreshed the commentary timestamp to July 13, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->