### PR TITLE
Fixed "not participated" for all-closed-question forecasters

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournament/components/participation_block.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournament/components/participation_block.tsx
@@ -51,19 +51,22 @@ const ParticipationBlock: FC<Props> = ({ tournament, posts }) => {
 
   if (
     isNil(user) ||
-    user.is_bot ||
     !tournament.forecasts_flow_enabled ||
     tournament.timeline.all_questions_closed
   ) {
     return null;
   }
-  const isParticipated = posts.some((post) =>
+  const hasOpenQuestionForecast = posts.some((post) =>
     isPostOpenQuestionPredicted(post, {
       checkAllSubquestions: false,
       treatClosedAsPredicted: false,
       treatWithdrawnAsPredicted: true,
     })
   );
+  // has_participated also covers now-closed questions, which the flow omits
+  const isParticipated =
+    !!tournament.has_participated || hasOpenQuestionForecast;
+
   const unpredictedPosts: PredictionFlowPost[] = [];
   const withdrawnPosts: PredictionFlowPost[] = [];
   const stalePredictionsPosts: PredictionFlowPost[] = [];

--- a/front_end/src/app/(prediction-flow)/tournament/[slug]/prediction-flow/page.tsx
+++ b/front_end/src/app/(prediction-flow)/tournament/[slug]/prediction-flow/page.tsx
@@ -49,7 +49,6 @@ export default async function PredictionFlow(props: Props) {
   }
   if (
     !user ||
-    user.is_bot ||
     !tournament.forecasts_flow_enabled ||
     tournament.timeline.all_questions_closed
   ) {

--- a/front_end/src/types/projects.ts
+++ b/front_end/src/types/projects.ts
@@ -96,6 +96,7 @@ export type Tournament = TournamentPreview & {
   };
   is_subscribed?: boolean;
   follow_questions?: boolean;
+  has_participated?: boolean;
   add_posts_to_main_feed: boolean;
   visibility: ProjectVisibility;
   default_permission?: ProjectPermissions | null;

--- a/projects/views/common.py
+++ b/projects/views/common.py
@@ -244,6 +244,11 @@ def tournament_by_slug_api_view(request: Request, slug: str):
         data["follow_questions"] = (
             subscription.follow_questions if subscription else False
         )
+        data["has_participated"] = (
+            Post.objects.filter_projects(obj)
+            .filter_user_has_forecasted(request.user.id)
+            .exists()
+        )
 
     if obj.index_id:
         data["index_data"] = serialize_index_data(obj.index)


### PR DESCRIPTION
Fixed an edge case of "Not Participated" block when user forecast are only related to closed questions

https://metaculus.slack.com/archives/C01Q9AQBVHB/p1784131960281229?thread_ts=1784047918.518829&cid=C01Q9AQBVHB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can access tournament prediction flows regardless of bot status.
  * Tournament participation is now recognized from existing participation data or open forecast questions.
  * Tournament details indicate whether the current user has already participated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->