### PR TITLE
fix: scope main-feed pending queue to site_main posts

### DIFF
--- a/posts/models.py
+++ b/posts/models.py
@@ -38,6 +38,15 @@ from users.models import User
 from utils.models import TimeStampedModel, TranslatedModel
 
 
+def projects_q(p: list[Project] | Project) -> Q:
+    if isinstance(p, Project):
+        p = [p]
+
+    return Q(default_project__in=p) | Exists(
+        Post.projects.through.objects.filter(post_id=OuterRef("pk"), project__in=p)
+    )
+
+
 class PostQuerySet(models.QuerySet):
     def prefetch_user_forecasts(self, user_id: int):
         question_relations = [
@@ -499,17 +508,7 @@ class PostQuerySet(models.QuerySet):
         )
 
     def filter_projects(self, p: list[Project] | Project):
-        if isinstance(p, Project):
-            p = [p]
-
-        return self.filter(
-            Q(default_project__in=p)
-            | Exists(
-                Post.projects.through.objects.filter(
-                    post_id=OuterRef("pk"), project__in=p
-                )
-            )
-        )
+        return self.filter(projects_q(p))
 
     def filter_for_main_feed(self):
         """

--- a/posts/services/feed.py
+++ b/posts/services/feed.py
@@ -13,6 +13,7 @@ from posts.services.search import (
     posts_full_text_search,
 )
 from projects.models import Project
+from projects.services.common import get_site_main_project
 from questions.models import Question
 from users.models import User
 from utils.cache import cache_get_or_set
@@ -140,7 +141,17 @@ def get_posts_feed(  # noqa: C901
 
     for status in statuses:
         if status in Post.CurationStatus:
-            post_status_q |= Q(curation_status=status)
+            status_q = Q(curation_status=status)
+            # Main-feed pending queue should only include posts attached to site_main,
+            # not pending posts from tournaments/question series with visibility=NORMAL.
+            if status == Post.CurationStatus.PENDING and for_main_feed:
+                site_main = get_site_main_project()
+                status_q &= Q(default_project=site_main) | Q(
+                    pk__in=Post.projects.through.objects.filter(
+                        project=site_main
+                    ).values("post_id")
+                )
+            post_status_q |= status_q
         if status == "open":
             post_status_q |= Q(
                 Q(published_at__lte=now)

--- a/posts/services/feed.py
+++ b/posts/services/feed.py
@@ -5,7 +5,7 @@ from django.db.models import Q, QuerySet, Exists, Max, OuterRef
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError, PermissionDenied
 
-from posts.models import Post, Vote
+from posts.models import Post, Vote, projects_q
 from posts.serializers import PostFilterSerializer
 from posts.services.search import (
     perform_post_search,
@@ -145,12 +145,7 @@ def get_posts_feed(  # noqa: C901
             # Main-feed pending queue should only include posts attached to site_main,
             # not pending posts from tournaments/question series with visibility=NORMAL.
             if status == Post.CurationStatus.PENDING and for_main_feed:
-                site_main = get_site_main_project()
-                status_q &= Q(default_project=site_main) | Q(
-                    pk__in=Post.projects.through.objects.filter(
-                        project=site_main
-                    ).values("post_id")
-                )
+                status_q &= projects_q(get_site_main_project())
             post_status_q |= status_q
         if status == "open":
             post_status_q |= Q(

--- a/tests/unit/test_posts/test_services/test_feed.py
+++ b/tests/unit/test_posts/test_services/test_feed.py
@@ -4,9 +4,12 @@ from rest_framework.exceptions import PermissionDenied
 
 from posts.models import PostUserSnapshot, Post
 from posts.services.feed import get_posts_feed
+from projects.models import Project
+from projects.services.common import get_site_main_project
 from questions.models import Question
 from tests.unit.test_comments.factories import factory_comment
 from tests.unit.test_posts.factories import factory_post
+from tests.unit.test_projects.factories import factory_project
 from tests.unit.test_questions.factories import create_question, factory_forecast
 from tests.unit.utils import datetime_aware
 
@@ -118,3 +121,54 @@ def test_get_posts_feed__exclude_unpublished(user1):
     posts = get_posts_feed(statuses=[Post.CurationStatus.PENDING])
     assert len(posts) == 1
     assert posts[0].id == post_pending.id
+
+
+def test_get_posts_feed__pending_main_feed_excludes_tournament_posts(user1):
+    """
+    The main-feed pending queue should only include posts attached to site_main,
+    not pending posts submitted into tournaments with visibility=NORMAL.
+    """
+
+    site_main = get_site_main_project()
+    tournament = factory_project(
+        type=Project.ProjectTypes.TOURNAMENT,
+        visibility=Project.Visibility.NORMAL,
+    )
+
+    post_pending_main = factory_post(
+        author=user1,
+        default_project=site_main,
+        question=create_question(question_type=Question.QuestionType.BINARY),
+        curation_status=Post.CurationStatus.PENDING,
+    )
+    post_pending_main_via_m2m = factory_post(
+        author=user1,
+        default_project=tournament,
+        projects=[site_main],
+        question=create_question(question_type=Question.QuestionType.BINARY),
+        curation_status=Post.CurationStatus.PENDING,
+    )
+    post_pending_tournament_only = factory_post(
+        author=user1,
+        default_project=tournament,
+        question=create_question(question_type=Question.QuestionType.BINARY),
+        curation_status=Post.CurationStatus.PENDING,
+    )
+
+    # Main-feed pending queue: only the site_main-attached posts show up
+    posts = get_posts_feed(
+        user=user1,
+        for_main_feed=True,
+        statuses=[Post.CurationStatus.PENDING],
+    )
+    post_ids = {p.id for p in posts}
+    assert post_ids == {post_pending_main.id, post_pending_main_via_m2m.id}
+    assert post_pending_tournament_only.id not in post_ids
+
+    # Without for_main_feed, the tournament-only pending post is included
+    posts = get_posts_feed(
+        user=user1,
+        statuses=[Post.CurationStatus.PENDING],
+    )
+    post_ids = {p.id for p in posts}
+    assert post_pending_tournament_only.id in post_ids


### PR DESCRIPTION
Fixes #3216

## Summary

The main-feed pending queue (`/questions/?status=pending`) previously showed pending posts from any public project (anything with `visibility=NORMAL`, including tournaments and question series). This change scopes the pending branch in `get_posts_feed()` so that when `for_main_feed=True`, only posts with `site_main` as their default project or as an M2M project are returned. Other curation statuses and tournament-page queries are unaffected.

## Test plan

- [ ] New unit test `test_get_posts_feed__pending_main_feed_excludes_tournament_posts` covers the site_main/tournament/M2M cases
- [ ] Manually verify `/questions/?status=pending` no longer shows pending tournament posts to curators/admins/creators of those tournaments
- [ ] Manually verify tournament pending queues still show their own pending posts

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pending posts in the main feed are now limited to posts associated with the site’s main project.
  * Pending posts from tournament projects no longer appear in the main feed, while remaining available in other feed views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->