### PR TITLE
Pin docker_build.yml buildkit version

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -124,6 +124,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.31.1
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build environment to use a specific BuildKit version.
  * Existing image building, tagging, caching, and publishing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->