### PR TITLE
Add Jacobian conjecture solved by Claude Fable 5 to labor hub activity monitor

### DIFF
--- a/front_end/src/app/(main)/labor-hub/activity_data.tsx
+++ b/front_end/src/app/(main)/labor-hub/activity_data.tsx
@@ -288,4 +288,22 @@ export const RAW_ACTIVITY_MONITOR_DATA: RawActivityMonitorEntry[] = [
       </>
     ),
   },
+  {
+    date: "2026-07-19",
+    type: "insight",
+    content: (
+      <>
+        A Harvard mathematician reported that Claude Fable 5 solved the Jacobian
+        conjecture, an 87-year-old math problem and the most difficult yet to be
+        solved by AI. -{" "}
+        <a
+          href="https://www.newscientist.com/article/2580374-ais-solution-to-87-year-old-riddle-takes-mathematicians-by-surprise/"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          New Scientist
+        </a>
+      </>
+    ),
+  },
 ];


### PR DESCRIPTION
Adds a new activity monitor entry for July 19, 2026 noting that a Harvard mathematician reported Claude Fable 5 solved the Jacobian conjecture, an 87-year-old math problem. Rendered as a lightbulb (`insight` type).

Closes #5057

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new activity insight dated July 19, 2026, including a “Claude Fable 5” claim and a linked New Scientist source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->