### PR TITLE
Show CP at resolution time on resolved questions

### DIFF
--- a/questions/serializers/aggregate_forecasts.py
+++ b/questions/serializers/aggregate_forecasts.py
@@ -160,10 +160,21 @@ def serialize_question_aggregations(
                 for forecast in forecasts
             ]
             latest_forecast = _get_latest_aggregate_forecast(question, forecasts)
-            serialized_data[method]["latest"] = (
-                serialize_aggregate_forecast(latest_forecast, question.type, full=True)
-                if latest_forecast
-                else None
-            )
+            if latest_forecast is not None:
+                latest_data = serialize_aggregate_forecast(
+                    latest_forecast, question.type, full=True
+                )
+                # For a closed/resolved question the "latest" preview is the final CP
+                # capped at actual_close_time. That forecast may carry a real past
+                # end_time (a later aggregation closed it off, e.g. a question resolved
+                # as of a past date that kept accumulating forecasts). The frontend gates
+                # CP previews/PDFs on end_time liveness, so present it as the active final
+                # CP — matching how the last live aggregation was shown before capping —
+                # to keep those previews rendering.
+                if question.actual_close_time is not None:
+                    latest_data["end_time"] = None
+                serialized_data[method]["latest"] = latest_data
+            else:
+                serialized_data[method]["latest"] = None
 
     return dict(serialized_data)  # convert defaultdict to dict

--- a/questions/serializers/aggregate_forecasts.py
+++ b/questions/serializers/aggregate_forecasts.py
@@ -56,6 +56,32 @@ def serialize_aggregate_forecast(
     return data
 
 
+def _get_latest_aggregate_forecast(
+    question: Question, forecasts: list[AggregateForecast]
+) -> AggregateForecast | None:
+    """
+    Pick the aggregate forecast used as the "latest"/default CP preview.
+
+    For questions that have effectively closed (closed or resolved), this is the last
+    forecast that was live at ``actual_close_time`` rather than the most recent one.
+    Questions resolved as of a past date can keep accumulating aggregate forecasts after
+    that date, and the default CP preview must reflect the value at resolution/close
+    time, not those later aggregations. ``forecasts`` are expected in ascending
+    ``start_time`` order.
+    """
+    if not forecasts:
+        return None
+
+    cutoff = question.actual_close_time
+    if cutoff is None:
+        return forecasts[-1]
+
+    eligible = [f for f in forecasts if f.start_time <= cutoff]
+    # Fall back to the earliest available forecast if every forecast starts after the
+    # cutoff (shouldn't normally happen, but keeps a CP visible rather than dropping it).
+    return eligible[-1] if eligible else forecasts[0]
+
+
 @sentry_sdk.trace
 def serialize_question_aggregations(
     question: Question,
@@ -133,9 +159,10 @@ def serialize_question_aggregations(
                 )
                 for forecast in forecasts
             ]
+            latest_forecast = _get_latest_aggregate_forecast(question, forecasts)
             serialized_data[method]["latest"] = (
-                serialize_aggregate_forecast(forecasts[-1], question.type, full=True)
-                if forecasts
+                serialize_aggregate_forecast(latest_forecast, question.type, full=True)
+                if latest_forecast
                 else None
             )
 

--- a/questions/serializers/aggregate_forecasts.py
+++ b/questions/serializers/aggregate_forecasts.py
@@ -77,9 +77,11 @@ def _get_latest_aggregate_forecast(
         return forecasts[-1]
 
     eligible = [f for f in forecasts if f.start_time <= cutoff]
-    # Fall back to the earliest available forecast if every forecast starts after the
-    # cutoff (shouldn't normally happen, but keeps a CP visible rather than dropping it).
-    return eligible[-1] if eligible else forecasts[0]
+    # If every forecast starts after the cutoff (e.g. a closed/resolved question whose
+    # only aggregations landed after it closed), expose no preview rather than a
+    # post-close forecast — matching get_last_aggregated_forecasts_for_questions, which
+    # excludes those forecasts on the feed path.
+    return eligible[-1] if eligible else None
 
 
 @sentry_sdk.trace

--- a/questions/serializers/aggregate_forecasts.py
+++ b/questions/serializers/aggregate_forecasts.py
@@ -162,10 +162,12 @@ def serialize_question_aggregations(
                 for forecast in forecasts
             ]
             latest_forecast = _get_latest_aggregate_forecast(question, forecasts)
-            if latest_forecast is not None:
-                latest_data = serialize_aggregate_forecast(
-                    latest_forecast, question.type, full=True
-                )
+            latest_data = (
+                serialize_aggregate_forecast(latest_forecast, question.type, full=True)
+                if latest_forecast is not None
+                else None
+            )
+            if latest_data is not None and question.actual_close_time is not None:
                 # For a closed/resolved question the "latest" preview is the final CP
                 # capped at actual_close_time. That forecast may carry a real past
                 # end_time (a later aggregation closed it off, e.g. a question resolved
@@ -173,10 +175,7 @@ def serialize_question_aggregations(
                 # CP previews/PDFs on end_time liveness, so present it as the active final
                 # CP — matching how the last live aggregation was shown before capping —
                 # to keep those previews rendering.
-                if question.actual_close_time is not None:
-                    latest_data["end_time"] = None
-                serialized_data[method]["latest"] = latest_data
-            else:
-                serialized_data[method]["latest"] = None
+                latest_data["end_time"] = None
+            serialized_data[method]["latest"] = latest_data
 
     return dict(serialized_data)  # convert defaultdict to dict

--- a/questions/services/forecasts.py
+++ b/questions/services/forecasts.py
@@ -406,13 +406,23 @@ def update_forecast_notification(
 def get_last_aggregated_forecasts_for_questions(
     questions: Iterable[Question], aggregated_forecast_qs: QuerySet[AggregateForecast]
 ):
-    # Return the most recent started forecast per (question, method), regardless of
-    # whether it is still live. Closed/resolved questions keep their final CP this way,
-    # and — crucially — this row is fully loaded, so serializing it with full=True does
-    # not trigger a deferred-field reload against the (heavy, deferred) CP history.
+    # Return the most recent started forecast per (question, method) that was live at
+    # the point the question effectively closed. For open questions actual_close_time
+    # is null, so we simply take the most recent started forecast. For closed/resolved
+    # questions we cap at actual_close_time: a question resolved as of a past date can
+    # keep accumulating aggregate forecasts after that date, and the default CP preview
+    # must reflect the value at resolution/close time, not those later aggregations.
+    # (actual_close_time == min(actual_resolve_time, scheduled_close_time), matching the
+    # horizon scoring uses.) Crucially, this row is also fully loaded, so serializing it
+    # with full=True does not trigger a deferred-field reload against the (heavy,
+    # deferred) CP history.
     return (
         aggregated_forecast_qs.filter(question__in=questions)
         .filter(start_time__lte=timezone.now())
+        .filter(
+            Q(question__actual_close_time__isnull=True)
+            | Q(start_time__lte=F("question__actual_close_time"))
+        )
         .order_by("question_id", "method", "-start_time")
         .distinct("question_id", "method")
     )

--- a/tests/unit/test_questions/test_services/test_forecasts.py
+++ b/tests/unit/test_questions/test_services/test_forecasts.py
@@ -1,0 +1,112 @@
+from datetime import datetime, timedelta
+
+import freezegun
+import pytest  # noqa
+from django.utils.timezone import make_aware
+
+from questions.models import AggregateForecast, Question
+from questions.serializers.aggregate_forecasts import (
+    serialize_question_aggregations,
+)
+from questions.services.forecasts import (
+    get_aggregated_forecasts_for_questions,
+    get_last_aggregated_forecasts_for_questions,
+)
+from questions.types import AggregationMethod
+from tests.unit.test_questions.factories import create_question
+
+
+def _dt(*args):
+    return make_aware(datetime(*args))
+
+
+def _make_aggregate(question, start_time, end_time, center):
+    # Binary aggregates store both outcomes; serialization strips the first element.
+    return AggregateForecast.objects.create(
+        question=question,
+        method=question.default_aggregation_method,
+        start_time=start_time,
+        end_time=end_time,
+        forecast_values=[1 - center, center],
+        centers=[1 - center, center],
+        interval_lower_bounds=[1 - center, center],
+        interval_upper_bounds=[1 - center, center],
+        forecaster_count=5,
+    )
+
+
+@freezegun.freeze_time("2024-06-01")
+class TestCPAtResolutionTime:
+    """
+    A question resolved as of a past date keeps accumulating aggregate forecasts
+    after that date (it appeared open until the resolution was entered). The default
+    CP preview must reflect the value at resolution/close time, not those later
+    aggregations.
+    """
+
+    def _build_retroactively_resolved_question(self) -> Question:
+        # Scheduled to close in the future, but resolved as of a past date.
+        question = create_question(
+            question_type=Question.QuestionType.BINARY,
+            default_aggregation_method=AggregationMethod.RECENCY_WEIGHTED,
+            open_time=_dt(2024, 1, 1),
+            scheduled_close_time=_dt(2024, 12, 31),
+            scheduled_resolve_time=_dt(2024, 12, 31),
+            actual_resolve_time=_dt(2024, 3, 1),
+            # min(actual_resolve_time, scheduled_close_time)
+            actual_close_time=_dt(2024, 3, 1),
+            resolution="yes",
+            resolution_set_time=_dt(2024, 5, 1),
+        )
+        # CP live at resolution time (2024-03-01)
+        _make_aggregate(question, _dt(2024, 2, 1), _dt(2024, 4, 1), 0.7)
+        # CP after resolution time (question still looked open until 2024-05-01)
+        _make_aggregate(question, _dt(2024, 4, 1), _dt(2024, 5, 1), 0.2)
+        _make_aggregate(question, _dt(2024, 5, 1), None, 0.1)
+        return question
+
+    def test_last_aggregate_is_capped_at_close_time_for_resolved_question(self):
+        question = self._build_retroactively_resolved_question()
+
+        last = list(
+            get_last_aggregated_forecasts_for_questions(
+                [question], AggregateForecast.objects.all()
+            )
+        )
+        assert len(last) == 1
+        # The CP at resolution time, not the last (0.1) forecast.
+        assert last[0].centers[1] == 0.7
+
+    def test_serialized_latest_uses_resolution_time_cp_with_full_history(self):
+        question = self._build_retroactively_resolved_question()
+
+        forecasts_by_question = get_aggregated_forecasts_for_questions(
+            [question], include_cp_history=True
+        )
+        serialized = serialize_question_aggregations(
+            question, forecasts_by_question[question]
+        )
+        method_data = serialized[question.default_aggregation_method]
+
+        # History still contains every aggregation...
+        assert len(method_data["history"]) == 3
+        # ...but the default preview is the CP at resolution time.
+        assert method_data["latest"]["centers"] == [0.7]
+
+    def test_open_question_still_uses_most_recent_cp(self):
+        question = create_question(
+            question_type=Question.QuestionType.BINARY,
+            default_aggregation_method=AggregationMethod.RECENCY_WEIGHTED,
+            open_time=_dt(2024, 1, 1),
+            scheduled_close_time=_dt(2024, 12, 31),
+        )
+        _make_aggregate(question, _dt(2024, 2, 1), _dt(2024, 5, 1), 0.7)
+        _make_aggregate(question, _dt(2024, 5, 1), None, 0.4)
+
+        last = list(
+            get_last_aggregated_forecasts_for_questions(
+                [question], AggregateForecast.objects.all()
+            )
+        )
+        assert len(last) == 1
+        assert last[0].centers[1] == 0.4

--- a/tests/unit/test_questions/test_services/test_forecasts.py
+++ b/tests/unit/test_questions/test_services/test_forecasts.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import freezegun
 import pytest  # noqa

--- a/tests/unit/test_questions/test_services/test_forecasts.py
+++ b/tests/unit/test_questions/test_services/test_forecasts.py
@@ -112,6 +112,41 @@ class TestCPAtResolutionTime:
         assert method_data["latest"]["centers"] == [0.7]
         assert method_data["latest"]["end_time"] is None
 
+    def test_no_preview_when_all_forecasts_start_after_close(self):
+        # Degenerate case: a resolved question whose only aggregations landed after
+        # actual_close_time. The history path must not expose a post-close forecast as
+        # the "latest" preview — it should be None, consistent with the feed path
+        # (get_last_aggregated_forecasts_for_questions excludes those forecasts).
+        question = create_question(
+            question_type=Question.QuestionType.BINARY,
+            default_aggregation_method=AggregationMethod.RECENCY_WEIGHTED,
+            open_time=_dt(2024, 1, 1),
+            scheduled_close_time=_dt(2024, 12, 31),
+            actual_resolve_time=_dt(2024, 3, 1),
+            actual_close_time=_dt(2024, 3, 1),
+            resolution="yes",
+            resolution_set_time=_dt(2024, 5, 1),
+        )
+        # Both aggregations start strictly after the close/resolution time.
+        _make_aggregate(question, _dt(2024, 4, 1), _dt(2024, 5, 1), 0.2)
+        _make_aggregate(question, _dt(2024, 5, 1), None, 0.1)
+
+        # Feed path: nothing qualifies, so no aggregate is fetched at all.
+        feed = get_aggregated_forecasts_for_questions(
+            [question], include_cp_history=False
+        )
+        assert feed[question] == []
+
+        # History path: history is present, but the latest preview is None (not a
+        # post-close forecast).
+        with_history = get_aggregated_forecasts_for_questions(
+            [question], include_cp_history=True
+        )
+        serialized = serialize_question_aggregations(question, with_history[question])
+        method_data = serialized[question.default_aggregation_method]
+        assert len(method_data["history"]) == 2
+        assert method_data["latest"] is None
+
     def test_open_question_still_uses_most_recent_cp(self):
         question = create_question(
             question_type=Question.QuestionType.BINARY,

--- a/tests/unit/test_questions/test_services/test_forecasts.py
+++ b/tests/unit/test_questions/test_services/test_forecasts.py
@@ -92,6 +92,25 @@ class TestCPAtResolutionTime:
         assert len(method_data["history"]) == 3
         # ...but the default preview is the CP at resolution time.
         assert method_data["latest"]["centers"] == [0.7]
+        # The capped preview is presented as the active final CP (end_time nulled),
+        # so the frontend keeps rendering the CP preview/PDF (which gates on liveness).
+        assert method_data["latest"]["end_time"] is None
+
+    def test_serialized_latest_on_feed_path_without_history(self):
+        # Feed cards fetch a single aggregate per question (include_cp_history=False).
+        question = self._build_retroactively_resolved_question()
+
+        forecasts_by_question = get_aggregated_forecasts_for_questions(
+            [question], include_cp_history=False
+        )
+        serialized = serialize_question_aggregations(
+            question, forecasts_by_question[question]
+        )
+        method_data = serialized[question.default_aggregation_method]
+
+        assert len(method_data["history"]) == 1
+        assert method_data["latest"]["centers"] == [0.7]
+        assert method_data["latest"]["end_time"] is None
 
     def test_open_question_still_uses_most_recent_cp(self):
         question = create_question(


### PR DESCRIPTION
## Summary
Fixes #5053. The default aggregate forecast ("latest" CP) preview on resolved questions showed the *last* CP value rather than the CP at the point of resolution. These differ when a question is resolved as of a past date (it kept accumulating forecasts until the resolution was actually entered). The preview now reflects the forecast value at the question's effective close/resolution time.

## Key Changes
- **`questions/services/forecasts.py`**: `get_last_aggregated_forecasts_for_questions()` now caps the "last" aggregate at `actual_close_time`. Open questions (null `actual_close_time`) still use the most recent forecast; closed/resolved questions only consider forecasts that started at or before `actual_close_time`.
- **`questions/serializers/aggregate_forecasts.py`**: Added `_get_latest_aggregate_forecast()`, which selects the forecast live at `actual_close_time` for the "latest" CP preview instead of blindly taking the most recent one. Full history is still serialized; only the "latest" preview is capped.
- **`tests/unit/test_questions/test_services/test_forecasts.py`**: New `TestCPAtResolutionTime` suite covering retroactively-resolved questions (preview uses CP at resolution time, not the later ones) and a regression guard that open questions still show the most recent CP.

## Notes
- `actual_close_time` = `min(actual_resolve_time, scheduled_close_time)`, matching the horizon that scoring already uses.
- **Scores are unaffected**: scoring (`scoring/score_math.py`) already clamps every forecast window to `actual_close_time`, so it computes on the correct range independently of this display value — the bug was display-only.
- Supersedes #5054 (recreated on a branch without "github" in the name, which Fly.io's abuse filter blocked for the preview deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgUzpLZNHiVXK3t7UGoSsU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgUzpLZNHiVXK3t7UGoSsU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed “latest” forecast selection for resolved questions to use the last available aggregation at (or before) the question’s actual close time.
  * Updated resolved-question previews so the close-time result is shown as active, including clearing its effective end time for preview purposes.
  * Prevented previews from displaying when no eligible forecasts exist at or before the actual close time (returns no preview).
  * Preserved full forecast history when requested, while feed views show only the relevant aggregation; open questions still use the most recent forecast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->