### PR TITLE
Cap aggregate forecast previews at question close time

### DIFF
--- a/questions/serializers/aggregate_forecasts.py
+++ b/questions/serializers/aggregate_forecasts.py
@@ -56,6 +56,32 @@ def serialize_aggregate_forecast(
     return data
 
 
+def _get_latest_aggregate_forecast(
+    question: Question, forecasts: list[AggregateForecast]
+) -> AggregateForecast | None:
+    """
+    Pick the aggregate forecast used as the "latest"/default CP preview.
+
+    For questions that have effectively closed (closed or resolved), this is the last
+    forecast that was live at ``actual_close_time`` rather than the most recent one.
+    Questions resolved as of a past date can keep accumulating aggregate forecasts after
+    that date, and the default CP preview must reflect the value at resolution/close
+    time, not those later aggregations. ``forecasts`` are expected in ascending
+    ``start_time`` order.
+    """
+    if not forecasts:
+        return None
+
+    cutoff = question.actual_close_time
+    if cutoff is None:
+        return forecasts[-1]
+
+    eligible = [f for f in forecasts if f.start_time <= cutoff]
+    # Fall back to the earliest available forecast if every forecast starts after the
+    # cutoff (shouldn't normally happen, but keeps a CP visible rather than dropping it).
+    return eligible[-1] if eligible else forecasts[0]
+
+
 @sentry_sdk.trace
 def serialize_question_aggregations(
     question: Question,
@@ -133,9 +159,10 @@ def serialize_question_aggregations(
                 )
                 for forecast in forecasts
             ]
+            latest_forecast = _get_latest_aggregate_forecast(question, forecasts)
             serialized_data[method]["latest"] = (
-                serialize_aggregate_forecast(forecasts[-1], question.type, full=True)
-                if forecasts
+                serialize_aggregate_forecast(latest_forecast, question.type, full=True)
+                if latest_forecast
                 else None
             )
 

--- a/questions/services/forecasts.py
+++ b/questions/services/forecasts.py
@@ -406,13 +406,23 @@ def update_forecast_notification(
 def get_last_aggregated_forecasts_for_questions(
     questions: Iterable[Question], aggregated_forecast_qs: QuerySet[AggregateForecast]
 ):
-    # Return the most recent started forecast per (question, method), regardless of
-    # whether it is still live. Closed/resolved questions keep their final CP this way,
-    # and — crucially — this row is fully loaded, so serializing it with full=True does
-    # not trigger a deferred-field reload against the (heavy, deferred) CP history.
+    # Return the most recent started forecast per (question, method) that was live at
+    # the point the question effectively closed. For open questions actual_close_time
+    # is null, so we simply take the most recent started forecast. For closed/resolved
+    # questions we cap at actual_close_time: a question resolved as of a past date can
+    # keep accumulating aggregate forecasts after that date, and the default CP preview
+    # must reflect the value at resolution/close time, not those later aggregations.
+    # (actual_close_time == min(actual_resolve_time, scheduled_close_time), matching the
+    # horizon scoring uses.) Crucially, this row is also fully loaded, so serializing it
+    # with full=True does not trigger a deferred-field reload against the (heavy,
+    # deferred) CP history.
     return (
         aggregated_forecast_qs.filter(question__in=questions)
         .filter(start_time__lte=timezone.now())
+        .filter(
+            Q(question__actual_close_time__isnull=True)
+            | Q(start_time__lte=F("question__actual_close_time"))
+        )
         .order_by("question_id", "method", "-start_time")
         .distinct("question_id", "method")
     )

--- a/tests/unit/test_questions/test_services/test_forecasts.py
+++ b/tests/unit/test_questions/test_services/test_forecasts.py
@@ -1,0 +1,112 @@
+from datetime import datetime, timedelta
+
+import freezegun
+import pytest  # noqa
+from django.utils.timezone import make_aware
+
+from questions.models import AggregateForecast, Question
+from questions.serializers.aggregate_forecasts import (
+    serialize_question_aggregations,
+)
+from questions.services.forecasts import (
+    get_aggregated_forecasts_for_questions,
+    get_last_aggregated_forecasts_for_questions,
+)
+from questions.types import AggregationMethod
+from tests.unit.test_questions.factories import create_question
+
+
+def _dt(*args):
+    return make_aware(datetime(*args))
+
+
+def _make_aggregate(question, start_time, end_time, center):
+    # Binary aggregates store both outcomes; serialization strips the first element.
+    return AggregateForecast.objects.create(
+        question=question,
+        method=question.default_aggregation_method,
+        start_time=start_time,
+        end_time=end_time,
+        forecast_values=[1 - center, center],
+        centers=[1 - center, center],
+        interval_lower_bounds=[1 - center, center],
+        interval_upper_bounds=[1 - center, center],
+        forecaster_count=5,
+    )
+
+
+@freezegun.freeze_time("2024-06-01")
+class TestCPAtResolutionTime:
+    """
+    A question resolved as of a past date keeps accumulating aggregate forecasts
+    after that date (it appeared open until the resolution was entered). The default
+    CP preview must reflect the value at resolution/close time, not those later
+    aggregations.
+    """
+
+    def _build_retroactively_resolved_question(self) -> Question:
+        # Scheduled to close in the future, but resolved as of a past date.
+        question = create_question(
+            question_type=Question.QuestionType.BINARY,
+            default_aggregation_method=AggregationMethod.RECENCY_WEIGHTED,
+            open_time=_dt(2024, 1, 1),
+            scheduled_close_time=_dt(2024, 12, 31),
+            scheduled_resolve_time=_dt(2024, 12, 31),
+            actual_resolve_time=_dt(2024, 3, 1),
+            # min(actual_resolve_time, scheduled_close_time)
+            actual_close_time=_dt(2024, 3, 1),
+            resolution="yes",
+            resolution_set_time=_dt(2024, 5, 1),
+        )
+        # CP live at resolution time (2024-03-01)
+        _make_aggregate(question, _dt(2024, 2, 1), _dt(2024, 4, 1), 0.7)
+        # CP after resolution time (question still looked open until 2024-05-01)
+        _make_aggregate(question, _dt(2024, 4, 1), _dt(2024, 5, 1), 0.2)
+        _make_aggregate(question, _dt(2024, 5, 1), None, 0.1)
+        return question
+
+    def test_last_aggregate_is_capped_at_close_time_for_resolved_question(self):
+        question = self._build_retroactively_resolved_question()
+
+        last = list(
+            get_last_aggregated_forecasts_for_questions(
+                [question], AggregateForecast.objects.all()
+            )
+        )
+        assert len(last) == 1
+        # The CP at resolution time, not the last (0.1) forecast.
+        assert last[0].centers[1] == 0.7
+
+    def test_serialized_latest_uses_resolution_time_cp_with_full_history(self):
+        question = self._build_retroactively_resolved_question()
+
+        forecasts_by_question = get_aggregated_forecasts_for_questions(
+            [question], include_cp_history=True
+        )
+        serialized = serialize_question_aggregations(
+            question, forecasts_by_question[question]
+        )
+        method_data = serialized[question.default_aggregation_method]
+
+        # History still contains every aggregation...
+        assert len(method_data["history"]) == 3
+        # ...but the default preview is the CP at resolution time.
+        assert method_data["latest"]["centers"] == [0.7]
+
+    def test_open_question_still_uses_most_recent_cp(self):
+        question = create_question(
+            question_type=Question.QuestionType.BINARY,
+            default_aggregation_method=AggregationMethod.RECENCY_WEIGHTED,
+            open_time=_dt(2024, 1, 1),
+            scheduled_close_time=_dt(2024, 12, 31),
+        )
+        _make_aggregate(question, _dt(2024, 2, 1), _dt(2024, 5, 1), 0.7)
+        _make_aggregate(question, _dt(2024, 5, 1), None, 0.4)
+
+        last = list(
+            get_last_aggregated_forecasts_for_questions(
+                [question], AggregateForecast.objects.all()
+            )
+        )
+        assert len(last) == 1
+        assert last[0].centers[1] == 0.4

--- a/tests/unit/test_questions/test_services/test_forecasts.py
+++ b/tests/unit/test_questions/test_services/test_forecasts.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import freezegun
 import pytest  # noqa


### PR DESCRIPTION
## Summary
Fix the default aggregate forecast ("latest" CP) preview for questions that were resolved retroactively (resolved as of a past date but kept accumulating forecasts until the resolution was entered). The preview now correctly reflects the forecast value at the question's effective close time rather than the most recent forecast.

## Key Changes
- **`questions/services/forecasts.py`**: Updated `get_last_aggregated_forecasts_for_questions()` to filter aggregate forecasts by `actual_close_time`. For open questions (where `actual_close_time` is null), the most recent forecast is used. For closed/resolved questions, only forecasts that started at or before `actual_close_time` are considered.

- **`questions/serializers/aggregate_forecasts.py`**: Added `_get_latest_aggregate_forecast()` helper function that selects the appropriate forecast for the "latest" CP preview. It respects the `actual_close_time` cutoff for closed questions while maintaining full history in serialization.

- **`tests/unit/test_questions/test_services/test_forecasts.py`**: Added comprehensive test suite (`TestCPAtResolutionTime`) covering:
  - Retroactively resolved questions with forecasts after resolution time
  - Verification that the latest preview uses the forecast at resolution time, not the most recent one
  - Confirmation that open questions still use the most recent forecast

## Implementation Details
- `actual_close_time` is defined as `min(actual_resolve_time, scheduled_close_time)`, matching the horizon scoring logic
- The solution maintains backward compatibility: open questions continue to use the most recent forecast
- Full forecast history is preserved in serialization; only the "latest" preview is capped at close time
- Includes fallback behavior: if all forecasts start after the cutoff (edge case), the earliest available forecast is used to keep a CP visible

https://claude.ai/code/session_01XgUzpLZNHiVXK3t7UGoSsU