### PR TITLE
copy edit: simplify new comments email intro

### DIFF
--- a/notifications/templates/emails/post_new_comments.html
+++ b/notifications/templates/emails/post_new_comments.html
@@ -174,7 +174,7 @@
                     </tr>
                     <tr>
                       <td align="left" class="general-text" style="font-size:0px;padding:10px 25px;padding-bottom:4px;word-break:break-word;">
-                        <div style="font-family:Inter Variable, Inter, Arial, sans-serif;font-size:15px;line-height:24px;text-align:left;color:#6B7280;">{% blocktrans with count=notifications|length %} There are new comments on these {{ count }} questions: {% endblocktrans %}</div>
+                        <div style="font-family:Inter Variable, Inter, Arial, sans-serif;font-size:15px;line-height:24px;text-align:left;color:#6B7280;">{% trans "There are new comments on" %}</div>
                       </td>
                     </tr>
                   </tbody>

--- a/notifications/templates/emails/post_new_comments.mjml
+++ b/notifications/templates/emails/post_new_comments.mjml
@@ -11,9 +11,7 @@
                 </mj-text>
 
                 <mj-text font-size="15px" color="#6B7280" padding-bottom="4px">
-                    {% blocktrans with count=notifications|length %}
-                    There are new comments on these {{ count }} questions:
-                    {% endblocktrans %}
+                    {% trans "There are new comments on" %}
                 </mj-text>
             </mj-column>
         </mj-section>


### PR DESCRIPTION
Simplifies the intro line in the new comments transactional email so it no longer awkwardly renders "these 1 questions" in the singular case.

Changes:
- Update intro text from "There are new comments on these {{ count }} questions:" to "There are new comments on"
- Applied to both the `.mjml` source and the compiled `.html` template

Closes #3184

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated new-comment email notifications with clearer introductory wording.
  * Removed potentially confusing notification counts and question-specific phrasing from the email header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->