### PR TITLE
Show relative timestamps in comments feed 

### DIFF
--- a/front_end/src/components/comment_feed/comment_card.tsx
+++ b/front_end/src/components/comment_feed/comment_card.tsx
@@ -121,6 +121,7 @@ const ExpandableCommentContent = ({
               datetime={comment.created_at}
               format="relative"
               threshold="P1D"
+              prefix={t("onDate", { date: "" }).trim()}
               year="numeric"
               month="short"
               day="numeric"

--- a/front_end/src/components/comment_feed/comment_card.tsx
+++ b/front_end/src/components/comment_feed/comment_card.tsx
@@ -16,6 +16,7 @@ import KeyFactorsCarousel from "@/app/(main)/questions/[id]/components/key_facto
 import CommentVoter from "@/components/comment_feed/comment_voter";
 import MarkdownEditor from "@/components/markdown_editor";
 import Button from "@/components/ui/button";
+import RelativeTime from "@/components/ui/relative_time";
 import { BECommentType, KeyFactor } from "@/types/comment";
 import { parseUserMentions } from "@/utils/comments";
 import cn from "@/utils/core/cn";
@@ -115,13 +116,19 @@ const ExpandableCommentContent = ({
           >
             {formatUsername(comment.author)}
           </Link>
-          <span
-            className="shrink-0 text-sm font-normal leading-5 text-gray-500 dark:text-gray-500-dark"
-            suppressHydrationWarning
-          >
-            {t("onDate", {
-              date: formatDate(locale, new Date(comment.created_at)),
-            })}
+          <span className="shrink-0 text-sm font-normal leading-5 text-gray-500 dark:text-gray-500-dark">
+            <RelativeTime
+              datetime={comment.created_at}
+              format="relative"
+              threshold="P1D"
+              year="numeric"
+              month="short"
+              day="numeric"
+            >
+              {t("onDate", {
+                date: formatDate(locale, new Date(comment.created_at)),
+              })}
+            </RelativeTime>
           </span>
         </div>
         {commentUrl && (


### PR DESCRIPTION
closes #5059

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Comment timestamps now display using relative time formatting for recent comments, while retaining calendar dates for older comments.
  * Improved consistency and reliability when rendering comment creation dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->