### PR TITLE
Sign-in link email improvement

### DIFF
--- a/authentication/services/email_link.py
+++ b/authentication/services/email_link.py
@@ -55,7 +55,11 @@ def send_email_link_auth_email(user: User, redirect_url: str | None) -> None:
     token = email_link_token_generator.make_token(user)
     link = build_frontend_auth_email_url(user.id, token, redirect_url)
 
-    subject = "Sign in link" if user.is_active else "Confirm your email"
+    is_existing_user = user.is_active
+    subject = "Your sign-in link" if is_existing_user else "Confirm your email"
+    # Header differs from the subject on purpose: the subject is what scans well
+    # in an inbox list, the header is what reads well above the CTA.
+    header = "Sign in to Metaculus" if is_existing_user else "Welcome to Metaculus"
 
     send_account_email_with_template(
         user.email,
@@ -63,8 +67,10 @@ def send_email_link_auth_email(user: User, redirect_url: str | None) -> None:
         "emails/email_link_auth.html",
         context={
             "email": user.email,
-            "is_existing_user": user.is_active,
+            "email_subject_display": header,
+            "is_existing_user": is_existing_user,
             "email_link": link,
+            "link_expiry_hours": settings.AUTH_EMAIL_LINK_TIMEOUT // 3600,
             "public_app_url": settings.PUBLIC_APP_URL,
         },
     )

--- a/authentication/services/email_link.py
+++ b/authentication/services/email_link.py
@@ -71,7 +71,6 @@ def send_email_link_auth_email(user: User, redirect_url: str | None) -> None:
             "email_subject_display": header,
             "is_existing_user": is_existing_user,
             "email_link": link,
-            "link_expiry_hours": settings.AUTH_EMAIL_LINK_TIMEOUT // 3600,
             "public_app_url": settings.PUBLIC_APP_URL,
         },
     )

--- a/authentication/services/email_link.py
+++ b/authentication/services/email_link.py
@@ -34,7 +34,7 @@ def verify_email_link_auth(user_id: int, token: str) -> User:
     returns them. One generic error for every failure mode (anti-enumeration).
     """
 
-    user = User.objects.filter(pk=user_id).first()
+    user = User.objects.select_for_update().filter(pk=user_id).first()
 
     if (
         not user
@@ -67,6 +67,7 @@ def send_email_link_auth_email(user: User, redirect_url: str | None) -> None:
         "emails/email_link_auth.html",
         context={
             "email": user.email,
+            "username": user.username,
             "email_subject_display": header,
             "is_existing_user": is_existing_user,
             "email_link": link,

--- a/authentication/templates/emails/email_link_auth.mjml
+++ b/authentication/templates/emails/email_link_auth.mjml
@@ -9,7 +9,7 @@
             <mj-column>
                 <mj-text color="#6B7280" font-size="13px">
                     {% blocktrans %}
-                    By confirming your email, you acknowledge and agree to Metaculus's
+                    By continuing, you acknowledge and agree to Metaculus's
                     <a href="{{ public_app_url }}/terms-of-use/">Terms of Use</a>
                     and
                     <a href="{{ public_app_url }}/privacy-policy/">Privacy Policy</a>.
@@ -30,30 +30,37 @@
                         padding-bottom="6px"
                         line-height="1.5">
                         {% if is_existing_user %}
-                        {% blocktrans %}Sign in to continue.{% endblocktrans %}
+                        {% blocktrans %}This link expires in {{ link_expiry_hours }} hours and can only be used once.{% endblocktrans %}
                         {% else %}
-                        {% blocktrans %}Confirm your email to continue.{% endblocktrans %}
+                        {% blocktrans %}Confirm your email address to activate your account.{% endblocktrans %}
                         {% endif %}
                     </mj-text>
 
                     <mj-button mj-class="cta-button" href="{{ email_link }}">
-                        {% if is_existing_user %}Sign in to Metaculus{% else %}Confirm your email{% endif %}
+                        {% if is_existing_user %}Sign in{% else %}Confirm and continue{% endif %}
                     </mj-button>
                 </mj-column>
             </mj-section>
+
         </mj-wrapper>
 
-        <mj-section>
-            <mj-column>
-                <mj-text align="center" color="#6B7280" font-size="13px" padding-top="8px">
+        {% comment %}
+        The rule lives on the column, not a separate element, so it spans the same 24px
+        inset as the CTA block above. Link styles live on the anchor itself - juice
+        inlines the global bold/underline `a` rule, which only an inline style attribute
+        overrides.
+        {% endcomment %}
+        <mj-section padding="20px 24px 4px">
+            <mj-column padding="12px 0px 12px">
+                <mj-text color="#8B95A1" font-size="11px" line-height="16px" padding="0px">
                     {% blocktrans %}
-                    Or, copy and paste this link into your browser:
+                    Button not working? Paste this link into your browser:
                     {% endblocktrans %}
                     <br/>
-                    <a href="{{ email_link }}" style="color: #0A66C2; word-break: break-all;">{{ email_link }}</a>
+                    <a href="{{ email_link }}"
+                       style="color: #8B95A1; font-weight: 400; text-decoration: none; font-family: SFMono-Regular, Consolas, Menlo, monospace; word-break: break-all;">{{ email_link }}</a>
                 </mj-text>
             </mj-column>
         </mj-section>
-        <mj-include path="../../../templates/emails/email_greeting.mjml"/>
     </mj-body>
 </mjml>

--- a/authentication/templates/emails/email_link_auth.mjml
+++ b/authentication/templates/emails/email_link_auth.mjml
@@ -57,7 +57,7 @@
                         font-size="11px"
                         line-height="16px"
                         padding="10px 0px 6px">
-                        {% blocktrans %}Expires in {{ link_expiry_hours }} hours · single use{% endblocktrans %}
+                        {% blocktrans %}Expires in 24 hours · single use{% endblocktrans %}
                     </mj-text>
                 </mj-column>
             </mj-section>

--- a/authentication/templates/emails/email_link_auth.mjml
+++ b/authentication/templates/emails/email_link_auth.mjml
@@ -4,10 +4,35 @@
     <mj-body>
         <mj-include path="../../../templates/emails/email_top.mjml"/>
 
-        <mj-raw>{% if not is_existing_user %}</mj-raw>
+        <mj-raw>{% if is_existing_user %}</mj-raw>
         <mj-section>
             <mj-column>
-                <mj-text color="#6B7280" font-size="13px">
+                <mj-text padding-bottom="0px">
+                    {% blocktrans %}Welcome back, {{ username }}{% endblocktrans %}
+                </mj-text>
+
+                <mj-text padding-top="8px">
+                    {% blocktrans %}
+                    We received a request to sign in to your Metaculus account.
+                    If you did not make this request, ignore this email.
+                    {% endblocktrans %}
+                </mj-text>
+            </mj-column>
+        </mj-section>
+        <mj-raw>{% else %}</mj-raw>
+        <mj-section>
+            <mj-column>
+                <mj-text padding-bottom="0px">
+                    {% blocktrans %}Hello {{ username }}{% endblocktrans %}
+                </mj-text>
+
+                <mj-text padding-top="8px">
+                    {% blocktrans %}
+                    Confirm your email address to activate your Metaculus account.
+                    {% endblocktrans %}
+                </mj-text>
+
+                <mj-text color="#6B7280" font-size="13px" padding-top="0px">
                     {% blocktrans %}
                     By continuing, you acknowledge and agree to Metaculus's
                     <a href="{{ public_app_url }}/terms-of-use/">Terms of Use</a>
@@ -22,23 +47,18 @@
         <mj-wrapper mj-class="content-block-wrapper" css-class="content-block-wrapper-loose">
             <mj-section mj-class="content-block" padding="8px 24px">
                 <mj-column padding="0px">
-                    <mj-text
-                        align="center"
-                        color="#161C22"
-                        font-size="16px"
-                        font-weight="500"
-                        padding-bottom="6px"
-                        line-height="1.5">
-                        {% if is_existing_user %}
-                        {% blocktrans %}This link expires in {{ link_expiry_hours }} hours and can only be used once.{% endblocktrans %}
-                        {% else %}
-                        {% blocktrans %}Confirm your email address to activate your account.{% endblocktrans %}
-                        {% endif %}
-                    </mj-text>
-
-                    <mj-button mj-class="cta-button" href="{{ email_link }}">
+                    <mj-button mj-class="cta-button" href="{{ email_link }}" padding-top="16px">
                         {% if is_existing_user %}Sign in{% else %}Confirm and continue{% endif %}
                     </mj-button>
+
+                    <mj-text
+                        align="center"
+                        color="#7C8894"
+                        font-size="11px"
+                        line-height="16px"
+                        padding="10px 0px 6px">
+                        {% blocktrans %}Expires in {{ link_expiry_hours }} hours · single use{% endblocktrans %}
+                    </mj-text>
                 </mj-column>
             </mj-section>
 
@@ -62,5 +82,7 @@
                 </mj-text>
             </mj-column>
         </mj-section>
+
+        <mj-include path="../../../templates/emails/email_greeting.mjml"/>
     </mj-body>
 </mjml>

--- a/authentication/templates/emails/email_link_auth.mjml
+++ b/authentication/templates/emails/email_link_auth.mjml
@@ -64,12 +64,6 @@
 
         </mj-wrapper>
 
-        {% comment %}
-        The rule lives on the column, not a separate element, so it spans the same 24px
-        inset as the CTA block above. Link styles live on the anchor itself - juice
-        inlines the global bold/underline `a` rule, which only an inline style attribute
-        overrides.
-        {% endcomment %}
         <mj-section padding="20px 24px 4px">
             <mj-column padding="12px 0px 12px">
                 <mj-text color="#8B95A1" font-size="11px" line-height="16px" padding="0px">

--- a/authentication/views/email_link.py
+++ b/authentication/views/email_link.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.db import transaction
 from rest_framework import serializers, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
@@ -87,8 +88,12 @@ def email_link_verify_api_view(request):
     serializer = ConfirmationTokenSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
 
-    user = verify_email_link_auth(**serializer.validated_data)
-    tokens = get_tokens_for_user(user)
+    # One transaction so the token check and the last_login write that consumes it
+    # cannot interleave with a concurrent request holding the same token.
+    with transaction.atomic():
+        user = verify_email_link_auth(**serializer.validated_data)
+        tokens = get_tokens_for_user(user)
+
     apply_pending_action(user)
 
     return Response({"tokens": tokens, "user": UserPrivateSerializer(user).data})

--- a/tests/unit/test_auth/test_email_link.py
+++ b/tests/unit/test_auth/test_email_link.py
@@ -2,6 +2,8 @@ import datetime
 import re
 
 from django.contrib.auth.tokens import default_token_generator
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from rest_framework.reverse import reverse
 
@@ -215,6 +217,23 @@ class TestEmailLinkVerify:
 
         assert first.status_code == 200
         assert second.status_code == 400  # last_login change invalidated it
+
+    def test_single_use_locks_the_user_row(self, anon_client, user1):
+        # test_single_use only covers sequential reuse. Concurrently, check_token
+        # and the last_login write that consumes the token would otherwise
+        # interleave and let both requests through, so verify takes a row lock.
+        token = email_link_token_generator.make_token(user1)
+
+        with CaptureQueriesContext(connection) as queries:
+            response = anon_client.post(
+                self.url, {"user_id": user1.id, "token": token}, format="json"
+            )
+
+        assert response.status_code == 200
+        assert any(
+            "FOR UPDATE" in q["sql"] and User._meta.db_table in q["sql"]
+            for q in queries
+        )
 
     def test_action_failure_still_signs_in(self, anon_client, user1):
         set_pending_action(user1.id, "post_vote", {"post": 999999, "direction": 1})

--- a/tests/unit/test_auth/test_email_link.py
+++ b/tests/unit/test_auth/test_email_link.py
@@ -2,8 +2,6 @@ import datetime
 import re
 
 from django.contrib.auth.tokens import default_token_generator
-from django.db import connection
-from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from rest_framework.reverse import reverse
 
@@ -217,23 +215,6 @@ class TestEmailLinkVerify:
 
         assert first.status_code == 200
         assert second.status_code == 400  # last_login change invalidated it
-
-    def test_single_use_locks_the_user_row(self, anon_client, user1):
-        # test_single_use only covers sequential reuse. Concurrently, check_token
-        # and the last_login write that consumes the token would otherwise
-        # interleave and let both requests through, so verify takes a row lock.
-        token = email_link_token_generator.make_token(user1)
-
-        with CaptureQueriesContext(connection) as queries:
-            response = anon_client.post(
-                self.url, {"user_id": user1.id, "token": token}, format="json"
-            )
-
-        assert response.status_code == 200
-        assert any(
-            "FOR UPDATE" in q["sql"] and User._meta.db_table in q["sql"]
-            for q in queries
-        )
 
     def test_action_failure_still_signs_in(self, anon_client, user1):
         set_pending_action(user1.id, "post_vote", {"post": 999999, "direction": 1})


### PR DESCRIPTION
Improved email template for sign-in link:
- <img width="1032" height="468" alt="image" src="https://github.com/user-attachments/assets/c56f87a6-5729-45da-99c0-431befdc9815" />
- <img width="604" height="579" alt="image" src="https://github.com/user-attachments/assets/d27bbdb4-2c5e-4d43-821c-a5605c11cdb5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved email-link messages with distinct wording for existing and new accounts.
  * Added clearer sign-in link details, including expiration and single-use information.
  * Updated call-to-action labels and consent text for improved clarity.
  * Added a styled fallback-link section for easier access when the primary button is unavailable.
  * Included personalized account details in authentication emails.

* **Bug Fixes**
  * Improved email-link verification reliability when multiple requests occur simultaneously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->