### PR TITLE
fix: labor hub commentary — jobs monitor 2027 mismatch

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -8,9 +8,9 @@ export const JOBS_INSIGHTS = {
     ),
     negative: (
       <>
-        By 2027, <strong>sales representatives</strong> are expected to see
-        early declines as AI begins to automate outreach and client
-        interactions.
+        By 2027, <strong>designers</strong> and{" "}
+        <strong>sales representatives</strong> are expected to see early
+        declines as AI begins to automate creative and client-facing work.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-07-25">Jul 25</time>
+              Commentary last updated: <time dateTime="2026-08-03">Aug 3</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated QA pass on the [Labor Automation Forecasting Hub](https://www.metaculus.com/labor-hub) cross-referencing chart/table data against the surrounding commentary text. One misalignment found and fixed, in the Jobs Monitor section's 2027 view. (Supersedes #5103, which had the identical fix on a stale branch — closed in favor of this PR.)

## Fix

**Jobs Monitor — 2027 "Expected decline" insight**

- **Before:** "By 2027, **sales representatives** are expected to see early declines as AI begins to automate outreach and client interactions."
- **After:** "By 2027, **designers** and **sales representatives** are expected to see early declines as AI begins to automate creative and client-facing work."
- **Why:** For the 2027 forecast, only 5 occupations have data. Of the 4 declining, **Designers** (-1.5%) has the largest decline — ahead of Software Developers, Sales Representatives, and Financial Specialists (all roughly -0.8% to -1.0%). The prior copy singled out Sales Representatives as the lead story while omitting Designers, the actual largest decliner.

2030 and 2035 insights were re-checked as well (including toggling the Jobs Monitor year buttons live) and correctly reflect their underlying data — no changes needed there.

Also bumped the "Commentary last updated" date on the hero section to reflect this change.

## Scope

Only commentary copy was changed — no chart data, component structure, or unrelated code was touched. Formatter (prettier) and linter (eslint) were run on both changed files with no errors.

## Test plan

- [x] `npx prettier --write` on changed files — no diff
- [x] `npx eslint` on changed files — no errors
- [x] Live browser QA of the Jobs Monitor 2027/2030/2035 toggle via headless Chromium (screenshots + DOM/aria-label extraction) confirming chart values before applying the fix

🤖 Generated with [Claude Code](https://claude.ai/code)

Claude-Session: https://claude.ai/code/session_01BjUAoXZt67XqN2yMqFgMUF

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjUAoXZt67XqN2yMqFgMUF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the 2027 negative job outlook to include designers and reflect automation of creative and client-facing work.
  * Updated the displayed commentary date to August 3, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->