### PR TITLE
Edit question page crashes for large groups

### DIFF
--- a/front_end/src/app/(main)/questions/components/__tests__/numeric_question_input.test.tsx
+++ b/front_end/src/app/(main)/questions/components/__tests__/numeric_question_input.test.tsx
@@ -1,0 +1,43 @@
+import { isApproximatelyEqualScaling } from "../numeric_question_input";
+
+describe("isApproximatelyEqualScaling", () => {
+  it("treats exactly equal numbers as equal", () => {
+    expect(isApproximatelyEqualScaling(42, 42)).toBe(true);
+    expect(isApproximatelyEqualScaling(0, 0)).toBe(true);
+    expect(isApproximatelyEqualScaling(-1.5, -1.5)).toBe(true);
+  });
+
+  it("absorbs tiny float drift around small numeric/discrete bounds", () => {
+    expect(isApproximatelyEqualScaling(1.2, 1.2 + 1e-10)).toBe(true);
+    expect(isApproximatelyEqualScaling(0.1 + 0.2, 0.3)).toBe(true);
+    const derived = 5 - 0.5 * 0.3333333333 + 0.5 * 0.3333333333;
+    expect(isApproximatelyEqualScaling(derived, 5)).toBe(true);
+  });
+
+  it("absorbs harmless precision drift on large Date-like timestamps", () => {
+    const ts = 1_700_000_000;
+    const noisy = (1e10 * ts) / 1e10;
+    expect(isApproximatelyEqualScaling(noisy, ts)).toBe(true);
+    expect(isApproximatelyEqualScaling(ts + ts * 4 * Number.EPSILON, ts)).toBe(
+      true
+    );
+  });
+
+  it("detects meaningful differences, including sub-second date edits", () => {
+    expect(isApproximatelyEqualScaling(1_700_000_001, 1_700_000_000)).toBe(
+      false
+    );
+    expect(isApproximatelyEqualScaling(4.75, 5)).toBe(false);
+    expect(isApproximatelyEqualScaling(1.2, 1.2 + 1e-6)).toBe(false);
+  });
+
+  it("preserves null / undefined semantics", () => {
+    expect(isApproximatelyEqualScaling(null, null)).toBe(true);
+    expect(isApproximatelyEqualScaling(undefined, undefined)).toBe(true);
+    expect(isApproximatelyEqualScaling(null, undefined)).toBe(false);
+    expect(isApproximatelyEqualScaling(null, 0)).toBe(false);
+    expect(isApproximatelyEqualScaling(5, undefined)).toBe(false);
+    expect(isApproximatelyEqualScaling(NaN, undefined)).toBe(false);
+    expect(isApproximatelyEqualScaling(NaN, NaN)).toBe(true);
+  });
+});

--- a/front_end/src/app/(main)/questions/components/__tests__/viewport_render.test.tsx
+++ b/front_end/src/app/(main)/questions/components/__tests__/viewport_render.test.tsx
@@ -1,0 +1,50 @@
+import { act, render, screen } from "@testing-library/react";
+
+import ViewportRender from "../viewport_render";
+
+class IntersectionObserverMock {
+  static instances: IntersectionObserverMock[] = [];
+
+  callback: IntersectionObserverCallback;
+  disconnect = jest.fn();
+  observe = jest.fn();
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    IntersectionObserverMock.instances.push(this);
+  }
+
+  trigger(isIntersecting: boolean) {
+    this.callback(
+      [{ isIntersecting } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver
+    );
+  }
+}
+
+describe("ViewportRender", () => {
+  beforeEach(() => {
+    IntersectionObserverMock.instances = [];
+    global.IntersectionObserver =
+      IntersectionObserverMock as unknown as typeof IntersectionObserver;
+  });
+
+  it("renders its children after entering the viewport", () => {
+    render(
+      <ViewportRender>
+        <div>Heavy content</div>
+      </ViewportRender>
+    );
+
+    expect(screen.queryByText("Heavy content")).not.toBeInTheDocument();
+
+    const observer = IntersectionObserverMock.instances[0];
+    expect(observer).toBeDefined();
+    expect(observer?.observe).toHaveBeenCalledTimes(1);
+
+    act(() => observer?.trigger(true));
+
+    expect(screen.getByText("Heavy content")).toBeInTheDocument();
+    expect(observer?.disconnect).toHaveBeenCalled();
+  });
+});

--- a/front_end/src/app/(main)/questions/components/group_form.tsx
+++ b/front_end/src/app/(main)/questions/components/group_form.tsx
@@ -464,9 +464,20 @@ const GroupForm: React.FC<Props> = ({
   const { title: formattedQuestionType, description: questionDescription } =
     questionSubtypeDisplayMap[subtype] || { title: subtype, description: "" };
 
+  const updateSubQuestionAt = useCallback(
+    (index: number, patch: Partial<SubQuestionDraft>) => {
+      setSubQuestions((previous) =>
+        previous.map((subQuestion, iterIndex) =>
+          iterIndex === index ? { ...subQuestion, ...patch } : subQuestion
+        )
+      );
+    },
+    []
+  );
+
   const onBulkEdit = (attrs: BulkBulkQuestionAttrs) => {
-    setSubQuestions(
-      subQuestions.map((subQuestion) => ({
+    setSubQuestions((previous) =>
+      previous.map((subQuestion) => ({
         ...subQuestion,
         ...attrs,
       }))
@@ -791,14 +802,7 @@ const GroupForm: React.FC<Props> = ({
                 >
                   <Input
                     onChange={(e) => {
-                      setSubQuestions(
-                        subQuestions.map((subQuestion, iter_index) => {
-                          if (index === iter_index) {
-                            subQuestion["label"] = e.target.value;
-                          }
-                          return subQuestion;
-                        })
-                      );
+                      updateSubQuestionAt(index, { label: e.target.value });
                     }}
                     className="rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
                     value={subQuestion?.label}
@@ -816,13 +820,9 @@ const GroupForm: React.FC<Props> = ({
                       >
                         <Input
                           onChange={(e) => {
-                            setSubQuestions(
-                              subQuestions.map((subQuestion, iter_index) => {
-                                if (index === iter_index)
-                                  subQuestion.unit = e.target.value;
-                                return subQuestion;
-                              })
-                            );
+                            updateSubQuestionAt(index, {
+                              unit: e.target.value,
+                            });
                           }}
                           className="rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
                           value={subQuestion?.unit ?? ""}
@@ -841,14 +841,9 @@ const GroupForm: React.FC<Props> = ({
                             form.clearErrors(
                               `subQuestion-${index}-scheduled_close_time`
                             );
-                            setSubQuestions(
-                              subQuestions.map((subQuestion, iter_index) => {
-                                if (index === iter_index) {
-                                  subQuestion.scheduled_close_time = value;
-                                }
-                                return subQuestion;
-                              })
-                            );
+                            updateSubQuestionAt(index, {
+                              scheduled_close_time: value,
+                            });
                           }}
                           onError={(error) => {
                             form.setError(
@@ -880,14 +875,9 @@ const GroupForm: React.FC<Props> = ({
                             form.clearErrors(
                               `subQuestion-${index}-scheduled_resolve_time`
                             );
-                            setSubQuestions(
-                              subQuestions.map((subQuestion, iter_index) => {
-                                if (index === iter_index) {
-                                  subQuestion.scheduled_resolve_time = value;
-                                }
-                                return subQuestion;
-                              })
-                            );
+                            updateSubQuestionAt(index, {
+                              scheduled_resolve_time: value,
+                            });
                           }}
                           onError={(error) => {
                             form.setError(
@@ -918,14 +908,7 @@ const GroupForm: React.FC<Props> = ({
                           className="rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
                           defaultValue={subQuestion.open_time}
                           onChange={(value) => {
-                            setSubQuestions(
-                              subQuestions.map((subQuestion, iter_index) => {
-                                if (index === iter_index) {
-                                  subQuestion.open_time = value;
-                                }
-                                return subQuestion;
-                              })
-                            );
+                            updateSubQuestionAt(index, { open_time: value });
                           }}
                         />
                       </InputContainer>
@@ -937,14 +920,9 @@ const GroupForm: React.FC<Props> = ({
                           className="rounded border border-gray-500 px-3 py-2 text-base dark:border-gray-500-dark dark:bg-blue-50-dark"
                           defaultValue={subQuestion.cp_reveal_time}
                           onChange={(value) => {
-                            setSubQuestions(
-                              subQuestions.map((subQuestion, iter_index) => {
-                                if (index === iter_index) {
-                                  subQuestion.cp_reveal_time = value;
-                                }
-                                return subQuestion;
-                              })
-                            );
+                            updateSubQuestionAt(index, {
+                              cp_reveal_time: value,
+                            });
                           }}
                         />
                       </InputContainer>
@@ -979,23 +957,16 @@ const GroupForm: React.FC<Props> = ({
                           zero_point,
                           inbound_outcome_count,
                         }) => {
-                          setSubQuestions(
-                            subQuestions.map((subQuestion, iter_index) =>
-                              index === iter_index
-                                ? {
-                                    ...subQuestion,
-                                    open_lower_bound,
-                                    open_upper_bound,
-                                    inbound_outcome_count,
-                                    scaling: {
-                                      range_min,
-                                      range_max,
-                                      zero_point,
-                                    },
-                                  }
-                                : subQuestion
-                            )
-                          );
+                          updateSubQuestionAt(index, {
+                            open_lower_bound,
+                            open_upper_bound,
+                            inbound_outcome_count,
+                            scaling: {
+                              range_min,
+                              range_max,
+                              zero_point,
+                            },
+                          });
                         }}
                         control={form as unknown as UseFormReturn}
                         index={index}
@@ -1010,13 +981,10 @@ const GroupForm: React.FC<Props> = ({
                       size="sm"
                       variant="tertiary"
                       onClick={() => {
-                        setCollapsedSubQuestions(
-                          collapsedSubQuestions.map((x, iter_index) => {
-                            if (iter_index === index) {
-                              return !x;
-                            }
-                            return x;
-                          })
+                        setCollapsedSubQuestions((previous) =>
+                          previous.map((x, iter_index) =>
+                            iter_index === index ? !x : x
+                          )
                         );
                       }}
                     >
@@ -1037,16 +1005,16 @@ const GroupForm: React.FC<Props> = ({
                         }
                         onClick={() => {
                           if (!isManual) return;
-                          setSubQuestions(
-                            shiftArrayElement(subQuestions, index, -1).map(
+                          setSubQuestions((previous) =>
+                            shiftArrayElement(previous, index, -1).map(
                               (q, idx) => ({
                                 ...q,
                                 group_rank: idx,
                               })
                             )
                           );
-                          setCollapsedSubQuestions(
-                            shiftArrayElement(collapsedSubQuestions, index, -1)
+                          setCollapsedSubQuestions((previous) =>
+                            shiftArrayElement(previous, index, -1)
                           );
                         }}
                       >
@@ -1066,16 +1034,16 @@ const GroupForm: React.FC<Props> = ({
                         }
                         onClick={() => {
                           if (!isManual) return;
-                          setSubQuestions(
-                            shiftArrayElement(subQuestions, index, 1).map(
+                          setSubQuestions((previous) =>
+                            shiftArrayElement(previous, index, 1).map(
                               (q, idx) => ({
                                 ...q,
                                 group_rank: idx,
                               })
                             )
                           );
-                          setCollapsedSubQuestions(
-                            shiftArrayElement(collapsedSubQuestions, index, 1)
+                          setCollapsedSubQuestions((previous) =>
+                            shiftArrayElement(previous, index, 1)
                           );
                         }}
                       >
@@ -1090,15 +1058,11 @@ const GroupForm: React.FC<Props> = ({
                     variant="tertiary"
                     className="border-red-200 text-red-400 hover:border-red-400 active:border-red-600 active:bg-red-100/50 dark:border-red-400/50 dark:text-red-400 dark:hover:border-red-400 dark:active:border-red-300/75 dark:active:bg-red-400/15"
                     onClick={() => {
-                      setSubQuestions(
-                        subQuestions.filter(
-                          (subQuestion, iter_index) => index !== iter_index
-                        )
+                      setSubQuestions((previous) =>
+                        previous.filter((_, iter_index) => index !== iter_index)
                       );
-                      setCollapsedSubQuestions(
-                        collapsedSubQuestions.filter(
-                          (_, iter_index) => index !== iter_index
-                        )
+                      setCollapsedSubQuestions((previous) =>
+                        previous.filter((_, iter_index) => index !== iter_index)
                       );
                     }}
                   >
@@ -1161,11 +1125,11 @@ const GroupForm: React.FC<Props> = ({
                     }
                   }
 
-                  setSubQuestions([...subQuestions, clone]);
+                  setSubQuestions((previous) => [...previous, clone]);
                 } else {
                   if (subtype === QuestionType.Numeric) {
-                    setSubQuestions([
-                      ...subQuestions,
+                    setSubQuestions((previous) => [
+                      ...previous,
                       {
                         type: QuestionType.Numeric,
                         clientId: crypto.randomUUID(),
@@ -1184,8 +1148,8 @@ const GroupForm: React.FC<Props> = ({
                       },
                     ]);
                   } else if (subtype === QuestionType.Discrete) {
-                    setSubQuestions([
-                      ...subQuestions,
+                    setSubQuestions((previous) => [
+                      ...previous,
                       {
                         type: QuestionType.Discrete,
                         clientId: crypto.randomUUID(),
@@ -1205,8 +1169,8 @@ const GroupForm: React.FC<Props> = ({
                       },
                     ]);
                   } else if (subtype === QuestionType.Date) {
-                    setSubQuestions([
-                      ...subQuestions,
+                    setSubQuestions((previous) => [
+                      ...previous,
                       {
                         type: QuestionType.Date,
                         clientId: crypto.randomUUID(),
@@ -1225,8 +1189,8 @@ const GroupForm: React.FC<Props> = ({
                       },
                     ]);
                   } else {
-                    setSubQuestions([
-                      ...subQuestions,
+                    setSubQuestions((previous) => [
+                      ...previous,
                       {
                         type: QuestionType.Binary,
                         clientId: crypto.randomUUID(),
@@ -1239,7 +1203,7 @@ const GroupForm: React.FC<Props> = ({
                     ]);
                   }
                 }
-                setCollapsedSubQuestions([...collapsedSubQuestions, true]);
+                setCollapsedSubQuestions((previous) => [...previous, true]);
               }}
               className="w-fit capitalize"
             >

--- a/front_end/src/app/(main)/questions/components/numeric_question_input.tsx
+++ b/front_end/src/app/(main)/questions/components/numeric_question_input.tsx
@@ -19,6 +19,31 @@ import {
 import { ContinuousQuestionType, QuestionType } from "@/types/question";
 import { getQuestionDraft } from "@/utils/drafts/questionForm";
 
+import ViewportRender from "./viewport_render";
+
+const SCALING_ABS_TOLERANCE = 1e-9;
+const SCALING_REL_TOLERANCE = 16 * Number.EPSILON;
+
+export const isApproximatelyEqualScaling = (
+  a: number | null | undefined,
+  b: number | null | undefined
+): boolean => {
+  if (Object.is(a, b)) {
+    return true;
+  }
+  if (typeof a !== "number" || typeof b !== "number") {
+    return false;
+  }
+  if (!Number.isFinite(a) || !Number.isFinite(b)) {
+    return false;
+  }
+  const tolerance = Math.max(
+    SCALING_ABS_TOLERANCE,
+    SCALING_REL_TOLERANCE * Math.max(Math.abs(a), Math.abs(b))
+  );
+  return Math.abs(a - b) <= tolerance;
+};
+
 const NumericQuestionInput: React.FC<{
   onChange: ({
     range_min,
@@ -287,14 +312,24 @@ const NumericQuestionInput: React.FC<{
         );
         setZeroPoint(isNil(draftZeroPoint) ? zeroPoint : draftZeroPoint);
       } else {
-        onChange({
-          range_min: mn as number,
-          range_max: mx as number,
-          zero_point: zeroPoint,
-          open_lower_bound: openLowerBound,
-          open_upper_bound: openUpperBound,
-          inbound_outcome_count: inboundOutcomeCount,
-        });
+        const hasInitialValueChanges =
+          !isApproximatelyEqualScaling(mn, defaultMin) ||
+          !isApproximatelyEqualScaling(mx, defaultMax) ||
+          !isApproximatelyEqualScaling(zeroPoint, defaultZeroPoint) ||
+          !Object.is(openLowerBound, defaultOpenLowerBound) ||
+          !Object.is(openUpperBound, defaultOpenUpperBound) ||
+          !Object.is(inboundOutcomeCount, defaultInboundOutcomeCount);
+
+        if (hasInitialValueChanges) {
+          onChange({
+            range_min: mn as number,
+            range_max: mx as number,
+            zero_point: zeroPoint,
+            open_lower_bound: openLowerBound,
+            open_upper_bound: openUpperBound,
+            inbound_outcome_count: inboundOutcomeCount,
+          });
+        }
         shouldUpdateParrent.current = true;
       }
       isMounted.current = true;
@@ -573,7 +608,9 @@ const NumericQuestionInput: React.FC<{
         {errors.length === 0 && !isNil(max) && !isNil(min) && (
           <div>
             Example input chart:
-            <ExampleContinuousInput question={question} />
+            <ViewportRender>
+              <ExampleContinuousInput question={question} />
+            </ViewportRender>
           </div>
         )}
       </div>

--- a/front_end/src/app/(main)/questions/components/viewport_render.tsx
+++ b/front_end/src/app/(main)/questions/components/viewport_render.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { ReactNode, useEffect, useRef, useState } from "react";
+
+type Props = {
+  children: ReactNode;
+};
+
+const ViewportRender: React.FC<Props> = ({ children }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [hasEnteredViewport, setHasEnteredViewport] = useState(false);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    if (typeof IntersectionObserver === "undefined") {
+      const timeoutId = window.setTimeout(() => setHasEnteredViewport(true), 0);
+      return () => window.clearTimeout(timeoutId);
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setHasEnteredViewport(true);
+          observer.disconnect();
+        }
+      },
+      {
+        rootMargin: "800px 0px",
+      }
+    );
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={containerRef}>
+      {hasEnteredViewport ? (
+        children
+      ) : (
+        <div
+          aria-hidden
+          className="min-h-[32rem] animate-pulse rounded bg-gray-100 dark:bg-gray-100-dark"
+        />
+      )}
+    </div>
+  );
+};
+
+export default ViewportRender;


### PR DESCRIPTION
Fixes #5088

### Summary

Fixes crashes and long input blocking when editing large question groups: all numeric forecast previews were mounting at once, including charts, sliders, and calculation-heavy controls.

Implemented changes:

* `viewport_render.tsx`: added viewport-based deferred mounting for numeric forecast previews. Full preview controls mount shortly before they become visible and remain mounted afterward, preserving existing editing behavior.
* `numeric_question_input.tsx`: prevented redundant initial form updates caused by floating-point drift in re-derived Date and Discrete scaling bounds.
* `group_form.tsx`: switched subquestion updates to functional React state updates, preventing stale state from overwriting concurrent edits and removing direct state mutations.
* `numeric_question_input.test.tsx`: added coverage for exact values, floating-point rounding noise, Date timestamps, meaningful changes, and invalid/missing scaling values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Deferred rendering of continuous numeric examples until they are near the viewport, improving initial page responsiveness.
  * Added a lightweight placeholder while deferred content loads.

* **Bug Fixes**
  * Reduced unnecessary updates when numeric question defaults already match existing values.
  * Improved reliability when editing, reordering, adding, or removing grouped sub-questions.

* **Tests**
  * Added coverage for approximate numeric comparisons, viewport-triggered rendering, observer cleanup, and special numeric values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->