### PR TITLE
Restrict bot aggregates setting to admin and moderator users

### DIFF
--- a/front_end/src/app/(main)/questions/components/question_form.tsx
+++ b/front_end/src/app/(main)/questions/components/question_form.tsx
@@ -32,6 +32,7 @@ import { MarkdownText } from "@/components/ui/markdown_text";
 import SectionToggle from "@/components/ui/section_toggle";
 import Select from "@/components/ui/select";
 import { ContinuousQuestionTypes } from "@/constants/questions";
+import { useAuth } from "@/contexts/auth_context";
 import { useDebouncedCallback } from "@/hooks/use_debounce";
 import { ErrorResponse } from "@/types/fetch";
 import { Post, PostStatus, PostWithForecasts } from "@/types/post";
@@ -316,6 +317,8 @@ const QuestionForm: FC<Props> = ({
 }) => {
   const router = useRouter();
   const t = useTranslations();
+  const { user } = useAuth();
+  const isAdminOrModerator = !!user?.is_staff || !!user?.is_superuser;
   const { isDone, hasForecasts } = getQuestionStatus(post);
   const optionsLocked = hasForecasts && mode !== "create";
   const [isLoading, setIsLoading] = useState<boolean>();
@@ -1009,24 +1012,26 @@ const QuestionForm: FC<Props> = ({
               />
             )}
 
-          <InputContainer
-            labelText={t("includeBotsInAggregatesLabel")}
-            explanation={t("includeBotsInAggregatesExplanation")}
-            isNativeFormControl={false}
-            className="mb-6"
-          >
-            <Checkbox
-              label={t("includeBotsInAggregatesLabel")}
-              checked={form.watch("include_bots_in_aggregates") ?? false}
-              onChange={(checked) => {
-                form.setValue("include_bots_in_aggregates", checked, {
-                  shouldDirty: true,
-                  shouldTouch: true,
-                  shouldValidate: true,
-                });
-              }}
-            />
-          </InputContainer>
+          {isAdminOrModerator && (
+            <InputContainer
+              labelText={t("includeBotsInAggregatesLabel")}
+              explanation={t("includeBotsInAggregatesExplanation")}
+              isNativeFormControl={false}
+              className="mb-6"
+            >
+              <Checkbox
+                label={t("includeBotsInAggregatesLabel")}
+                checked={form.watch("include_bots_in_aggregates") ?? false}
+                onChange={(checked) => {
+                  form.setValue("include_bots_in_aggregates", checked, {
+                    shouldDirty: true,
+                    shouldTouch: true,
+                    shouldValidate: true,
+                  });
+                }}
+              />
+            </InputContainer>
+          )}
         </SectionToggle>
 
         <div className="flex-col">


### PR DESCRIPTION
## Summary
This change restricts the "Include Bots in Aggregates" form field to only be visible and editable by admin and moderator users in the question form component.

## Key Changes
- Added `useAuth` hook import to access current user authentication context
- Extracted user role information (`is_staff` and `is_superuser` flags) to determine admin/moderator status
- Wrapped the "Include Bots in Aggregates" input section with a conditional render that only displays when the user is an admin or moderator

## Implementation Details
- The visibility check uses a simple boolean flag `isAdminOrModerator` that evaluates to `true` if the user has either `is_staff` or `is_superuser` permissions
- The conditional rendering wraps the entire `InputContainer` component, preventing non-admin users from seeing or interacting with this setting
- No changes to the underlying form logic or validation; only the UI visibility is restricted

https://claude.ai/code/session_01MM2Sq2F2dPzAG3L7Bc613p