### PR TITLE
Editing doesn't work for some questions

### DIFF
--- a/front_end/src/app/(main)/questions/components/question_form.tsx
+++ b/front_end/src/app/(main)/questions/components/question_form.tsx
@@ -482,6 +482,11 @@ const QuestionForm: FC<Props> = ({
         post?.question?.include_bots_in_aggregates ?? false,
       options_order:
         post?.question?.options_order ?? MultipleChoiceOptionsOrder.DEFAULT,
+      scaling: post?.question?.scaling ?? undefined,
+      open_lower_bound: post?.question?.open_lower_bound ?? undefined,
+      open_upper_bound: post?.question?.open_upper_bound ?? undefined,
+      inbound_outcome_count:
+        post?.question?.inbound_outcome_count ?? DefaultInboundOutcomeCount,
     },
   });
   useEffect(() => {


### PR DESCRIPTION
### Summary

Fixes Save Edits silently failing when editing an existing Numeric/Date/Discrete question: `scaling` stayed unset in the form whenever the range inputs weren't touched (the normal case once a question has forecasts and those inputs are disabled), so required-field validation failed silently and the button appeared to do nothing.

Implemented changes:

* `front_end/src/app/(main)/questions/components/question_form.tsx`: seed `scaling`, `open_lower_bound`, `open_upper_bound`, `inbound_outcome_count` from `post.question` in `useForm`'s `defaultValues`, instead of relying solely on the child input's `onChange`.

Slack thread: https://metaculus.slack.com/archives/C01Q9AQBVHB/p1785375340453069

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Question forms now correctly prepopulate continuous-question fields, including scaling, bounds, and inbound outcome count, when editing existing questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->