### PR TITLE
fix: labor hub commentary — jobs monitor 2027 mismatch (Aug 10 run)

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -9,8 +9,8 @@ export const JOBS_INSIGHTS = {
     negative: (
       <>
         By 2027, <strong>designers</strong> and{" "}
-        <strong>sales representatives</strong> are expected to see early
-        declines as AI begins to automate creative and client-facing work.
+        <strong>software developers</strong> are expected to see early declines
+        as AI begins to automate creative and coding work.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-08-08">Aug 8</time>
+              Commentary last updated: <time dateTime="2026-08-10">Aug 10</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated QA on the [Labor Automation Forecasting Hub](https://www.metaculus.com/labor-hub) compared chart/table data against the surrounding commentary text across all sections (Overall Employment, Jobs Monitor, Wages, Graduates, Economy, State-Level View, Research comparison table), including the Jobs Monitor 2027/2030/2035 year toggle.

Two previously-known mismatches (workweek-hours delta and Washington technology-sector wording) were already fixed in a prior run (#5123) and remain correct in this codebase — no change needed there. One new mismatch was found, caused by forecast data drift since the last QA pass:

- **Jobs Monitor 2027 "negative" insight**: named **designers and sales representatives** as the early decliners. Current forecast data shows **software developers** now has a larger projected 2027 decline (≈-1.0%) than sales representatives (≈-0.7%), while designers remains the largest decliner (≈-2.0%). Updated the copy to name designers and software developers, with the reasoning updated from "creative and client-facing work" to "creative and coding work" to match (consistent with how software developers' automation driver is described elsewhere on the page).
- Bumped the "Commentary last updated" date to reflect this pass.

## Test plan
- [x] `prettier --write` on changed files
- [x] `eslint` on changed files (clean)
- [ ] Visual check in a running app (not performed — see notes)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01RdNQoRr7a65a9FKw2ovtka

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdNQoRr7a65a9FKw2ovtka)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the 2027 job outlook to highlight potential declines for designers and software developers due to automation.
  * Updated the displayed commentary date to August 10, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->