### PR TITLE
Fix forecast card rows not filling card width on storefront

### DIFF
--- a/front_end/src/app/(storefront)/components/homepage_post_card.tsx
+++ b/front_end/src/app/(storefront)/components/homepage_post_card.tsx
@@ -60,7 +60,11 @@ const HomepagePostCard: FC<Props> = ({ post, className }) => {
               )}
 
               {(isGroupOfQuestionsPost(post) || isMultipleChoicePost(post)) && (
-                <GroupForecastCard post={post} compact />
+                <GroupForecastCard
+                  post={post}
+                  compact
+                  buttonVariant="minimal"
+                />
               )}
             </HideCPProvider>
           </div>

--- a/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/numeric_forecast_card.tsx
@@ -265,7 +265,10 @@ const NumericForecastCard: FC<Props> = ({
   return (
     <div
       ref={containerRef}
-      className={cn("relative", effectiveFillHeight && "flex flex-1 flex-col")}
+      className={cn(
+        "relative w-full",
+        effectiveFillHeight && "flex flex-1 flex-col"
+      )}
     >
       <ForecastCardWrapper
         otherItemsCount={hiddenCount}

--- a/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
+++ b/front_end/src/components/consumer_post_card/group_forecast_card/percentage_forecast_card.tsx
@@ -158,7 +158,10 @@ const PercentageForecastCard: FC<Props> = ({
   return (
     <div
       ref={containerRef}
-      className={cn("relative", effectiveFillHeight && "flex flex-1 flex-col")}
+      className={cn(
+        "relative w-full",
+        effectiveFillHeight && "flex flex-1 flex-col"
+      )}
     >
       <ForecastCardWrapper
         otherItemsCount={hiddenCount}


### PR DESCRIPTION
<img width="397" height="510" alt="image" src="https://github.com/user-attachments/assets/889c9802-6121-44d6-bd5a-4d2883b9bc57" />

(ss of the problem)

## Problem

On the storefront, Multiple Choice card option rows render narrower than the card, leaving dead space on the right. The same cards in the feed look correct.

## Root cause

`PercentageForecastCard` and `NumericForecastCard` had a bare `relative` root with no width. That's invisible in most layouts, where a block element fills its parent — but both consumer card shells lay content out as `flex flex-col
items-center`, and in a *column* flex container `align-items` governs the horizontal axis. So the cards sized to `fit-content` and the rows collapsed to the widest label.

The feed and the similar-questions sidebar each worked around this with a `<div className="w-full">` wrapper. The storefront card was the one call site without one, so it was the only place the bug was visible.

## Fix

Add `w-full` to the two roots rather than a third copy of the wrapper. These two were the outliers — their siblings `DateForecastCard` and `TimeSeriesChart`, and their own child `ForecastCardWrapper`, already declare `w-full`. This covers multiple choice, binary groups, numeric/discrete groups and date groups at once (all of them had the bug on the storefront; MC is just what got reported).

Also passes `buttonVariant="minimal"` on the storefront card: it's fully covered by an `absolute z-100` Link overlay, so the "N others" chevron button underneath could never be clicked. The feed already passes `minimal` for this reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the layout of numeric and percentage forecast cards so they consistently use the available width.
  * Updated homepage forecast cards with a more streamlined button presentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->