### PR TITLE
Add GPT-5.6 preview news item to labor hub activity monitor

### DIFF
--- a/front_end/src/app/(main)/labor-hub/activity_data.tsx
+++ b/front_end/src/app/(main)/labor-hub/activity_data.tsx
@@ -253,4 +253,22 @@ export const RAW_ACTIVITY_MONITOR_DATA: RawActivityMonitorEntry[] = [
       </>
     ),
   },
+  {
+    date: "2026-06-26",
+    type: "news",
+    content: (
+      <>
+        OpenAI announces that it is previewing its latest model series, GPT-5.6,
+        with a small group of trusted partners, while delaying a broader rollout
+        at the request of the US government. -{" "}
+        <a
+          href="https://openai.com/index/previewing-gpt-5-6-sol/"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          OpenAI
+        </a>
+      </>
+    ),
+  },
 ];


### PR DESCRIPTION
Adds a news item for 2026-06-26 to the labor hub activity monitor covering OpenAI's GPT-5.6 preview announcement.

Closes #5020

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new activity feed update highlighting OpenAI’s preview of GPT-5.6 with trusted partners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->