### PR TITLE
fix: clarify Tetlock tutorial copy about CIA analyst access

### DIFF
--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -1315,7 +1315,7 @@
   "onboardingYouPredicted": "You predicted",
   "onboardingStep5AnyoneCanImprove": "Anyone can improve at forecasting by practicing and thinking through what factors could influence outcomes.",
   "onboardingStep5DidYouKnow": "Did you know?",
-  "onboardingStep5ForecastingCompetition": "In a series of forecasting competitions conducted by University of Pennsylvania professor Philip Tetlock, skilled forecasters outperformed CIA analysts without access to classified intelligence.",
+  "onboardingStep5ForecastingCompetition": "In a series of forecasting competitions conducted by University of Pennsylvania professor Philip Tetlock, skilled forecasters outperformed CIA analysts who had access to classified intelligence.",
   "onboardingStep5ReadyToExplore": "You are now ready to explore Metaculus by yourself. What would you like to do next?",
   "onboardingStep5ViewYourPredictions": "View Your Predictions",
   "onboardingStep5ForecastAnother": "Forecast Another",


### PR DESCRIPTION
Rewords the onboarding step 5 string so it unambiguously conveys that the CIA analysts had classified access (and skilled forecasters still outperformed them).

Closes #3290

Generated with [Claude Code](https://claude.ai/code)