### PR TITLE
Aggregation explorer: added `joined_before` date validation

### DIFF
--- a/utils/serializers.py
+++ b/utils/serializers.py
@@ -3,7 +3,7 @@ from typing import Self, Union
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from utils.the_math.aggregations import AGGREGATIONS
+from utils.the_math.aggregations import AGGREGATIONS, METHODS_REQUIRING_JOINED_BEFORE
 from questions.types import AggregationMethod
 from users.models import User
 
@@ -67,6 +67,9 @@ class SerializerKeyLookupMixin:
         return ret
 
 
+ALL_AGGREGATION_METHODS = "all"
+
+
 class DataGetRequestSerializer(serializers.Serializer):
     question_id = serializers.IntegerField(required=False)
     post_id = serializers.IntegerField(required=False)
@@ -88,15 +91,19 @@ class DataGetRequestSerializer(serializers.Serializer):
     joined_before_date = serializers.DateTimeField(required=False)
     include_key_factors = serializers.BooleanField(required=False, default=False)
 
+    def get_valid_aggregation_methods(self) -> list[str]:
+        return [aggregation.method for aggregation in AGGREGATIONS] + [
+            AggregationMethod.METACULUS_PREDICTION
+        ]
+
     def validate_aggregation_methods(self, value: str | None):
-        valid_aggregation_methods = [
-            aggregation.method for aggregation in AGGREGATIONS
-        ] + [AggregationMethod.METACULUS_PREDICTION]
+        valid_aggregation_methods = self.get_valid_aggregation_methods()
         if value is None:
             return
         user: User = self.context.get("user")
-        if value == "all":
-            return valid_aggregation_methods
+        if value == ALL_AGGREGATION_METHODS:
+            # Expanded in validate(), which can also see joined_before_date
+            return value
         methods: list[str] = [v.strip() for v in value.split(",")]
         invalid_methods = [
             method for method in methods if method not in valid_aggregation_methods
@@ -162,6 +169,28 @@ class DataGetRequestSerializer(serializers.Serializer):
                 "aggregation_methods must also be set."
             )
 
+        # Some methods can't be built without a joined_before_date. Asking for one by
+        # name without it is an error, while "all" just means "every method we can
+        # compute", so there we drop them instead.
+        if aggregation_methods == ALL_AGGREGATION_METHODS:
+            attrs["aggregation_methods"] = [
+                method
+                for method in self.get_valid_aggregation_methods()
+                if attrs.get("joined_before_date")
+                or method not in METHODS_REQUIRING_JOINED_BEFORE
+            ]
+        elif aggregation_methods and not attrs.get("joined_before_date"):
+            cohort_methods = [
+                method
+                for method in aggregation_methods
+                if method in METHODS_REQUIRING_JOINED_BEFORE
+            ]
+            if cohort_methods:
+                raise serializers.ValidationError(
+                    "joined_before_date is required for aggregation method(s): "
+                    f"{', '.join(cohort_methods)}"
+                )
+
         return attrs
 
 
@@ -178,13 +207,14 @@ class DataPostRequestSerializer(DataGetRequestSerializer):
         child=serializers.IntegerField(), required=False, allow_null=True
     )
 
+    def get_valid_aggregation_methods(self) -> list[str]:
+        return super().get_valid_aggregation_methods() + ["geometric_mean"]
+
     def validate_aggregation_methods(self, methods: str | None):
         if methods is None:
             return
         user: User = self.context.get("user")
-        valid_aggregation_methods = [
-            aggregation.method for aggregation in AGGREGATIONS
-        ] + [AggregationMethod.METACULUS_PREDICTION, "geometric_mean"]
+        valid_aggregation_methods = self.get_valid_aggregation_methods()
         invalid_methods = [
             method for method in methods if method not in valid_aggregation_methods
         ]

--- a/utils/serializers.py
+++ b/utils/serializers.py
@@ -100,7 +100,6 @@ class DataGetRequestSerializer(serializers.Serializer):
         valid_aggregation_methods = self.get_valid_aggregation_methods()
         if value is None:
             return
-        user: User = self.context.get("user")
         if value == ALL_AGGREGATION_METHODS:
             # Expanded in validate(), which can also see joined_before_date
             return value
@@ -112,12 +111,6 @@ class DataGetRequestSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 f"Invalid aggregation method(s): {', '.join(invalid_methods)}"
             )
-        if not user or not user.is_staff:
-            methods = [
-                method
-                for method in methods
-                if method != AggregationMethod.SINGLE_AGGREGATION
-            ]
         return methods
 
     def validate_user_ids(self, user_ids: list[int]):
@@ -160,26 +153,18 @@ class DataGetRequestSerializer(serializers.Serializer):
         user_ids = attrs.get("user_ids")
         include_bots = attrs.get("include_bots")
         minimize = attrs.get("minimize", True)
-
-        if not aggregation_methods and (
-            (user_ids is not None) or (include_bots is not None) or not minimize
-        ):
-            raise serializers.ValidationError(
-                "If user_ids, include_bots, or minimize is set, "
-                "aggregation_methods must also be set."
-            )
+        joined_before_date = attrs.get("joined_before_date")
 
         # Some methods can't be built without a joined_before_date. Asking for one by
         # name without it is an error, while "all" just means "every method we can
         # compute", so there we drop them instead.
         if aggregation_methods == ALL_AGGREGATION_METHODS:
-            attrs["aggregation_methods"] = [
+            aggregation_methods = [
                 method
                 for method in self.get_valid_aggregation_methods()
-                if attrs.get("joined_before_date")
-                or method not in METHODS_REQUIRING_JOINED_BEFORE
+                if joined_before_date or method not in METHODS_REQUIRING_JOINED_BEFORE
             ]
-        elif aggregation_methods and not attrs.get("joined_before_date"):
+        elif aggregation_methods and not joined_before_date:
             cohort_methods = [
                 method
                 for method in aggregation_methods
@@ -190,6 +175,24 @@ class DataGetRequestSerializer(serializers.Serializer):
                     "joined_before_date is required for aggregation method(s): "
                     f"{', '.join(cohort_methods)}"
                 )
+
+        if aggregation_methods:
+            user: User = self.context.get("user")
+            if not user or not user.is_staff:
+                aggregation_methods = [
+                    method
+                    for method in aggregation_methods
+                    if method != AggregationMethod.SINGLE_AGGREGATION
+                ]
+            attrs["aggregation_methods"] = aggregation_methods
+
+        if not aggregation_methods and (
+            (user_ids is not None) or (include_bots is not None) or not minimize
+        ):
+            raise serializers.ValidationError(
+                "If user_ids, include_bots, or minimize is set, "
+                "aggregation_methods must also be set."
+            )
 
         return attrs
 
@@ -213,7 +216,6 @@ class DataPostRequestSerializer(DataGetRequestSerializer):
     def validate_aggregation_methods(self, methods: str | None):
         if methods is None:
             return
-        user: User = self.context.get("user")
         valid_aggregation_methods = self.get_valid_aggregation_methods()
         invalid_methods = [
             method for method in methods if method not in valid_aggregation_methods
@@ -222,12 +224,6 @@ class DataPostRequestSerializer(DataGetRequestSerializer):
             raise serializers.ValidationError(
                 f"Invalid aggregation method(s): {', '.join(invalid_methods)}"
             )
-        if not user or not user.is_staff:
-            methods = [
-                method
-                for method in methods
-                if method != AggregationMethod.SINGLE_AGGREGATION
-            ]
         return methods
 
     def validate_user_ids(self, user_ids: list[int]):

--- a/utils/the_math/aggregations.py
+++ b/utils/the_math/aggregations.py
@@ -723,6 +723,13 @@ AGGREGATIONS: list[type[Aggregation]] = [
     JoinedBeforeDateAggregation,
 ]
 
+# Methods that cannot be built without an explicit `joined_before` date
+METHODS_REQUIRING_JOINED_BEFORE: list[str] = [
+    aggregation.method
+    for aggregation in AGGREGATIONS
+    if JoinedBeforeFiltered in aggregation.weighting_classes
+]
+
 
 def get_aggregation_by_name(method: str) -> type[Aggregation]:
     return next(agg for agg in AGGREGATIONS if agg.method == method)


### PR DESCRIPTION
Fixes:
- https://metaculus.sentry.io/issues/7653114962/?referrer=slack&notification_uuid=64ab46b6-2380-4963-9475-45a5c263e3db&environment=prod&alert_rule_id=15420910&alert_type=issue
- https://metaculus.sentry.io/issues/7653115723/?referrer=slack&notification_uuid=f73fbeec-a23a-4bef-9c70-2df4a0ffcfbb&environment=prod&alert_rule_id=15420910&alert_type=issue



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for requesting all available aggregation methods.
  * Added geometric mean support for POST requests.
  * Aggregation options now automatically exclude methods requiring a joined-before date when that date is not provided.

* **Bug Fixes**
  * Requests that explicitly select date-dependent cohort aggregations without a joined-before date are now rejected with clear validation feedback.
  * Staff filtering is now applied consistently during request validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->