### PR TITLE
fix: labor hub commentary — 2035 Jobs Monitor decline callout

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -46,10 +46,9 @@ export const JOBS_INSIGHTS = {
     negative: (
       <>
         By 2035, <strong>financial specialists</strong>,{" "}
-        <strong>lawyers and law clerks</strong>, and{" "}
-        <strong>laborers and movers</strong> are expected to see sharp staff
-        reductions as AI takes over analysis and research work while robotics
-        automates tasks in controlled indoor environments.{" "}
+        <strong>software developers</strong>, and{" "}
+        <strong>lawyers and law clerks</strong> are expected to see sharp staff
+        reductions as AI takes over coding, analysis, and research work.{" "}
         <strong>Sales representatives</strong> will also see reductions as AI
         automates outreach and client work.
       </>

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-07-13">Jul 13</time>
+              Commentary last updated: <time dateTime="2026-07-23">Jul 23</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated QA pass over the [Labor Hub](https://www.metaculus.com/labor-hub) comparing chart data against the surrounding commentary text. One misalignment found and fixed (forecast-related only; historical/current-value items and rounding-only differences were intentionally skipped per the QA scope).

### Jobs Monitor — 2035 "sharp staff reductions" callout

- **Section:** Jobs Monitor (2035 default view)
- **Old text:** "By 2035, **financial specialists**, **lawyers and law clerks**, and **laborers and movers** are expected to see sharp staff reductions as AI takes over analysis and research work while robotics automates tasks in controlled indoor environments."
- **Chart data contradicting it (2035 % change in employment):** Financial Specialists −15.2%, Software Developers −13.8%, Lawyers and Law Clerks −13.7%, Laborers and Movers −12.0%. Software Developers has a larger decline than Laborers and Movers, so it — not Laborers and Movers — belongs in the "three largest declines" callout. This is also consistent with the 2030 callout on the same page ("software developers, financial specialists, and sales are expected to see the largest declines") and the Key Insights section, which both correctly name Software Developers as a top decliner.
- **New text:** "By 2035, **financial specialists**, **software developers**, and **lawyers and law clerks** are expected to see sharp staff reductions as AI takes over coding, analysis, and research work."

Also bumped the "Commentary last updated" date in the hero to today.

## Test plan
- [x] `bun x prettier --write` on changed files
- [x] `bun x eslint` on changed files (no errors)
- [x] Re-rendered the live page (headless Chrome) after the fix to confirm the 2035 Jobs Monitor callout and chart values are now consistent
- [x] Checked 2027 and 2030 Jobs Monitor views for the same class of issue — no discrepancies found there

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01ArUcQi8QyCKicuad3rSyYE

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArUcQi8QyCKicuad3rSyYE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the 2035 outlook to highlight expected workforce reductions for software developers and lawyers and law clerks as AI adoption increases.
  * Refreshed the “Commentary last updated” date to July 23, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->