### PR TITLE
Tournament bot appearance fixes

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/components/participation_block.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/components/participation_block.tsx
@@ -51,6 +51,7 @@ const ParticipationBlock: FC<Props> = ({ tournament, posts }) => {
 
   if (
     isNil(user) ||
+    user.is_bot ||
     !tournament.forecasts_flow_enabled ||
     tournament.timeline.all_questions_closed
   ) {

--- a/front_end/src/app/(main)/(tournaments)/tournament/components/prediction_flow_button.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/components/prediction_flow_button.tsx
@@ -22,7 +22,7 @@ const PredictionFlowButton: React.FC<Props> = ({ tournament }) => {
     tournament.forecasts_flow_enabled &&
     !tournament.timeline.all_questions_closed;
 
-  if (!isForecastsFlowEnabled || isNil(user)) {
+  if (!isForecastsFlowEnabled || isNil(user) || user.is_bot) {
     return null;
   }
 

--- a/front_end/src/app/(prediction-flow)/tournament/[slug]/prediction-flow/page.tsx
+++ b/front_end/src/app/(prediction-flow)/tournament/[slug]/prediction-flow/page.tsx
@@ -49,6 +49,7 @@ export default async function PredictionFlow(props: Props) {
   }
   if (
     !user ||
+    user.is_bot ||
     !tournament.forecasts_flow_enabled ||
     tournament.timeline.all_questions_closed
   ) {

--- a/front_end/src/components/charts/fan_chart.tsx
+++ b/front_end/src/components/charts/fan_chart.tsx
@@ -1246,8 +1246,8 @@ function getFanOptionsFromContinuousGroup(
               q
             ).cdf);
       } else if (activeForecast?.forecast_values.length) {
-        // distribution_input can be absent even
-        // though forecast_values holds the full CDF, so fall back to it.
+        // distribution_input is absent for bots
+        // forecast_values still holds the full CDF, so fall back to it.
         userCdf = activeForecast.forecast_values;
       }
 

--- a/front_end/src/components/charts/fan_chart.tsx
+++ b/front_end/src/components/charts/fan_chart.tsx
@@ -1228,10 +1228,10 @@ function getFanOptionsFromContinuousGroup(
   return questions
     .map((q) => {
       const latest = q.my_forecasts?.latest;
+      const activeForecast =
+        latest && isForecastActive(latest) ? latest : undefined;
       const userForecast = extractPrevNumericForecastValue(
-        latest && isForecastActive(latest)
-          ? latest.distribution_input
-          : undefined
+        activeForecast?.distribution_input
       );
 
       let userCdf: number[] | null = null;
@@ -1245,6 +1245,10 @@ function getFanOptionsFromContinuousGroup(
               userForecast.components,
               q
             ).cdf);
+      } else if (activeForecast?.forecast_values.length) {
+        // distribution_input can be absent even
+        // though forecast_values holds the full CDF, so fall back to it.
+        userCdf = activeForecast.forecast_values;
       }
 
       return {


### PR DESCRIPTION
- Hide the prediction flow for bots
- Fixed rendering of empty latest bot forecasts in fan tooltips -- bots don’t pass `distribution_input`

https://metaculus.slack.com/archives/C01Q9AQBVHB/p1784047918518829

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented bot accounts from accessing tournament participation and prediction features.
  * Added redirects for bot accounts attempting to open prediction-flow pages.
  * Improved fan chart display when forecast distribution data is unavailable by using available forecast values as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->