### PR TITLE
ci: sanitize preview resource names and refresh Claude workflow

### DIFF
--- a/.github/scripts/slugify_branch.sh
+++ b/.github/scripts/slugify_branch.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Slugify a git branch ref into a name that is safe for preview-environment
+# resources (Fly apps, Fly Redis databases, Neon branches, Docker tags).
+#
+# Usage: slugify_branch.sh <branch-ref> [max-length]
+#
+# Reserved tokens are dropped rather than escaped: hosting providers refuse
+# resource names containing "github" (GitHub's trademark policy), and agent
+# tooling routinely opens PRs from branches like `claude/github-issue-123-foo`.
+
+set -euo pipefail
+
+BRANCH_REF="${1:-}"
+MAX_LENGTH="${2:-30}"
+
+# Space-separated tokens stripped from the slug. Matched as whole dash-delimited
+# tokens, so `github-issue-1` -> `issue-1` but `flagship-1` is left alone.
+# `claude`/`codex` are dropped as noise: every agent branch carries one, so they
+# waste the length budget without distinguishing one preview from another.
+RESERVED_TOKENS="github claude codex"
+
+# Lowercase, then collapse everything that is not [a-z0-9] into single dashes.
+SLUG="$(printf '%s' "$BRANCH_REF" | tr '[:upper:]' '[:lower:]' | sed -e 's/[^a-z0-9]/-/g')"
+
+SLUG="$(printf '%s' "$SLUG" | awk -v reserved="$RESERVED_TOKENS" '
+  BEGIN {
+    n = split(reserved, list, " ")
+    for (i = 1; i <= n; i++) drop[list[i]] = 1
+  }
+  {
+    out = ""
+    count = split($0, parts, "-")
+    for (i = 1; i <= count; i++) {
+      if (parts[i] == "" || (parts[i] in drop)) continue
+      out = (out == "") ? parts[i] : out "-" parts[i]
+    }
+    print out
+  }
+')"
+
+SLUG="$(printf '%s' "$SLUG" | cut -c "1-${MAX_LENGTH}" | sed -e 's/^-*//' -e 's/-*$//')"
+
+# A branch made entirely of reserved/invalid tokens would otherwise yield an
+# empty slug and produce trailing-dash resource names, which Fly.io rejects.
+if [ -z "$SLUG" ]; then
+  SLUG="branch"
+fi
+
+printf '%s\n' "$SLUG"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,11 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Queue rather than cancel: cancelling mid-run leaves a half-applied edit on the branch.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: |
@@ -45,6 +50,18 @@ jobs:
       - name: "Install node_modules"
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: cd front_end && bun ci
+
+      # Backend toolchain, so Claude can run the ruff format/check steps CLAUDE.md
+      # requires after editing Python. Keep the uv version in sync with unit_tests.yml.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.11.x"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: "Install Python dependencies"
+        run: uv sync --frozen
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -63,5 +80,5 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: |
-            --model claude-opus-4-7
-            --allowedTools "Bash(bun ci:*),Bash(bun install:*),Bash(bun run:*),Bash(bun x:*),Bash(cd:*)"
+            --model claude-opus-5
+            --allowedTools "Bash(bun ci:*),Bash(bun install:*),Bash(bun run:*),Bash(bun x:*),Bash(cd:*),Bash(uv run:*),Bash(git fetch:*),Bash(git remote set-branches:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*),Bash(git show:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,9 +11,12 @@ on:
     types: [submitted]
 
 # Queue rather than cancel: cancelling mid-run leaves a half-applied edit on the branch.
+# `queue: max` keeps every pending request; the default (`single`) would cancel an
+# already-pending run when a second @claude comment arrives, silently dropping it.
 concurrency:
   group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   claude:
@@ -81,4 +84,4 @@ jobs:
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: |
             --model claude-opus-5
-            --allowedTools "Bash(bun ci:*),Bash(bun install:*),Bash(bun run:*),Bash(bun x:*),Bash(cd:*),Bash(uv run:*),Bash(git fetch:*),Bash(git remote set-branches:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*),Bash(git show:*)"
+            --allowedTools "Bash(bun ci:*),Bash(bun install:*),Bash(bun run:*),Bash(bun x:*),Bash(cd:*),Bash(uv run ruff format:*),Bash(uv run ruff check:*),Bash(uv run pytest:*),Bash(git fetch:*),Bash(git remote set-branches:*),Bash(git log:*),Bash(git blame:*),Bash(git diff:*),Bash(git show:*)"

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -155,8 +155,7 @@ jobs:
           # Compute branch prefix for SHA tag
           # - For PRs: use head_ref (source branch)
           # - For pushes: use ref_name
-          # Slugify: lowercase, replace invalid chars with dash
-          BRANCH_SLUG="$(printf '%s' "$BRANCH_REF" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//')"
+          BRANCH_SLUG="$(bash .github/scripts/slugify_branch.sh "$BRANCH_REF" 60)"
           echo "branch_slug=${BRANCH_SLUG}" >> $GITHUB_OUTPUT
           echo "Branch slug: ${BRANCH_SLUG}"
 

--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -152,6 +152,11 @@ jobs:
       redis_name: ${{ steps.names.outputs.redis_name }}
       pr_head_ref: ${{ steps.pr_head_ref.outputs.pr_head_ref }}
     steps:
+      - name: Checkout scripts
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/scripts
+
       - name: Resolve PR head ref
         id: pr_head_ref
         uses: actions/github-script@v7
@@ -182,7 +187,7 @@ jobs:
           BRANCH_REF: ${{ steps.pr_head_ref.outputs.pr_head_ref || github.head_ref }}
           PR_NUMBER: ${{ github.event.number || inputs.pr_number }}
         run: |
-          BRANCH_SLUG="$(printf '%s' "$BRANCH_REF" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | cut -c1-30 | sed -e 's/^-*//' -e 's/-*$//')"
+          BRANCH_SLUG="$(bash .github/scripts/slugify_branch.sh "$BRANCH_REF" 30)"
 
           # Base preview identifier: pr-{number}-{branch_slug}
           PREVIEW_ID="pr-${PR_NUMBER}-${BRANCH_SLUG}"
@@ -448,11 +453,28 @@ jobs:
         with:
           version: 0.4.14
 
-      - name: Delete Fly app
+      # Resources are matched by `pr-{number}-` prefix rather than by the exact
+      # name computed in `setup`, so a preview created before a branch-slug
+      # change still gets destroyed instead of leaking.
+      - name: Delete Fly apps
         continue-on-error: true
+        env:
+          FLY_ORG: ${{ vars.FLY_ORG || 'personal' }}
+          APP_PREFIX: metaculus-pr-${{ github.event.number || inputs.pr_number }}-
         run: |
-          echo "Deleting Fly app: ${{ needs.setup.outputs.fly_app }}"
-          flyctl apps destroy "${{ needs.setup.outputs.fly_app }}" --yes || echo "App may not exist or already deleted"
+          APPS="$(flyctl apps list --json --org "${FLY_ORG}" \
+            | jq -r --arg prefix "${APP_PREFIX}" '.[].Name | select(startswith($prefix))')"
+
+          if [ -z "$APPS" ]; then
+            echo "ℹ️ No Fly apps matching ${APP_PREFIX}*"
+            exit 0
+          fi
+
+          echo "$APPS" | while read -r APP_NAME; do
+            [ -z "$APP_NAME" ] && continue
+            echo "Deleting Fly app: ${APP_NAME}"
+            flyctl apps destroy "${APP_NAME}" --yes || echo "⚠️ Failed to destroy ${APP_NAME}"
+          done
 
       - name: Delete Neon Branch
         continue-on-error: true
@@ -462,19 +484,54 @@ jobs:
           branch: ${{ needs.setup.outputs.neon_branch }}
           api_key: ${{ secrets.NEON_API_KEY }}
 
-      - name: Delete Fly Redis Database
+      - name: Delete leftover Neon branches
         continue-on-error: true
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
+          BRANCH_PREFIX: preview/pr-${{ github.event.number || inputs.pr_number }}-
         run: |
-          FLY_ORG="${{ vars.FLY_ORG || 'personal' }}"
-          REDIS_NAME="${{ needs.setup.outputs.redis_name }}"
+          API="https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches"
 
-          if flyctl redis list --org "${FLY_ORG}" | grep -qw "${REDIS_NAME}"; then
-            echo "Deleting Fly Redis database: ${REDIS_NAME}"
-            flyctl redis destroy "${REDIS_NAME}" --yes
-            echo "✅ Deleted Fly Redis database"
-          else
-            echo "ℹ️ Fly Redis database not found or already deleted"
+          # 10000 is the documented maximum for `limit`, far above any plausible branch
+          # count, so one request returns everything and no cursor walk is needed.
+          BRANCH_IDS="$(curl -sS -H "Authorization: Bearer ${NEON_API_KEY}" "${API}?limit=10000" \
+            | jq -r --arg prefix "${BRANCH_PREFIX}" \
+              '.branches[]? | select(.name | startswith($prefix)) | .id')"
+
+          if [ -z "$BRANCH_IDS" ]; then
+            echo "ℹ️ No Neon branches matching ${BRANCH_PREFIX}*"
+            exit 0
           fi
+
+          echo "$BRANCH_IDS" | while read -r BRANCH_ID; do
+            [ -z "$BRANCH_ID" ] && continue
+            echo "Deleting Neon branch: ${BRANCH_ID}"
+            curl -sS -X DELETE -H "Authorization: Bearer ${NEON_API_KEY}" "${API}/${BRANCH_ID}" > /dev/null \
+              || echo "⚠️ Failed to delete ${BRANCH_ID}"
+          done
+
+      - name: Delete Fly Redis Databases
+        continue-on-error: true
+        env:
+          FLY_ORG: ${{ vars.FLY_ORG || 'personal' }}
+          REDIS_PREFIX: mtc-redis-pr-${{ github.event.number || inputs.pr_number }}-
+        run: |
+          # `flyctl redis list` has no --json output (unlike `apps list`), so the names
+          # have to be scraped out of the table.
+          REDIS_NAMES="$(flyctl redis list --org "${FLY_ORG}" \
+            | grep -oE "${REDIS_PREFIX}[a-z0-9-]*" | sort -u)"
+
+          if [ -z "$REDIS_NAMES" ]; then
+            echo "ℹ️ No Fly Redis databases matching ${REDIS_PREFIX}*"
+            exit 0
+          fi
+
+          echo "$REDIS_NAMES" | while read -r REDIS_NAME; do
+            [ -z "$REDIS_NAME" ] && continue
+            echo "Deleting Fly Redis database: ${REDIS_NAME}"
+            flyctl redis destroy "${REDIS_NAME}" --yes || echo "⚠️ Failed to destroy ${REDIS_NAME}"
+          done
 
       - name: Delete PR Deployments from Preview Environment
         continue-on-error: true

--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -516,9 +516,13 @@ jobs:
 
           # --fail-with-body so HTTP 4xx/5xx exits non-zero while still returning the
           # error body; plain `curl -sS` exits 0 on an error response, which would read
-          # as "no branches found". 10000 is the documented maximum for `limit`, far
-          # above any plausible branch count, so one request returns everything.
-          if ! BRANCH_IDS="$(curl -sS --fail-with-body -H "Authorization: Bearer ${NEON_API_KEY}" "${API}?limit=10000" \
+          # as "no branches found". curl applies no total timeout by default, so bound
+          # both calls explicitly — otherwise a hung connection stalls the whole job.
+          CURL_OPTS=(-sS --fail-with-body --connect-timeout 10 --max-time 120)
+
+          # 10000 is the documented maximum for `limit`, far above any plausible branch
+          # count, so one request returns everything and no cursor walk is needed.
+          if ! BRANCH_IDS="$(curl "${CURL_OPTS[@]}" -H "Authorization: Bearer ${NEON_API_KEY}" "${API}?limit=10000" \
             | jq -r --arg prefix "${BRANCH_PREFIX}" \
               '.branches[]? | select(.name | startswith($prefix)) | .id')"; then
             echo "⚠️ Could not list Neon branches"
@@ -535,7 +539,7 @@ jobs:
           while IFS= read -r BRANCH_ID; do
             [ -z "$BRANCH_ID" ] && continue
             echo "Deleting Neon branch: ${BRANCH_ID}"
-            if ! BODY="$(curl -sS --fail-with-body -X DELETE -H "Authorization: Bearer ${NEON_API_KEY}" "${API}/${BRANCH_ID}")"; then
+            if ! BODY="$(curl "${CURL_OPTS[@]}" -X DELETE -H "Authorization: Bearer ${NEON_API_KEY}" "${API}/${BRANCH_ID}")"; then
               echo "⚠️ Failed to delete ${BRANCH_ID}: ${BODY:-no response body}"
               STATUS=failed
             fi

--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -457,24 +457,42 @@ jobs:
       # name computed in `setup`, so a preview created before a branch-slug
       # change still gets destroyed instead of leaking.
       - name: Delete Fly apps
+        id: fly_apps
         continue-on-error: true
         env:
           FLY_ORG: ${{ vars.FLY_ORG || 'personal' }}
           APP_PREFIX: metaculus-pr-${{ github.event.number || inputs.pr_number }}-
         run: |
-          APPS="$(flyctl apps list --json --org "${FLY_ORG}" \
-            | jq -r --arg prefix "${APP_PREFIX}" '.[].Name | select(startswith($prefix))')"
+          # pipefail so a flyctl failure isn't masked by jq succeeding on empty input,
+          # which would otherwise look identical to "no apps found".
+          set -o pipefail
+          STATUS=ok
 
-          if [ -z "$APPS" ]; then
-            echo "ℹ️ No Fly apps matching ${APP_PREFIX}*"
+          if ! APPS="$(flyctl apps list --json --org "${FLY_ORG}" \
+            | jq -r --arg prefix "${APP_PREFIX}" '.[].Name | select(startswith($prefix))')"; then
+            echo "⚠️ Could not list Fly apps"
+            echo "status=failed" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "$APPS" | while read -r APP_NAME; do
+          if [ -z "$APPS" ]; then
+            echo "ℹ️ No Fly apps matching ${APP_PREFIX}*"
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Here-string, not a pipe: a piped `while` runs in a subshell and STATUS
+          # changes would be discarded.
+          while IFS= read -r APP_NAME; do
             [ -z "$APP_NAME" ] && continue
             echo "Deleting Fly app: ${APP_NAME}"
-            flyctl apps destroy "${APP_NAME}" --yes || echo "⚠️ Failed to destroy ${APP_NAME}"
-          done
+            if ! flyctl apps destroy "${APP_NAME}" --yes; then
+              echo "⚠️ Failed to destroy ${APP_NAME}"
+              STATUS=failed
+            fi
+          done <<< "$APPS"
+
+          echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
 
       - name: Delete Neon Branch
         continue-on-error: true
@@ -485,55 +503,86 @@ jobs:
           api_key: ${{ secrets.NEON_API_KEY }}
 
       - name: Delete leftover Neon branches
+        id: neon_sweep
         continue-on-error: true
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
           NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
           BRANCH_PREFIX: preview/pr-${{ github.event.number || inputs.pr_number }}-
         run: |
+          set -o pipefail
+          STATUS=ok
           API="https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches"
 
-          # 10000 is the documented maximum for `limit`, far above any plausible branch
-          # count, so one request returns everything and no cursor walk is needed.
-          BRANCH_IDS="$(curl -sS -H "Authorization: Bearer ${NEON_API_KEY}" "${API}?limit=10000" \
+          # --fail-with-body so HTTP 4xx/5xx exits non-zero while still returning the
+          # error body; plain `curl -sS` exits 0 on an error response, which would read
+          # as "no branches found". 10000 is the documented maximum for `limit`, far
+          # above any plausible branch count, so one request returns everything.
+          if ! BRANCH_IDS="$(curl -sS --fail-with-body -H "Authorization: Bearer ${NEON_API_KEY}" "${API}?limit=10000" \
             | jq -r --arg prefix "${BRANCH_PREFIX}" \
-              '.branches[]? | select(.name | startswith($prefix)) | .id')"
-
-          if [ -z "$BRANCH_IDS" ]; then
-            echo "ℹ️ No Neon branches matching ${BRANCH_PREFIX}*"
+              '.branches[]? | select(.name | startswith($prefix)) | .id')"; then
+            echo "⚠️ Could not list Neon branches"
+            echo "status=failed" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "$BRANCH_IDS" | while read -r BRANCH_ID; do
+          if [ -z "$BRANCH_IDS" ]; then
+            echo "ℹ️ No Neon branches matching ${BRANCH_PREFIX}*"
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          while IFS= read -r BRANCH_ID; do
             [ -z "$BRANCH_ID" ] && continue
             echo "Deleting Neon branch: ${BRANCH_ID}"
-            curl -sS -X DELETE -H "Authorization: Bearer ${NEON_API_KEY}" "${API}/${BRANCH_ID}" > /dev/null \
-              || echo "⚠️ Failed to delete ${BRANCH_ID}"
-          done
+            if ! BODY="$(curl -sS --fail-with-body -X DELETE -H "Authorization: Bearer ${NEON_API_KEY}" "${API}/${BRANCH_ID}")"; then
+              echo "⚠️ Failed to delete ${BRANCH_ID}: ${BODY:-no response body}"
+              STATUS=failed
+            fi
+          done <<< "$BRANCH_IDS"
+
+          echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
 
       - name: Delete Fly Redis Databases
+        id: fly_redis
         continue-on-error: true
         env:
           FLY_ORG: ${{ vars.FLY_ORG || 'personal' }}
           REDIS_PREFIX: mtc-redis-pr-${{ github.event.number || inputs.pr_number }}-
         run: |
-          # `flyctl redis list` has no --json output (unlike `apps list`), so the names
-          # have to be scraped out of the table.
-          REDIS_NAMES="$(flyctl redis list --org "${FLY_ORG}" \
-            | grep -oE "${REDIS_PREFIX}[a-z0-9-]*" | sort -u)"
+          STATUS=ok
 
-          if [ -z "$REDIS_NAMES" ]; then
-            echo "ℹ️ No Fly Redis databases matching ${REDIS_PREFIX}*"
+          # `flyctl redis list` has no --json output (unlike `apps list`), so the names
+          # have to be scraped out of the table. Capture the listing first so a flyctl
+          # failure is distinguishable from grep simply finding no matches.
+          if ! REDIS_LIST="$(flyctl redis list --org "${FLY_ORG}")"; then
+            echo "⚠️ Could not list Fly Redis databases"
+            echo "status=failed" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "$REDIS_NAMES" | while read -r REDIS_NAME; do
+          REDIS_NAMES="$(printf '%s' "$REDIS_LIST" \
+            | grep -oE "${REDIS_PREFIX}[a-z0-9-]*" | sort -u || true)"
+
+          if [ -z "$REDIS_NAMES" ]; then
+            echo "ℹ️ No Fly Redis databases matching ${REDIS_PREFIX}*"
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          while IFS= read -r REDIS_NAME; do
             [ -z "$REDIS_NAME" ] && continue
             echo "Deleting Fly Redis database: ${REDIS_NAME}"
-            flyctl redis destroy "${REDIS_NAME}" --yes || echo "⚠️ Failed to destroy ${REDIS_NAME}"
-          done
+            if ! flyctl redis destroy "${REDIS_NAME}" --yes; then
+              echo "⚠️ Failed to destroy ${REDIS_NAME}"
+              STATUS=failed
+            fi
+          done <<< "$REDIS_NAMES"
+
+          echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
 
       - name: Delete PR Deployments from Preview Environment
+        id: deployments
         continue-on-error: true
         uses: strumwolf/delete-deployment-environment@v3
         with:
@@ -561,30 +610,52 @@ jobs:
             const closedAt = ${{ toJSON(github.event.pull_request.closed_at || '') }};
             const actor = ${{ toJSON(github.actor) }};
 
+            // Cleanup steps are continue-on-error, so report what actually happened
+            // rather than asserting every resource was removed.
+            const failed = '⚠️ Failed — see workflow logs';
+            const stepStatus = {
+              app: ${{ toJSON(steps.fly_apps.outputs.status) }},
+              neon: ${{ toJSON(steps.neon_sweep.outputs.status) }},
+              redis: ${{ toJSON(steps.fly_redis.outputs.status) }},
+              deployments: ${{ toJSON(steps.deployments.outcome) }},
+            };
+            const ok = (key) => ['ok', 'success'].includes(stepStatus[key]);
+            const anyFailed = Object.keys(stepStatus).some((k) => !ok(k));
+
             const table = [
               '| Resource | Status |',
               '|----------|--------|',
-              '| 🌐 Preview App | Deleted |',
-              '| 🗄️ PostgreSQL Branch | Deleted |',
-              '| ⚡ Redis Database | Deleted |',
-              '| 🔧 GitHub Deployments | Removed |',
+              `| 🌐 Preview App | ${ok('app') ? 'Deleted' : failed} |`,
+              `| 🗄️ PostgreSQL Branch | ${ok('neon') ? 'Deleted' : failed} |`,
+              `| ⚡ Redis Database | ${ok('redis') ? 'Deleted' : failed} |`,
+              `| 🔧 GitHub Deployments | ${ok('deployments') ? 'Removed' : failed} |`,
               '| 📦 Docker Image | Retained (auto-cleanup via GHCR policies) |'
             ].join('\n');
 
+            const removedPhrase = anyFailed ? 'partially removed' : 'fully removed';
+            const heading = anyFailed
+              ? 'Cleanup: Preview Environment Partially Removed'
+              : 'Cleanup: Preview Environment Removed';
+            const warning = anyFailed
+              ? '> ⚠️ Some resources could not be removed and may still be billing. Check the workflow logs, then re-run cleanup via the `PR Preview Environment` workflow (`action: cleanup`).'
+              : '';
+
             let body;
             if (isClosed) {
-              body = `## Cleanup: Preview Environment Removed
+              body = `## ${heading}
+            ${warning}
 
-            The preview environment for this PR has been destroyed.
+            The preview environment for this PR has been ${removedPhrase}.
 
             ${table}
 
             ---
             *Cleanup triggered by PR close at ${closedAt}*`;
             } else if (cleanupReason.toLowerCase().includes('stale')) {
-              body = `## Cleanup: Preview Environment Removed (Stale)
+              body = `## ${heading} (Stale)
+            ${warning}
 
-            This preview environment has been deleted because the PR was marked as **Stale** (no activity detected).
+            This preview environment was ${removedPhrase} because the PR was marked as **Stale** (no activity detected).
 
             ${table}
 
@@ -593,9 +664,10 @@ jobs:
             ---
             *Automated cleanup by weekly maintenance*`;
             } else {
-              body = `## Cleanup: Preview Environment Removed
+              body = `## ${heading}
+            ${warning}
 
-            The preview environment has been manually destroyed.
+            The preview environment has been ${removedPhrase} (manual cleanup).
 
             ${table}
 

--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -494,15 +494,7 @@ jobs:
 
           echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
 
-      - name: Delete Neon Branch
-        continue-on-error: true
-        uses: neondatabase/delete-branch-action@v3
-        with:
-          project_id: ${{ secrets.NEON_PROJECT_ID }}
-          branch: ${{ needs.setup.outputs.neon_branch }}
-          api_key: ${{ secrets.NEON_API_KEY }}
-
-      - name: Delete leftover Neon branches
+      - name: Delete Neon branches
         id: neon_sweep
         continue-on-error: true
         env:


### PR DESCRIPTION
## Summary

- Add shared branch slugification for safe, consistent preview resource names.
- Clean up orphaned Fly apps, Redis databases, and Neon branches by PR prefix.
- Queue Claude workflow runs and add backend tooling for Python checks.
- Upgrade Claude Code to Opus 5 with expanded repository inspection tools.

## Testing

- Not run (CI workflow and shell-script changes only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview environment cleanup to remove all resources associated with a pull request, reducing leftover temporary environments.
  * Cleanup now reports the status of each resource and provides guidance when removal is incomplete.

* **Chores**
  * Standardized branch-based resource naming for more consistent preview and build environments.
  * Improved automated workflows with better run coordination, dependency caching, and expanded tooling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->