### PR TITLE
Add "Commented" option to My Participation feed filters

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -185,6 +185,7 @@
   "searchOptionAny": "Jakákoliv",
   "searchOptionPredicted": "Predikováno",
   "searchOptionNotPredicted": "Nepredikováno",
+  "searchOptionCommented": "Komentováno",
   "searchOptionAuthored": "Vlastní",
   "searchOptionUpvoted": "Obodované",
   "searchOptionPrivate": "Privátní",

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -357,6 +357,7 @@
   "searchOptionActivePrediction": "Active Prediction",
   "searchOptionWithdrawnPrediction": "Withdrawn",
   "searchOptionNotPredicted": "Not Predicted",
+  "searchOptionCommented": "Commented",
   "searchOptionAuthored": "Authored",
   "searchOptionUpvoted": "Upvoted",
   "searchOptionPrivate": "Private",

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -185,6 +185,7 @@
   "searchOptionAny": "Cualquiera",
   "searchOptionPredicted": "Predicho",
   "searchOptionNotPredicted": "No Predicho",
+  "searchOptionCommented": "Comentado",
   "searchOptionAuthored": "Autorizado",
   "searchOptionUpvoted": "Votado positivamente",
   "searchOptionPrivate": "Privado",

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -207,6 +207,7 @@
   "searchOptionAny": "Qualquer",
   "searchOptionPredicted": "Previsto",
   "searchOptionNotPredicted": "Não Previsto",
+  "searchOptionCommented": "Comentado",
   "searchOptionAuthored": "Autorado",
   "searchOptionUpvoted": "Votado Positivamente",
   "searchOptionPrivate": "Privado",

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -227,6 +227,7 @@
   "searchOptionActivePrediction": "活躍的預測",
   "searchOptionWithdrawnPrediction": "已撤回",
   "searchOptionNotPredicted": "未預測",
+  "searchOptionCommented": "已評論",
   "searchOptionAuthored": "已創作",
   "searchOptionUpvoted": "已點贊",
   "searchOptionPrivate": "私人",

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -191,7 +191,7 @@
   "searchOptionAny": "任何",
   "searchOptionPredicted": "已預測",
   "searchOptionNotPredicted": "未預測",
-  "searchOptionCommented": "已評論",
+  "searchOptionCommented": "已评论",
   "searchOptionAuthored": "創作",
   "searchOptionUpvoted": "點贊",
   "searchOptionPrivate": "私有",

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -191,6 +191,7 @@
   "searchOptionAny": "任何",
   "searchOptionPredicted": "已預測",
   "searchOptionNotPredicted": "未預測",
+  "searchOptionCommented": "已評論",
   "searchOptionAuthored": "創作",
   "searchOptionUpvoted": "點贊",
   "searchOptionPrivate": "私有",

--- a/front_end/src/app/(main)/questions/helpers/filters.ts
+++ b/front_end/src/app/(main)/questions/helpers/filters.ts
@@ -390,6 +390,13 @@ export function getFilterSectionParticipation({
         active: !!params.get(POST_UPVOTED_BY_FILTER),
         isPersisted: true,
       },
+      {
+        id: POST_COMMENTED_BY_FILTER,
+        label: t("searchOptionCommented"),
+        value: user.id.toString(),
+        active: !!params.get(POST_COMMENTED_BY_FILTER),
+        isPersisted: true,
+      },
     ],
   };
 }

--- a/posts/models.py
+++ b/posts/models.py
@@ -190,6 +190,24 @@ class PostQuerySet(models.QuerySet):
             )
         )
 
+    def filter_user_has_commented(self, author_id: int):
+        """
+        Filter to posts where user has commented.
+        Uses EXISTS which is more efficient than annotate + filter IS NOT NULL.
+        """
+        # Local import: comments.models imports Post
+        from comments.models import Comment
+
+        return self.filter(
+            Exists(
+                Comment.objects.filter(
+                    on_post_id=OuterRef("pk"),
+                    author_id=author_id,
+                    is_soft_deleted=False,
+                )
+            )
+        )
+
     def annotate_has_active_forecast(self, author_id: int):
         """
         Annotates if user has active forecast for post

--- a/posts/serializers.py
+++ b/posts/serializers.py
@@ -228,6 +228,7 @@ class PostFilterSerializer(SerializerKeyLookupMixin, serializers.Serializer):
     not_forecaster_id = serializers.IntegerField(required=False, allow_null=True)
     similar_to_post_id = serializers.IntegerField(required=False, allow_null=True)
     upvoted_by = serializers.IntegerField(required=False, allow_null=True)
+    commented_by = serializers.IntegerField(required=False, allow_null=True)
 
     search = serializers.CharField(required=False, allow_null=True)
     for_main_feed = serializers.BooleanField(required=False, allow_null=True)

--- a/posts/services/feed.py
+++ b/posts/services/feed.py
@@ -48,6 +48,7 @@ def get_posts_feed(  # noqa: C901
     show_on_homepage: bool = None,
     following: bool = None,
     upvoted_by: int = None,
+    commented_by: int = None,
     **kwargs,
 ) -> Post.objects:
     """
@@ -59,6 +60,9 @@ def get_posts_feed(  # noqa: C901
         raise PermissionDenied()
 
     if not_forecaster_id and (not user or not_forecaster_id != user.id):
+        raise PermissionDenied()
+
+    if commented_by and (not user or commented_by != user.id):
         raise PermissionDenied()
 
     if qs is None:
@@ -216,6 +220,9 @@ def get_posts_feed(  # noqa: C901
             votes__user=upvoted_by,
             votes__direction=Vote.VoteDirection.UP,
         )
+
+    if commented_by:
+        qs = qs.filter_user_has_commented(commented_by)
 
     # Followed posts
     if user and user.is_authenticated and following:

--- a/tests/unit/test_posts/test_services/test_feed.py
+++ b/tests/unit/test_posts/test_services/test_feed.py
@@ -5,6 +5,7 @@ from rest_framework.exceptions import PermissionDenied
 from posts.models import PostUserSnapshot, Post
 from posts.services.feed import get_posts_feed
 from questions.models import Question
+from tests.unit.test_comments.factories import factory_comment
 from tests.unit.test_posts.factories import factory_post
 from tests.unit.test_questions.factories import create_question, factory_forecast
 from tests.unit.utils import datetime_aware
@@ -39,6 +40,40 @@ def test_get_posts_feed__forecaster_id(user1, user2):
 
     with pytest.raises(PermissionDenied):
         get_posts_feed(user=user2, forecaster_id=user1.id)
+
+
+def test_get_posts_feed__commented_by(user1, user2):
+    post_1 = factory_post(
+        author=user1,
+        question=create_question(question_type=Question.QuestionType.BINARY),
+    )
+    post_2 = factory_post(
+        author=user1,
+        question=create_question(question_type=Question.QuestionType.BINARY),
+    )
+    post_3 = factory_post(
+        author=user1,
+        question=create_question(question_type=Question.QuestionType.BINARY),
+    )
+
+    factory_comment(author=user1, on_post=post_1)
+    factory_comment(author=user2, on_post=post_2)
+    # Soft-deleted comments don't count
+    factory_comment(author=user1, on_post=post_3, is_soft_deleted=True)
+
+    posts = get_posts_feed(user=user1, commented_by=user1.id)
+    assert len(posts) == 1
+    assert posts[0].id == post_1.id
+
+    posts = get_posts_feed(user=user2, commented_by=user2.id)
+    assert len(posts) == 1
+    assert posts[0].id == post_2.id
+
+    with pytest.raises(PermissionDenied):
+        get_posts_feed(user=user1, commented_by=user2.id)
+
+    with pytest.raises(PermissionDenied):
+        get_posts_feed(user=None, commented_by=user1.id)
 
 
 @freeze_time("2025-01-10")


### PR DESCRIPTION
## What

Adds a **"Commented"** toggle to the **My Participation** section of the Question Feed filter overlay (logged-in users only). When active, the feed shows only posts the user has commented on.

## Why

The filter section covered Predicted / Not Predicted / Followed / Upvoted, but had no way to find questions you've participated in via comments.

## Changes

**Backend** (net-new — the API had no `commented_by` support):
- `PostFilterSerializer`: new `commented_by` int param
- `PostQuerySet.filter_user_has_commented()`: `EXISTS` semi-join over non-soft-deleted comments, mirroring `filter_user_has_forecasted`
- `get_posts_feed()`: applies the filter; raises `PermissionDenied` unless the ID matches the logged-in user (same policy as `forecaster_id` / `not_forecaster_id`)
- New test `test_get_posts_feed__commented_by` (positive match, other-user data excluded, soft-deleted comments ignored, 403 for other/anonymous users)

**Frontend**:
- New "Commented" chip in `getFilterSectionParticipation` (`filters.ts`), behaving like Upvoted/Followed (`isPersisted`)
- `searchOptionCommented` translation key added to all six locale files

## Investigation notes

- The frontend `commented_by` plumbing (URL param constant, query parser, `PostsParams` type, search-params→API mapping) **already existed end-to-end** — only the UI chip and the backend were missing. History: 50ca4fa98 (June 2024) originally shipped a `COMMENTED_BY_FILTER` chip (mislabeled with the "moderating" translation) against a backend param that was never implemented; the chip was later removed but the plumbing survived. This PR completes that abandoned feature.
- Considered reusing the existing comments API (`/api/comments/?author=<id>`, used by profile pages) instead of a backend change — not viable: it returns paginated *comments*, not posts, so it can't compose with feed filters/ordering/pagination (and prolific users have 20k+ comments).
- `PostUserSnapshot.comments_count` also isn't reusable — it stores the comment count at last view (unread tracking), not authorship.
- Query performance: the existing composite index `comment_user_private_post_idx (author, is_private, on_post)` covers the semi-join via its `author` prefix; no new index needed.

## Testing

- `pytest tests/unit/test_posts/test_services/test_feed.py` passes; ruff + frontend lint/build clean
- Verified against a local DB: authenticated `?commented_by=<own id>` returns only posts with that user's live comments (spot-checked against the Comment table); other user's ID and anonymous requests both return 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Commented” filter option to the search UI.
  * Feed filtering now supports showing only posts the authenticated user has commented on.
  * Added localized “Commented” labels for Czech, English, Spanish, Portuguese, Simplified Chinese, and Traditional Chinese.

* **Bug Fixes**
  * Ensures results exclude soft-deleted comments.
  * Prevents unauthorized access to another user’s “commented” feed.

* **Tests**
  * Added coverage for `commented_by` feed filtering and permission handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->