### PR TITLE
Social auth flow: fixed accounts associations match

### DIFF
--- a/authentication/social_pipeline.py
+++ b/authentication/social_pipeline.py
@@ -5,6 +5,37 @@ from rest_framework.exceptions import ValidationError
 from users.models import User
 
 
+def associate_by_email(backend, details, user=None, *args, **kwargs):
+    """
+    Replaces social_core's associate_by_email, which only matches active users -
+    so a provider login whose email belonged to a pending signup created a
+    duplicate account instead of matching it.
+
+    Mirrors the email-link flow: a never-activated account is claimed and
+    activated, while deactivated and spam accounts are refused.
+    """
+    if user:
+        return None
+
+    email = details.get("email")
+    if not email:
+        return None
+
+    existing = User.objects.filter(email__iexact=email).last()
+
+    if not existing:
+        return None
+
+    if not existing.is_active:
+        if not existing.check_can_activate():
+            raise ValidationError("This account is no longer available")
+
+        existing.is_active = True
+        existing.save(update_fields=["is_active"])
+
+    return {"user": existing, "is_new": False}
+
+
 def create_user(strategy, details, backend, user=None, *args, **kwargs):
     """
     Replaces social_core's create_user step so we own social account creation.

--- a/metaculus_web/settings.py
+++ b/metaculus_web/settings.py
@@ -253,7 +253,7 @@ SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.social_auth.auth_allowed",
     "social_core.pipeline.social_auth.social_user",
     "social_core.pipeline.user.get_username",
-    "social_core.pipeline.social_auth.associate_by_email",
+    "authentication.social_pipeline.associate_by_email",
     "authentication.social_pipeline.create_user",
     "social_core.pipeline.social_auth.associate_user",
     "social_core.pipeline.social_auth.load_extra_data",

--- a/tests/unit/test_auth/test_social_pipeline.py
+++ b/tests/unit/test_auth/test_social_pipeline.py
@@ -1,0 +1,91 @@
+from datetime import timedelta
+from unittest.mock import Mock
+
+import pytest
+from django.utils import timezone
+from rest_framework.exceptions import ValidationError
+
+from authentication.social_pipeline import associate_by_email
+from tests.unit.test_users.factories import factory_user
+from users.models import User
+
+EMAIL = "pending@example.com"
+
+
+def details(email=EMAIL):
+    return {"email": email, "username": "social_user"}
+
+
+def user_with_email(email=EMAIL, **kwargs):
+    """A signup awaiting its activation email unless overridden."""
+    kwargs.setdefault("is_active", False)
+    kwargs.setdefault("last_login", None)
+    kwargs.setdefault("is_spam", False)
+
+    return factory_user(email=email, **kwargs)
+
+
+class TestAssociateByEmail:
+    """
+    Social login must reuse the account that already owns the email instead of
+    creating a duplicate. social_core's own step only looks at active users, so
+    a pending signup was invisible to it and every such login minted a second
+    account.
+    """
+
+    def test_claims_pending_signup(self):
+        existing = user_with_email()
+
+        result = associate_by_email(Mock(), details())
+
+        existing.refresh_from_db()
+        assert result == {"user": existing, "is_new": False}
+        assert existing.is_active
+        assert User.objects.count() == 1
+
+    @pytest.mark.parametrize(
+        "state",
+        [{"last_login": timezone.now()}, {"is_spam": True}],
+        ids=["deactivated", "spam"],
+    )
+    def test_refuses_unavailable_account(self, state):
+        user_with_email(**state)
+
+        with pytest.raises(ValidationError):
+            associate_by_email(Mock(), details())
+
+    def test_associates_active_account(self):
+        existing = user_with_email(is_active=True)
+
+        result = associate_by_email(Mock(), details())
+
+        assert result == {"user": existing, "is_new": False}
+
+    def test_matches_email_case_insensitively(self):
+        existing = user_with_email(email="Mixed@Example.com")
+
+        result = associate_by_email(Mock(), details("mixed@example.com"))
+
+        assert result["user"] == existing
+
+    def test_picks_last_when_email_is_duplicated(self):
+        user_with_email(is_active=True, date_joined=timezone.now())
+        newest = user_with_email(is_active=True)
+
+        result = associate_by_email(Mock(), details())
+
+        assert result["user"] == newest
+
+    def test_ignores_unknown_email(self):
+        assert associate_by_email(Mock(), details("nobody@example.com")) is None
+
+    def test_ignores_login_without_email(self):
+        # Bots and cleaned-up accounts share the empty email and must not match
+        factory_user(email="", is_active=True)
+
+        assert associate_by_email(Mock(), {"username": "social_user"}) is None
+
+    def test_ignores_already_associated_login(self):
+        user_with_email()
+
+        assert associate_by_email(Mock(), details(), user=factory_user()) is None

--- a/tests/unit/test_auth/test_social_pipeline.py
+++ b/tests/unit/test_auth/test_social_pipeline.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from unittest.mock import Mock
 
 import pytest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Social login now associates by email using a case-insensitive match.
  * If there’s a matching inactive account that can be reactivated, it will be activated during social login.
* **Bug Fixes**
  * Prevents associating social login with deactivated or spam accounts.
  * When multiple active accounts match the same email, the most recently joined account is selected.
  * Safely handles missing/unknown email values and avoids rematching when already linked.
* **Tests**
  * Added unit coverage for the social login association behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->