### PR TITLE
fix: labor hub commentary — jobs monitor 2027 mismatch

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -8,9 +8,9 @@ export const JOBS_INSIGHTS = {
     ),
     negative: (
       <>
-        By 2027, <strong>sales representatives</strong> are expected to see
-        early declines as AI begins to automate outreach and client
-        interactions.
+        By 2027, <strong>designers</strong> and{" "}
+        <strong>sales representatives</strong> are expected to see early
+        declines as AI begins to automate creative and client-facing work.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-07-25">Jul 25</time>
+              Commentary last updated: <time dateTime="2026-07-31">Jul 31</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated QA pass on the [Labor Automation Forecasting Hub](https://www.metaculus.com/labor-hub) cross-referencing chart/table data against the surrounding commentary text. One misalignment found and fixed, in the Jobs Monitor section's 2027 view.

## Fix

**Jobs Monitor — 2027 "Expected decline" insight**

- **Before:** "By 2027, **sales representatives** are expected to see early declines as AI begins to automate outreach and client interactions."
- **After:** "By 2027, **designers** and **sales representatives** are expected to see early declines as AI begins to automate creative and client-facing work."
- **Why:** For the 2027 forecast, only 5 occupations have data. Of the 4 declining, **Designers** has the largest decline, with Sales Representatives, Financial Specialists, and Software Developers all close behind. The prior copy singled out Sales Representatives as the lead story while omitting Designers, the actual largest decliner. (2030 and 2035 insights were checked as well and correctly reflect their underlying data — no changes needed there.)

Also bumped the "Commentary last updated" date on the hero section to reflect this change.

## Scope

Only commentary copy was changed — no chart data, component structure, or unrelated code was touched. Formatter (prettier) and linter (eslint) were run on both changed files with no errors.

## Test plan

- [x] `npx prettier --write` on changed files — no diff
- [x] `npx eslint` on changed files — no errors
- [ ] Visual check of the Jobs Monitor 2027 tab in a running app (not performed in this session — see notes)

## Notes

Browser-based visual QA (screenshot, live click-through of the 2027/2030/2035 toggle) was not possible in this session: the sandboxed Chromium instance could not complete a TLS handshake to metaculus.com through the network egress proxy (consistent `ERR_CONNECTION_RESET` at the TLS layer), while plain `curl` through the same proxy worked fine. Analysis was instead done by fetching the server-rendered HTML/RSC payload directly (which embeds the full per-occupation, per-year dataset for the Jobs Monitor and comparison tables) and cross-referencing it against this repo's source, which is a more precise source of truth for the underlying data than a screenshot would have been.


---
_Generated by [Claude Code](https://claude.ai/code/session_013jLpTSebRJvC5cFMihiiSg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Updated the 2027 job outlook to include designers among roles potentially affected by automation.
  - Revised the outlook explanation to reference creative and client-facing work.
  - Updated the displayed commentary date to July 31, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->