### PR TITLE
fix: labor hub commentary vs chart data mismatches (Aug 8 run)

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -18,10 +18,10 @@ export const JOBS_INSIGHTS = {
     positive: (
       <>
         By 2030, <strong>nurses</strong>, <strong>construction workers</strong>,
-        and <strong>restaurant servers</strong> are expected to see the largest
-        gains, driven by an aging population, infrastructure buildouts, and
-        continued demand for in-person service that AI is unlikely to displace
-        in the short term.
+        and <strong>physicians</strong> are expected to see the largest gains,
+        driven by an aging population, infrastructure buildouts, and continued
+        demand for in-person service that AI is unlikely to displace in the
+        short term.
       </>
     ),
     negative: (

--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -198,7 +198,7 @@ export default function LaborAutomationHubPage() {
               </span>
               , <strong>median wages are expected to grow.</strong> The workweek
               is also expected to become{" "}
-              <strong>about three hours shorter by 2035</strong> among all
+              <strong>about two hours shorter by 2035</strong> among all
               workers, while productivity grows.
             </ContentParagraph>
             <ContentParagraph>

--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -782,9 +782,9 @@ export default function LaborAutomationHubPage() {
               forecasted to grow through 2027, largely unaffected by AI in this
               timeframe. Aerospace (employing 2%) is expected to see minor
               growth in the short-term, while technology (employing 10%) is
-              expected to see marginal growth, largely consistent with
-              historical trends. These forecasts are short-term, leading to
-              minimal predicted change.
+              expected to stay roughly flat, largely consistent with historical
+              trends. These forecasts are short-term, leading to minimal
+              predicted change.
             </ContentParagraph>
           </DualPaneSectionLeft>
           <DualPaneSectionRight className="lg:mt-16 print:mt-12">

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-08-03">Aug 3</time>
+              Commentary last updated: <time dateTime="2026-08-08">Aug 8</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated QA pass over `/labor-hub`, cross-referencing chart/table data against surrounding commentary text. Found and fixed 3 misalignments, all related to forecast/prediction data (current/historical-value mismatches and pure rounding differences were excluded per the automation's rules).

| Section | Old text | Corrected text |
|---|---|---|
| Hours, Pay, and Financial Well-Being (Wages) | "The workweek is also expected to become **about three hours shorter by 2035**" | "The workweek is also expected to become **about two hours shorter by 2035**" |
| Jobs Monitor (2030 growth callout) | "By 2030, nurses, construction workers, and **restaurant servers** are expected to see the largest gains" | "By 2030, nurses, construction workers, and **physicians** are expected to see the largest gains" |
| State-Level View (Washington) | "while technology (employing 10%) is expected to see **marginal growth**, largely consistent with historical trends" | "while technology (employing 10%) is expected to **stay roughly flat**, largely consistent with historical trends" |

### Details

- **Workweek decline**: "Average weekly hours worked" chart shows 2025 baseline of 38.3 hours declining to ~36.1 hours by 2035 — a ~2.2 hour drop, not three hours.
- **Jobs Monitor 2030 view**: ranked occupation data for 2030 shows Physicians at +2.9%, which ranks above Restaurant Servers at +2.5% in the same "by 2030" view, so Physicians belongs in the "largest gains" callout instead.
- **Washington technology sector**: "Employment change for the state of Washington for 2027" table shows Technology Sector at 0%, which is flat, not growth.

Also bumped the "Commentary last updated" date in the hero section to reflect this review.

## Test plan

- [x] `prettier --write` on all edited files
- [x] `eslint` clean on all edited files
- [ ] Visual smoke test on staging (no local dev server run in this session)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mgke6VhugK8RQULy4qBNHx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the 2030 jobs outlook to highlight physicians as a role expected to see major gains.
  * Revised the 2035 workweek forecast to indicate a reduction of about two hours.
  * Updated Washington’s technology employment forecast to show roughly flat growth with minimal predicted change.
  * Updated the Labor Hub commentary date to August 8, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->