### PR TITLE
Add "We Must Act Now" economists statement to labor hub activity monitor

### DIFF
--- a/front_end/src/app/(main)/labor-hub/activity_data.tsx
+++ b/front_end/src/app/(main)/labor-hub/activity_data.tsx
@@ -271,4 +271,21 @@ export const RAW_ACTIVITY_MONITOR_DATA: RawActivityMonitorEntry[] = [
       </>
     ),
   },
+  {
+    date: "2026-07-13",
+    type: "insight",
+    content: (
+      <>
+        A group of leading economists signed a joint statement saying “We must
+        act now.” -{" "}
+        <a
+          href="https://www.wemustactnow.ai/"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          We Must Act Now
+        </a>
+      </>
+    ),
+  },
 ];


### PR DESCRIPTION
Adds a new insight-type (lightbulb) entry to the labor hub activity monitor for the July 13, 2026 joint statement by leading economists at https://www.wemustactnow.ai/.

Fixes #5042

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Insight activity entry dated July 13, 2026, with a link to wemustactnow.ai.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->