### PR TITLE
Social auth flow: gated actions support

### DIFF
--- a/authentication/services/gated_actions.py
+++ b/authentication/services/gated_actions.py
@@ -189,6 +189,37 @@ def validate_gated_action(action) -> tuple[str, object]:
     return slug, payload
 
 
+def apply_gated_action(user: User, slug: str, payload) -> None:
+    """
+    Apply one already-resolved gated action and log the outcome. Never raises:
+    an action failure must not roll back a sign-in that already succeeded.
+    """
+    try:
+        GATED_ACTIONS[slug].apply(user, payload)
+
+        logger.info(f"Gated action {slug} applied for user {user.id}")
+    except Exception:
+        logger.exception(f"Gated action {slug} failed for user {user.id}")
+
+
+def validate_and_apply_gated_action(user: User, action) -> None:
+    """
+    Validate a raw action envelope and apply it in one shot, best-effort. Never
+    raises. For flows where capture and apply happen in the same authenticated
+    request (social auth), so there is no Redis round trip to bridge them.
+    """
+    if not action:
+        return
+
+    try:
+        slug, payload = validate_gated_action(action)
+    except Exception as exc:
+        logger.warning(f"Invalid inline gated action for user {user.id}: {exc}")
+        return
+
+    apply_gated_action(user, slug, payload)
+
+
 def apply_pending_action(user: User) -> None:
     """
     Pop and apply the user's pending gated action. Never raises - sign-in must
@@ -201,11 +232,4 @@ def apply_pending_action(user: User) -> None:
         logger.info(f"email_link: no pending action for user={user.id}")
         return
 
-    slug = entry["type"]
-
-    try:
-        GATED_ACTIONS[slug].apply(user, entry["payload"])
-    except Exception:
-        logger.exception(f"Gated action {slug} crashed for user {user.id}")
-    else:
-        logger.info(f"Gated action {slug} applied for user {user.id}")
+    apply_gated_action(user, entry["type"], entry["payload"])

--- a/authentication/services/gated_actions.py
+++ b/authentication/services/gated_actions.py
@@ -232,4 +232,9 @@ def apply_pending_action(user: User) -> None:
         logger.info(f"email_link: no pending action for user={user.id}")
         return
 
-    apply_gated_action(user, entry["type"], entry["payload"])
+    try:
+        apply_gated_action(user, entry["type"], entry["payload"])
+    except Exception as exc:
+        logger.warning(
+            f"email_link: malformed pending action for user={user.id}: {exc}"
+        )

--- a/authentication/views/social.py
+++ b/authentication/views/social.py
@@ -9,6 +9,7 @@ from rest_social_auth.views import SocialTokenOnlyAuthView
 from social_core.backends.oauth import BaseOAuth2
 
 from authentication.services.common import get_tokens_for_user
+from authentication.services.gated_actions import validate_and_apply_gated_action
 from users.models import User
 
 
@@ -58,3 +59,9 @@ class SocialCodeAuth(SocialTokenOnlyAuthView):
         response = super().respond_error(error)
 
         return Response({"detail": response.data}, status=status.HTTP_400_BAD_REQUEST)
+
+    def do_login(self, backend, user):
+        super().do_login(backend, user)
+        # Same request that mints the JWT carries the gated action, so apply it
+        # inline (best-effort, never blocks sign-in) - no Redis bridge needed.
+        validate_and_apply_gated_action(user, self.request.data.get("gated_action"))

--- a/tests/unit/test_auth/test_gated_actions.py
+++ b/tests/unit/test_auth/test_gated_actions.py
@@ -10,7 +10,6 @@ from authentication.services.gated_actions import (
     clear_pending_action,
     pop_pending_action,
     set_pending_action,
-    validate_and_apply_gated_action,
     validate_gated_action,
 )
 from posts.models import PostSubscription, Vote

--- a/tests/unit/test_auth/test_gated_actions.py
+++ b/tests/unit/test_auth/test_gated_actions.py
@@ -5,10 +5,12 @@ from django.utils import timezone as dj_timezone
 from rest_framework.exceptions import ValidationError
 
 from authentication.services.gated_actions import (
+    apply_gated_action,
     apply_pending_action,
     clear_pending_action,
     pop_pending_action,
     set_pending_action,
+    validate_and_apply_gated_action,
     validate_gated_action,
 )
 from posts.models import PostSubscription, Vote
@@ -231,3 +233,16 @@ class TestForecastAction:
         apply_pending_action(user2)
 
         assert not Forecast.objects.filter(author=user2).exists()
+
+
+class TestApplyGatedAction:
+    def test_applies_resolved_action(self, user1, user2, public_post):
+        apply_gated_action(user2, "post_vote", {"post": public_post.pk, "direction": 1})
+
+        assert Vote.objects.filter(user=user2, post=public_post, direction=1).exists()
+
+    def test_swallows_handler_failure(self, user1):
+        # Missing post -> handler raises; must be caught, not propagated.
+        apply_gated_action(user1, "post_vote", {"post": 999999, "direction": 1})
+
+        assert not Vote.objects.filter(user=user1).exists()

--- a/tests/unit/test_auth/test_gated_actions.py
+++ b/tests/unit/test_auth/test_gated_actions.py
@@ -121,6 +121,28 @@ class TestApplyPendingAction:
 
         assert not Vote.objects.filter(user=user2).exists()
 
+    def test_malformed_entry_missing_keys_does_not_raise(self, mocker, user1):
+        # A cache entry missing "type"/"payload" must not raise; sign-in continues.
+        mocker.patch(
+            "authentication.services.gated_actions.pop_pending_action",
+            return_value={"payload": {"post": 1, "direction": 1}},
+        )
+
+        apply_pending_action(user1)
+
+        assert not Vote.objects.filter(user=user1).exists()
+
+    def test_non_dict_entry_does_not_raise(self, mocker, user1):
+        # A non-dict decoded cache value must not raise on entry["type"].
+        mocker.patch(
+            "authentication.services.gated_actions.pop_pending_action",
+            return_value=["not", "a", "dict"],
+        )
+
+        apply_pending_action(user1)
+
+        assert not Vote.objects.filter(user=user1).exists()
+
 
 class TestPostSubscribeAction:
     PAYLOAD_SUBS = [


### PR DESCRIPTION
**Backend:** `POST /auth/social/<provider>/` now accepts an optional `gated_action` in the body and applies it inline right after sign-in (vote/subscribe/forecast), fail-open — a bad/missing action is logged and dropped, never blocking sign-in. 

No Redis: unlike email-link, capture and apply happen in the same authenticated request.

**Frontend (proposed, next):** before redirecting to the OAuth provider, persist the pending `gated_action` in the browser (local/sessionStorage), then send it with the code exchange on return. Social auth almost always completes in the *same* browser — unlike the email-link token, which can be opened on a different browser/device and therefore needs server-side storage. Encoding the action into the OAuth `state`/redirect URL is possible but can make the URL extremely long, so local storage is preferred.

closes #5096 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Social sign-in now processes eligible gated actions provided in the sign-in request.
* **Bug Fixes**
  * Gated actions are applied consistently for both immediate and pending-action flows.
  * Failures during gated action handling no longer interrupt authentication or create unintended side effects.
  * Malformed pending actions are safely ignored without impacting stored results.
* **Tests**
  * Added coverage for successful gated action application and graceful handling of handler failures and malformed pending entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->