### PR TITLE
text/markdown accept header support

### DIFF
--- a/front_end/bun.lock
+++ b/front_end/bun.lock
@@ -101,6 +101,7 @@
         "undici": "^7.25.0",
         "victory": "^37.3.6",
         "whatwg-fetch": "^3.6.20",
+        "yaml": "^2.8.3",
         "zod": "^3.25.0",
       },
       "devDependencies": {

--- a/front_end/next.config.mjs
+++ b/front_end/next.config.mjs
@@ -1,6 +1,8 @@
 import { withSentryConfig } from "@sentry/nextjs";
 import createNextIntlPlugin from "next-intl/plugin";
 
+import { buildMarkdownRewrites } from "./src/agent_markdown/routes.mjs";
+
 const withNextIntl = createNextIntlPlugin();
 
 const AWS_STORAGE_BUCKET_NAME = process.env.AWS_STORAGE_BUCKET_NAME;
@@ -76,17 +78,23 @@ const nextConfig = {
     ];
   },
   async rewrites() {
-    return [
-      {
-        source: "/index/:slug",
-        destination: "/tournament/:slug",
-      },
-      {
-        source: "/files/forecasting-owid-report.pdf",
-        destination:
-          "https://metaculus-public.s3.us-west-2.amazonaws.com/OWID%2Breport.pdf",
-      },
-    ];
+    return {
+      // Must run before filesystem routes so an Accept: text/markdown request
+      // reaches the markdown handler instead of the page owning that path.
+      beforeFiles: buildMarkdownRewrites(),
+      // Previously a bare array, which Next treats as afterFiles
+      afterFiles: [
+        {
+          source: "/index/:slug",
+          destination: "/tournament/:slug",
+        },
+        {
+          source: "/files/forecasting-owid-report.pdf",
+          destination:
+            "https://metaculus-public.s3.us-west-2.amazonaws.com/OWID%2Breport.pdf",
+        },
+      ],
+    };
   },
   webpack: (config, { buildId, webpack }) => {
     // propagate buildId to environment so we could trigger prompt message on outdated version

--- a/front_end/package.json
+++ b/front_end/package.json
@@ -122,6 +122,7 @@
     "undici": "^7.25.0",
     "victory": "^37.3.6",
     "whatwg-fetch": "^3.6.20",
+    "yaml": "^2.8.3",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/front_end/src/agent_markdown/frontmatter.ts
+++ b/front_end/src/agent_markdown/frontmatter.ts
@@ -11,17 +11,12 @@ export type FrontmatterValue =
 function isPresent(value: FrontmatterValue): boolean {
   if (value === null || value === undefined) return false;
   if (Array.isArray(value)) return value.length > 0;
-  // The API returns "" for unset text fields; emitting `key: ""` reads as a
-  // real but empty value, so treat blank as absent.
+  // The API returns "" for unset text fields; `key: ""` reads as a real value
   if (typeof value === "string") return value.trim() !== "";
   return true;
 }
 
-/**
- * Render frontmatter as a fenced YAML block. Key order is the caller's
- * insertion order, and absent values are dropped so builders can pass optional
- * fields through unconditionally.
- */
+/** Fenced YAML block in insertion order; absent values are dropped. */
 export function serializeFrontmatter(
   entries: Record<string, FrontmatterValue>
 ): string {

--- a/front_end/src/agent_markdown/frontmatter.ts
+++ b/front_end/src/agent_markdown/frontmatter.ts
@@ -1,0 +1,37 @@
+import { stringify } from "yaml";
+
+export type FrontmatterValue =
+  | string
+  | number
+  | boolean
+  | readonly string[]
+  | null
+  | undefined;
+
+function isPresent(value: FrontmatterValue): boolean {
+  if (value === null || value === undefined) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  // The API returns "" for unset text fields; emitting `key: ""` reads as a
+  // real but empty value, so treat blank as absent.
+  if (typeof value === "string") return value.trim() !== "";
+  return true;
+}
+
+/**
+ * Render frontmatter as a fenced YAML block. Key order is the caller's
+ * insertion order, and absent values are dropped so builders can pass optional
+ * fields through unconditionally.
+ */
+export function serializeFrontmatter(
+  entries: Record<string, FrontmatterValue>
+): string {
+  const present = Object.entries(entries).filter(([, value]) =>
+    isPresent(value)
+  );
+
+  if (present.length === 0) return "";
+
+  const body = stringify(Object.fromEntries(present)).trimEnd();
+
+  return ["---", body, "---"].join("\n");
+}

--- a/front_end/src/agent_markdown/respond.ts
+++ b/front_end/src/agent_markdown/respond.ts
@@ -1,0 +1,82 @@
+import { logError } from "@/utils/core/errors";
+import { getPublicSettings } from "@/utils/public_settings.server";
+
+import { serializeFrontmatter } from "./frontmatter";
+import { getMarkdownRoute, toRouteParams } from "./routes.mjs";
+import { MarkdownDocument } from "./types";
+
+const NEGOTIATED_HEADERS = {
+  // Set here rather than on the HTML response: on Next 16.2 the router owns
+  // Vary for HTML renders and overwrites next.config headers() and proxy.ts.
+  Vary: "Accept, Accept-Language",
+};
+
+const MARKDOWN_HEADERS = {
+  ...NEGOTIATED_HEADERS,
+  "Content-Type": "text/markdown; charset=utf-8",
+};
+
+function plain(status: number, message: string): Response {
+  return new Response(message, {
+    status,
+    headers: {
+      ...NEGOTIATED_HEADERS,
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}
+
+function absolute(path: string): string {
+  const { PUBLIC_APP_URL } = getPublicSettings();
+  return new URL(path, PUBLIC_APP_URL).toString();
+}
+
+/**
+ * `/md` routes are excluded from `proxy.ts`, so the gate it enforces for HTML
+ * is re-checked here, before any data is fetched.
+ *
+ * Alpha access is deliberately not checked: the proxy's alpha branch only runs
+ * for requests that already have a session and merely redirects them to
+ * /alpha-auth, so anonymous callers are not alpha-gated on the HTML side
+ * either. Gating here would 404 all markdown on every alpha deployment.
+ */
+function isGated(): boolean {
+  return getPublicSettings().PUBLIC_AUTHENTICATION_REQUIRED;
+}
+
+function serialize(document: MarkdownDocument): string {
+  return `${serializeFrontmatter(document.frontmatter)}\n\n${document.body}`;
+}
+
+export async function renderMarkdownResponse(
+  type: string,
+  args: readonly string[]
+): Promise<Response> {
+  if (isGated()) return plain(404, "Not found");
+
+  const route = getMarkdownRoute(type);
+  if (!route) return plain(404, "Not found");
+
+  const params = toRouteParams(route, args);
+
+  try {
+    const { builder } = await route.load();
+    const result = await builder.build(params);
+
+    if (result.status === "not_found") return plain(404, "Not found");
+
+    return new Response(serialize(result.document), {
+      status: 200,
+      headers: {
+        ...MARKDOWN_HEADERS,
+        Link: `<${absolute(result.document.canonicalPath)}>; rel="canonical"`,
+      },
+    });
+  } catch (error) {
+    logError(error, {
+      message: "Markdown rendering failed",
+      payload: { type, params },
+    });
+    return plain(500, "Internal server error");
+  }
+}

--- a/front_end/src/agent_markdown/respond.ts
+++ b/front_end/src/agent_markdown/respond.ts
@@ -5,9 +5,9 @@ import { serializeFrontmatter } from "./frontmatter";
 import { getMarkdownRoute, toRouteParams } from "./routes.mjs";
 import { MarkdownDocument } from "./types";
 
+// Can't also go on the HTML response: Next 16.2 overwrites Vary on the render
+// path, from both next.config headers() and proxy.ts.
 const NEGOTIATED_HEADERS = {
-  // Set here rather than on the HTML response: on Next 16.2 the router owns
-  // Vary for HTML renders and overwrites next.config headers() and proxy.ts.
   Vary: "Accept, Accept-Language",
 };
 
@@ -31,17 +31,18 @@ function absolute(path: string): string {
   return new URL(path, PUBLIC_APP_URL).toString();
 }
 
-/**
- * `/md` routes are excluded from `proxy.ts`, so the gate it enforces for HTML
- * is re-checked here, before any data is fetched.
- *
- * Alpha access is deliberately not checked: the proxy's alpha branch only runs
- * for requests that already have a session and merely redirects them to
- * /alpha-auth, so anonymous callers are not alpha-gated on the HTML side
- * either. Gating here would 404 all markdown on every alpha deployment.
- */
+// `/md` is excluded from proxy.ts, so its gate is re-checked here. Alpha access
+// is not: the proxy only alpha-gates requests that already have a session, so
+// gating here would 404 all markdown on every alpha deployment.
 function isGated(): boolean {
   return getPublicSettings().PUBLIC_AUTHENTICATION_REQUIRED;
+}
+
+// notFound()/redirect() throw with a `NEXT_`-prefixed digest; ApiError uses
+// `[API_ERROR]`, so the two never collide.
+function isNextControlFlow(error: unknown): boolean {
+  const digest = (error as { digest?: unknown } | null)?.digest;
+  return typeof digest === "string" && digest.startsWith("NEXT_");
 }
 
 function serialize(document: MarkdownDocument): string {
@@ -73,6 +74,10 @@ export async function renderMarkdownResponse(
       },
     });
   } catch (error) {
+    // Let Next render its own 404 instead of logging a 500. Inlined rather
+    // than next/navigation's unstable_rethrow, which next/jest stubs out.
+    if (isNextControlFlow(error)) throw error;
+
     logError(error, {
       message: "Markdown rendering failed",
       payload: { type, params },

--- a/front_end/src/agent_markdown/routes.mjs
+++ b/front_end/src/agent_markdown/routes.mjs
@@ -1,0 +1,89 @@
+/**
+ * Every markdown-enabled page type is declared here once. `next.config.mjs`
+ * reads `pattern` to generate rewrites; the `/md/[type]` route handler calls
+ * `load` to get the builder, and derives its param names from the same
+ * pattern. Plain JS because next.config is loaded raw by Node and cannot
+ * import TypeScript — `load` is never executed there, so its specifier is
+ * only resolved when the app bundles this module.
+ *
+ * Adding a page type: one entry here, one co-located `markdown.ts` builder.
+ *
+ * `pattern` is a restricted path-to-regexp subset: literals, `:name`,
+ * `:name(regex)`, and a single optional `:name?` in the final position.
+ */
+export const MARKDOWN_ROUTES = {
+  notebook: {
+    pattern: "/notebooks/:id(\\d+)/:slug?",
+    load: () => import("../app/(main)/notebooks/[id]/[[...slug]]/markdown"),
+  },
+};
+
+const ACCEPT_MARKDOWN = {
+  type: "header",
+  key: "accept",
+  value: ".*text/markdown.*",
+};
+
+const PARAM_SYNTAX = /^:([A-Za-z][A-Za-z0-9_]*)(?:\(([^)]+)\))?(\?)?$/;
+
+export function routeParamNames(pattern) {
+  return pattern
+    .split("/")
+    .map((segment) => PARAM_SYNTAX.exec(segment)?.[1])
+    .filter((name) => !!name);
+}
+
+export function getMarkdownRoute(type) {
+  // hasOwn, so a type like `constructor` cannot reach Object.prototype
+  return Object.hasOwn(MARKDOWN_ROUTES, type)
+    ? MARKDOWN_ROUTES[type]
+    : undefined;
+}
+
+/** Zip the positional URL segments onto the pattern's param names. */
+export function toRouteParams(route, args) {
+  return Object.fromEntries(
+    routeParamNames(route.pattern).map((name, index) => [name, args[index]])
+  );
+}
+
+/** `/a/:b?` -> [`/a`, `/a/:b`] so each arity gets a concrete rewrite. */
+function expandOptional(pattern) {
+  const segments = pattern.split("/").filter(Boolean);
+  const last = segments.at(-1);
+  const param = last ? PARAM_SYNTAX.exec(last) : null;
+
+  if (!param?.[3]) return [segments];
+
+  const [, name, source] = param;
+  const head = segments.slice(0, -1);
+
+  return [head, [...head, source ? `:${name}(${source})` : `:${name}`]];
+}
+
+/**
+ * @typedef {{ type: string, key: string, value?: string }} RewriteCondition
+ * @typedef {{ source: string, destination: string, has?: RewriteCondition[] }} MarkdownRewrite
+ */
+
+/**
+ * Content negotiation on the canonical URL. Params travel as path segments
+ * because a rewrite's destination query string is not readable from a Route
+ * Handler — `request.nextUrl` there still reports the original URL.
+ *
+ * @param {Record<string, { pattern: string }>} [routes]
+ * @returns {MarkdownRewrite[]}
+ */
+export function buildMarkdownRewrites(routes = MARKDOWN_ROUTES) {
+  return Object.entries(routes).flatMap(([type, { pattern }]) =>
+    expandOptional(pattern).map((segments) => ({
+      // trailingSlash: true means the matched request always carries it
+      source: `/${segments.join("/")}/`,
+      has: [ACCEPT_MARKDOWN],
+      destination: `/md/${type}/${segments
+        .filter((segment) => PARAM_SYNTAX.test(segment))
+        .map((segment) => `:${PARAM_SYNTAX.exec(segment)?.[1]}`)
+        .join("/")}/`,
+    }))
+  );
+}

--- a/front_end/src/agent_markdown/routes.mjs
+++ b/front_end/src/agent_markdown/routes.mjs
@@ -1,15 +1,9 @@
 /**
- * Every markdown-enabled page type is declared here once. `next.config.mjs`
- * reads `pattern` to generate rewrites; the `/md/[type]` route handler calls
- * `load` to get the builder, and derives its param names from the same
- * pattern. Plain JS because next.config is loaded raw by Node and cannot
- * import TypeScript — `load` is never executed there, so its specifier is
- * only resolved when the app bundles this module.
+ * Every markdown-enabled page type, declared once: add an entry here and a
+ * co-located `markdown.ts` builder. `pattern` is a restricted path-to-regexp
+ * subset — literals, `:name`, `:name(regex)`, and one trailing `:name?`.
  *
- * Adding a page type: one entry here, one co-located `markdown.ts` builder.
- *
- * `pattern` is a restricted path-to-regexp subset: literals, `:name`,
- * `:name(regex)`, and a single optional `:name?` in the final position.
+ * Plain JS so next.config.mjs, which Node loads raw, can import it.
  */
 export const MARKDOWN_ROUTES = {
   notebook: {
@@ -40,7 +34,6 @@ export function getMarkdownRoute(type) {
     : undefined;
 }
 
-/** Zip the positional URL segments onto the pattern's param names. */
 export function toRouteParams(route, args) {
   return Object.fromEntries(
     routeParamNames(route.pattern).map((name, index) => [name, args[index]])
@@ -67,9 +60,8 @@ function expandOptional(pattern) {
  */
 
 /**
- * Content negotiation on the canonical URL. Params travel as path segments
- * because a rewrite's destination query string is not readable from a Route
- * Handler — `request.nextUrl` there still reports the original URL.
+ * Params travel as path segments because a rewrite's destination query string
+ * is not readable from a Route Handler.
  *
  * @param {Record<string, { pattern: string }>} [routes]
  * @returns {MarkdownRewrite[]}
@@ -77,7 +69,7 @@ function expandOptional(pattern) {
 export function buildMarkdownRewrites(routes = MARKDOWN_ROUTES) {
   return Object.entries(routes).flatMap(([type, { pattern }]) =>
     expandOptional(pattern).map((segments) => ({
-      // trailingSlash: true means the matched request always carries it
+      // trailingSlash: true, so the matched request always carries one
       source: `/${segments.join("/")}/`,
       has: [ACCEPT_MARKDOWN],
       destination: `/md/${type}/${segments

--- a/front_end/src/agent_markdown/types.ts
+++ b/front_end/src/agent_markdown/types.ts
@@ -1,0 +1,28 @@
+import { FrontmatterValue } from "./frontmatter";
+
+export type MarkdownDocument = {
+  /** Serialized in insertion order; absent values are dropped. */
+  frontmatter: Record<string, FrontmatterValue>;
+  body: string;
+  /**
+   * Site-relative path of the HTML page this document mirrors. `respond` makes
+   * it absolute, so builders need no knowledge of the deployment's origin.
+   */
+  canonicalPath: string;
+};
+
+/**
+ * Builders return a result rather than calling `notFound()` or throwing, so a
+ * miss can never render Next's HTML error page into a text/markdown response.
+ */
+export type MarkdownBuildResult =
+  | { status: "ok"; document: MarkdownDocument }
+  | { status: "not_found" };
+
+export type MarkdownRouteParams = Record<string, string | undefined>;
+
+export type MarkdownBuilder<
+  P extends MarkdownRouteParams = MarkdownRouteParams,
+> = {
+  build(params: P): Promise<MarkdownBuildResult>;
+};

--- a/front_end/src/agent_markdown/types.ts
+++ b/front_end/src/agent_markdown/types.ts
@@ -4,17 +4,11 @@ export type MarkdownDocument = {
   /** Serialized in insertion order; absent values are dropped. */
   frontmatter: Record<string, FrontmatterValue>;
   body: string;
-  /**
-   * Site-relative path of the HTML page this document mirrors. `respond` makes
-   * it absolute, so builders need no knowledge of the deployment's origin.
-   */
+  /** Site-relative path of the HTML page this mirrors; `respond` absolutizes it. */
   canonicalPath: string;
 };
 
-/**
- * Builders return a result rather than calling `notFound()` or throwing, so a
- * miss can never render Next's HTML error page into a text/markdown response.
- */
+// A result, not notFound(), so a miss can't render HTML into a markdown response
 export type MarkdownBuildResult =
   | { status: "ok"; document: MarkdownDocument }
   | { status: "not_found" };

--- a/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/markdown.ts
+++ b/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/markdown.ts
@@ -1,9 +1,17 @@
 import { MarkdownBuilder, MarkdownBuildResult } from "@/agent_markdown/types";
 import ServerPostsApi from "@/services/api/posts/posts.server";
+import { ApiError } from "@/utils/core/errors";
 import { getPostLink } from "@/utils/navigation";
 
 /** `slug` is decorative — the id identifies the post, as on the HTML page. */
 type Params = { id?: string; slug?: string };
+
+// 403 answers 404 so a private notebook's existence isn't leaked. Everything
+// else propagates: faults become a logged 500, and an API 404 arrives as Next's
+// notFound(), which respond hands back to the framework.
+function isMissing(error: unknown): boolean {
+  return ApiError.isApiError(error) && error.response.status === 403;
+}
 
 export const builder: MarkdownBuilder<Params> = {
   async build({ id }): Promise<MarkdownBuildResult> {
@@ -12,14 +20,14 @@ export const builder: MarkdownBuilder<Params> = {
     let post;
     try {
       post = await ServerPostsApi.getPost(Number(id), false);
-    } catch {
-      return { status: "not_found" };
+    } catch (error) {
+      if (isMissing(error)) return { status: "not_found" };
+      throw error;
     }
 
     if (!post?.notebook) return { status: "not_found" };
 
-    // Always the slugged URL, so the canonical link is right even when the
-    // request omitted the slug — no redirect needed to correct the caller.
+    // Always the slugged URL, so this is right even when the request omitted it
     const canonicalPath = getPostLink(post);
 
     return {

--- a/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/markdown.ts
+++ b/front_end/src/app/(main)/notebooks/[id]/[[...slug]]/markdown.ts
@@ -1,0 +1,44 @@
+import { MarkdownBuilder, MarkdownBuildResult } from "@/agent_markdown/types";
+import ServerPostsApi from "@/services/api/posts/posts.server";
+import { getPostLink } from "@/utils/navigation";
+
+/** `slug` is decorative — the id identifies the post, as on the HTML page. */
+type Params = { id?: string; slug?: string };
+
+export const builder: MarkdownBuilder<Params> = {
+  async build({ id }): Promise<MarkdownBuildResult> {
+    if (!id) return { status: "not_found" };
+
+    let post;
+    try {
+      post = await ServerPostsApi.getPost(Number(id), false);
+    } catch {
+      return { status: "not_found" };
+    }
+
+    if (!post?.notebook) return { status: "not_found" };
+
+    // Always the slugged URL, so the canonical link is right even when the
+    // request omitted the slug — no redirect needed to correct the caller.
+    const canonicalPath = getPostLink(post);
+
+    return {
+      status: "ok",
+      document: {
+        canonicalPath,
+        frontmatter: {
+          title: post.title,
+          type: "notebook",
+          published: post.published_at,
+          updated: post.notebook.edited_at,
+          authors: [
+            post.author_username,
+            ...(post.coauthors ?? []).map((coauthor) => coauthor.username),
+          ].filter(Boolean),
+          image: post.notebook.image_url,
+        },
+        body: post.notebook.markdown,
+      },
+    };
+  },
+};

--- a/front_end/src/app/(md)/md/[type]/[[...args]]/route.ts
+++ b/front_end/src/app/(md)/md/[type]/[[...args]]/route.ts
@@ -1,11 +1,7 @@
 import { renderMarkdownResponse } from "@/agent_markdown/respond";
 
-/**
- * Single entry point for markdown requests: `/md/<type>/<...params>`.
- *
- * Params travel as path segments because a rewrite's destination query string
- * is not visible here — `request.nextUrl` still reports the original URL.
- */
+// Params arrive as path segments: a rewrite's destination query string is not
+// visible here, since request.nextUrl still reports the original URL.
 export async function GET(
   _request: Request,
   context: { params: Promise<{ type: string; args?: string[] }> }

--- a/front_end/src/app/(md)/md/[type]/[[...args]]/route.ts
+++ b/front_end/src/app/(md)/md/[type]/[[...args]]/route.ts
@@ -1,0 +1,16 @@
+import { renderMarkdownResponse } from "@/agent_markdown/respond";
+
+/**
+ * Single entry point for markdown requests: `/md/<type>/<...params>`.
+ *
+ * Params travel as path segments because a rewrite's destination query string
+ * is not visible here — `request.nextUrl` still reports the original URL.
+ */
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ type: string; args?: string[] }> }
+) {
+  const { type, args } = await context.params;
+
+  return renderMarkdownResponse(type, args ?? []);
+}

--- a/front_end/src/proxy.ts
+++ b/front_end/src/proxy.ts
@@ -210,11 +210,10 @@ export const config = {
       // Run for pages only
       // Ignores prefetch requests, all media files
       // And embedded urls
-      //
-      // `md` is excluded because markdown responses are anonymous and public:
-      // no token verification, CSP nonce or experiment enrollment is needed.
-      // agent_markdown/respond.ts re-checks the access gates enforced above,
-      // which is what keeps that safe.
+      // `md` is excluded: those responses are anonymous and public, and
+      // agent_markdown/respond.ts re-checks the gate enforced above. Do NOT
+      // exclude by Accept header — this matcher is site-wide, so that would
+      // let any request skip the gate on paths that still render HTML.
       source:
         "/((?!api|md|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|csp-report|questions/embed|experiments/embed|opengraph-image-|twitter-image-|app-version|.*\\..*).*)",
       missing: [

--- a/front_end/src/proxy.ts
+++ b/front_end/src/proxy.ts
@@ -210,8 +210,13 @@ export const config = {
       // Run for pages only
       // Ignores prefetch requests, all media files
       // And embedded urls
+      //
+      // `md` is excluded because markdown responses are anonymous and public:
+      // no token verification, CSP nonce or experiment enrollment is needed.
+      // agent_markdown/respond.ts re-checks the access gates enforced above,
+      // which is what keeps that safe.
       source:
-        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|csp-report|questions/embed|experiments/embed|opengraph-image-|twitter-image-|app-version|.*\\..*).*)",
+        "/((?!api|md|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|csp-report|questions/embed|experiments/embed|opengraph-image-|twitter-image-|app-version|.*\\..*).*)",
       missing: [
         { type: "header", key: "next-router-prefetch" },
         { type: "header", key: "purpose", value: "prefetch" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Markdown representations for supported notebook routes.
  * Markdown responses now support content negotiation, canonical links, frontmatter, and route parameters.
  * Added access checks and clear not-found or error responses for Markdown requests.

* **Bug Fixes**
  * Improved route handling so Markdown requests bypass unrelated middleware while retaining dedicated access controls.
  * Added support for optional route parameters and reliable route matching.
  * Improved handling of rendering failures with appropriate server error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->