### PR TITLE
Nginx: return 404 for `/_next/static/`

### DIFF
--- a/scripts/nginx/etc/nginx/conf.d/app_nginx.template
+++ b/scripts/nginx/etc/nginx/conf.d/app_nginx.template
@@ -64,6 +64,10 @@ server {
         client_max_body_size 10M;
     }
 
+    location = /_next/static/ {
+        return 404;
+    }
+
     location /_next/static/ {
         alias /app/front_end/.next/static/;
         expires 1y;


### PR DESCRIPTION
fixes https://app.logdna.com/2e8ec2b5b2/logs/view/1cb50a191c/?t=timestamp:1786023595015

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of requests targeting the static asset directory root by returning a 404 response instead of serving directory contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->