### PR TITLE
fix: hide "send back to review" button for non-approved posts

### DIFF
--- a/front_end/src/components/post_actions/post_dropdown_menu.tsx
+++ b/front_end/src/components/post_actions/post_dropdown_menu.tsx
@@ -217,8 +217,8 @@ export const PostDropdownMenu: FC<Props> = ({ post, button, hideShare }) => {
         ]
       : []),
 
-    // Include if upcoming and user is admin or curator
-    ...(isUpcoming && (isAdmin || isCurator)
+    // Include if post is approved & upcoming and user is admin or curator
+    ...(isApproved && isUpcoming && (isAdmin || isCurator)
       ? [
           {
             id: "sendBackToReview",


### PR DESCRIPTION
## Summary

Adds an `isApproved` guard to the `sendBackToReview` visibility condition in `post_dropdown_menu.tsx` so the button only renders for posts that are actually eligible for the action.

Previously the button showed whenever the post had a future `open_time` and the viewer was admin/curator, but the backend `send_back_to_review` action requires `curation_status == APPROVED`. A `PENDING`/`DRAFT`/`REJECTED` post whose question had a future `open_time` would render the button, and clicking it would 400 on the server.

Fixes #3029

## Test plan
- [ ] Load a `PENDING` post whose underlying question has a future `open_time` as an admin — verify "Send back to review" is no longer in the menu
- [ ] Load an `APPROVED` upcoming post as an admin/curator — verify "Send back to review" still appears and works
- [ ] Load an `APPROVED` post whose `open_time` has already passed — verify button remains hidden

Generated with [Claude Code](https://claude.ai/code)