### PR TITLE
fix: cap year at 4 digits and prevent crash on invalid datetime input

### DIFF
--- a/front_end/src/components/ui/datetime_utc.tsx
+++ b/front_end/src/components/ui/datetime_utc.tsx
@@ -83,7 +83,8 @@ const DatetimeUtc = forwardRef<HTMLInputElement, DatetimeUtcProps>(
       <Input
         ref={ref}
         type="datetime-local"
-        defaultValue={localValue ? format(localValue, formatStr) : ""}
+        defaultValue={localValue}
+        max={props.type === "date" ? "9999-12-31" : "9999-12-31T23:59"}
         className={className}
         onChange={handleChange}
         onBlur={handleChange}


### PR DESCRIPTION
Fixes #3640

## Summary

- Add `max="9999-12-31[T23:59]"` to datetime-local inputs so years cannot exceed 4 digits.
- Drop the redundant `format(localValue, formatStr)` call in the render path — `localValue` is already the formatted string from the effect, and re-formatting a raw user string with an out-of-range year threw `RangeError: Invalid time value` mid-render, which the global error boundary caught as a page crash.

## Test plan

- [ ] Open question creation form, try to type a 5+ digit year — browser should cap at 4 digits.
- [ ] Confirm the page no longer crashes when an out-of-range date is briefly entered.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved datetime input handling by ensuring the displayed default value uses the correctly formatted local datetime.
  * Prevented unnecessary reformatting that could cause inconsistencies in date and time displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->