### PR TITLE
fix: labor hub commentary vs chart data mismatches (Aug 7 run)

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -18,10 +18,10 @@ export const JOBS_INSIGHTS = {
     positive: (
       <>
         By 2030, <strong>nurses</strong>, <strong>construction workers</strong>,
-        and <strong>restaurant servers</strong> are expected to see the largest
-        gains, driven by an aging population, infrastructure buildouts, and
-        continued demand for in-person service that AI is unlikely to displace
-        in the short term.
+        and <strong>physicians</strong> are expected to see the largest gains,
+        driven by an aging population, infrastructure buildouts, and continued
+        demand for in-person service that AI is unlikely to displace in the
+        short term.
       </>
     ),
     negative: (

--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -198,8 +198,8 @@ export default function LaborAutomationHubPage() {
               </span>
               , <strong>median wages are expected to grow.</strong> The workweek
               is also expected to become{" "}
-              <strong>about three hours shorter by 2035</strong> among all
-              workers, while productivity grows.
+              <strong>a couple hours shorter by 2035</strong> among all workers,
+              while productivity grows.
             </ContentParagraph>
             <ContentParagraph>
               Lower income households are expected to see their government
@@ -782,9 +782,9 @@ export default function LaborAutomationHubPage() {
               forecasted to grow through 2027, largely unaffected by AI in this
               timeframe. Aerospace (employing 2%) is expected to see minor
               growth in the short-term, while technology (employing 10%) is
-              expected to see marginal growth, largely consistent with
-              historical trends. These forecasts are short-term, leading to
-              minimal predicted change.
+              expected to stay roughly flat, largely consistent with historical
+              trends. These forecasts are short-term, leading to minimal
+              predicted change.
             </ContentParagraph>
           </DualPaneSectionLeft>
           <DualPaneSectionRight className="lg:mt-16 print:mt-12">

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-08-03">Aug 3</time>
+              Commentary last updated: <time dateTime="2026-08-07">Aug 7</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated QA pass over `/labor-hub` cross-referencing chart/table data against the surrounding commentary text. Found and fixed 3 misalignments (forecast-data related only; current/historical-value mismatches and pure rounding differences were excluded per the automation's rules).

| Section | Old text | Corrected text |
|---|---|---|
| Hours, Pay, and Financial Well-Being | "The workweek is also expected to become **about three hours shorter by 2035**" | "The workweek is also expected to become **a couple hours shorter by 2035**" |
| State-Level View | "while technology (employing 10%) is expected to see **marginal growth**, largely consistent with historical trends" | "while technology (employing 10%) is expected to **stay roughly flat**, largely consistent with historical trends" |
| Jobs Monitor (2030 growth callout) | "By 2030, nurses, construction workers, and **restaurant servers** are expected to see the largest gains" | "By 2030, nurses, construction workers, and **physicians** are expected to see the largest gains" |

### Details

- **Workweek decline**: "Average weekly hours worked" chart shows 2024 baseline of 38.3 hours declining to 36.1 hours by 2035 (a ~2.2 hour drop), not three hours.
- **WA technology sector**: "Employment change for the state of Washington for 2027" table shows Technology Sector at exactly **+0%**, which is flat, not growth.
- **Jobs Monitor 2030 view**: ranked occupation data for 2030 shows Physicians at **+2.9%**, which ranks above Restaurant Servers at **+2.5%** in the same "by 2030" view, so Physicians belongs in the "largest gains" callout instead.

Also bumped the "Commentary last updated" date in the hero section to reflect this review.

## Test plan

- [x] `prettier --write` on all edited files
- [x] `eslint` clean on all edited files
- [x] `tsc --noEmit` shows no errors introduced in these files
- [ ] Visual smoke test on staging (no local dev server run in this session)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013kUmkNzjWuWWB2im6yyicF

---
_Generated by [Claude Code](https://claude.ai/code/session_013kUmkNzjWuWWB2im6yyicF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the 2030 job-growth insight to highlight physicians.
  * Revised the projected 2035 workweek reduction to “a couple hours.”
  * Clarified that Washington’s technology-sector employment is expected to remain roughly flat.
  * Updated the commentary date to Aug. 7, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->