### PR TITLE
feat: noindex questions whose default project matches bot-only keywords

### DIFF
--- a/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
+++ b/front_end/src/app/(main)/questions/[id]/[[...slug]]/page.tsx
@@ -13,6 +13,12 @@ type Props = {
   searchParams: Promise<SearchParams>;
 };
 
+const NOINDEX_DEFAULT_PROJECT_KEYWORDS = [
+  "futureeval",
+  "AI Forecasting Benchmark Tournament",
+  "minibench",
+];
+
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
   const postData = await cachedGetPostForMetadata(params.id);
@@ -21,6 +27,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     return {};
   }
   const questionTitle = getPostTitle(postData);
+  const defaultProjectName = postData.projects?.default_project?.name ?? "";
+  const shouldNoindex = NOINDEX_DEFAULT_PROJECT_KEYWORDS.some((keyword) =>
+    defaultProjectName.toLowerCase().includes(keyword.toLowerCase())
+  );
   return {
     title:
       getValidString(postData.html_metadata_json?.title) ??
@@ -52,6 +62,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
         alt: "community predictions",
       },
     },
+    ...(shouldNoindex ? { robots: { index: false, follow: false } } : {}),
   };
 }
 


### PR DESCRIPTION
Closes #4423.

Adds a noindex/nofollow robots meta directive to the individual question page when the default project's name (case-insensitively) contains any of:

- `futureeval`
- `AI Forecasting Benchmark Tournament`
- `minibench`

Tournament pages and notebooks remain indexable.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO**
  * Prevented search engines from indexing selected default project pages while still allowing existing links to be followed.
  * Preserved existing page titles, descriptions, and social sharing metadata for all question pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->