### PR TITLE
Improve Private Notes UX: autosave hint + note indicator dot

### DIFF
--- a/front_end/messages/cs.json
+++ b/front_end/messages/cs.json
@@ -1893,6 +1893,7 @@
   "mySpotPeerScore": "Moje skóre podle spolužáků pro My Spot",
   "privateNote": "Soukromá poznámka",
   "privateNoteUpdatedFrom": "z <date></date>",
+  "privateNoteAutosaveHint": "změny se ukládají automaticky",
   "savedAgo": "uloženo <date></date>",
   "loadMore": "Načíst více",
   "noPrivateNotes": "Žádné soukromé poznámky",

--- a/front_end/messages/en.json
+++ b/front_end/messages/en.json
@@ -2039,6 +2039,7 @@
   "copyQuestionLinkToAccount": "Copy",
   "privateNote": "Private Note",
   "privateNoteUpdatedFrom": "from <date></date>",
+  "privateNoteAutosaveHint": "changes are saved automatically",
   "savedAgo": "saved <date></date>",
   "loadMore": "Load More",
   "noPrivateNotes": "No private notes yet",

--- a/front_end/messages/es.json
+++ b/front_end/messages/es.json
@@ -1892,6 +1892,7 @@
   "mySpotPeerScore": "Mi Puntaje de Comparación de Spot",
   "privateNote": "Nota privada",
   "privateNoteUpdatedFrom": "de <date></date>",
+  "privateNoteAutosaveHint": "los cambios se guardan automáticamente",
   "savedAgo": "guardado <date></date>",
   "loadMore": "Cargar más",
   "noPrivateNotes": "Aún no hay notas privadas",

--- a/front_end/messages/pt.json
+++ b/front_end/messages/pt.json
@@ -1890,6 +1890,7 @@
   "mySpotPeerScore": "Minha Pontuação de Comparação com Pares Spot",
   "privateNote": "Nota Privada",
   "privateNoteUpdatedFrom": "de <date></date>",
+  "privateNoteAutosaveHint": "as alterações são salvas automaticamente",
   "savedAgo": "salvo <date></date>",
   "loadMore": "Carregar Mais",
   "noPrivateNotes": "Ainda não há notas privadas",

--- a/front_end/messages/zh-TW.json
+++ b/front_end/messages/zh-TW.json
@@ -1889,6 +1889,7 @@
   "mySpotPeerScore": "我的地點同儕分數",
   "privateNote": "私人筆記",
   "privateNoteUpdatedFrom": "從 <date></date>",
+  "privateNoteAutosaveHint": "變更會自動儲存",
   "savedAgo": "已儲存 <date></date>",
   "loadMore": "載入更多",
   "noPrivateNotes": "尚無私人筆記",

--- a/front_end/messages/zh.json
+++ b/front_end/messages/zh.json
@@ -1894,6 +1894,7 @@
   "mySpotPeerScore": "我的同伴分数",
   "privateNote": "私人筆記",
   "privateNoteUpdatedFrom": "從 <date></date>",
+  "privateNoteAutosaveHint": "更改会自动保存",
   "savedAgo": "<date></date>前已保存",
   "loadMore": "加載更多",
   "noPrivateNotes": "尚無私人筆記",

--- a/front_end/src/app/(main)/questions/[id]/components/question_layout/question_layout_context.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_layout/question_layout_context.tsx
@@ -43,6 +43,12 @@ type QuestionLayoutContextValue = {
   // Active tab state (shared between mobile + desktop tab bars)
   activeTab?: string;
   setActiveTab: (tab: string) => void;
+
+  // Latest known private note text — persists across tab-panel unmounts so the
+  // editor and the tab indicator survive switching away from the Private Notes tab.
+  // undefined = not yet edited this session (fall back to server data).
+  privateNoteText?: string;
+  setPrivateNoteText: (text: string) => void;
 };
 
 const TAB_HASH_VALUES = new Set([
@@ -63,6 +69,7 @@ export const QuestionLayoutProvider = ({ children }: PropsWithChildren) => {
   const hash = useHash();
   const [keyFactorsExpanded, setKeyFactorsExpanded] = useState<boolean>();
   const [activeTab, setActiveTab] = useState<string>();
+  const [privateNoteText, setPrivateNoteText] = useState<string>();
   const [keyFactorOverlay, setKeyFactorOverlay] =
     useState<KeyFactorOverlayState>(null);
 
@@ -130,6 +137,8 @@ export const QuestionLayoutProvider = ({ children }: PropsWithChildren) => {
       clearScrollToComment,
       activeTab,
       setActiveTab,
+      privateNoteText,
+      setPrivateNoteText,
     }),
     [
       keyFactorsExpanded,
@@ -145,6 +154,7 @@ export const QuestionLayoutProvider = ({ children }: PropsWithChildren) => {
       requestScrollToComment,
       clearScrollToComment,
       activeTab,
+      privateNoteText,
     ]
   );
 

--- a/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tab_bar.tsx
+++ b/front_end/src/app/(main)/questions/[id]/components/question_page_shell/tab_bar.tsx
@@ -34,6 +34,7 @@ type TabDef = {
   key: TabKey;
   label: string;
   count?: number;
+  indicator?: boolean;
 };
 
 type Props = {
@@ -53,9 +54,11 @@ const tabClassName = (isActive: boolean) =>
 
 const QuestionPageShellTabBar: FC<Props> = ({ post, variant, className }) => {
   const t = useTranslations();
-  const { activeTab, setActiveTab } = useQuestionLayout();
+  const { activeTab, setActiveTab, privateNoteText } = useQuestionLayout();
   const { user } = useAuth();
   const isAdmin = !!(user?.is_staff || user?.is_superuser);
+  const hasPrivateNote =
+    (privateNoteText ?? post.private_note?.text ?? "").trim().length > 0;
 
   const isSm = useBreakpoint("sm");
   const { hideCP } = useHideCP();
@@ -84,7 +87,11 @@ const QuestionPageShellTabBar: FC<Props> = ({ post, variant, className }) => {
     { key: "info", label: t("info") },
     ...newsHotnessTab,
     { key: "question-links", label: t("questionLinks") },
-    { key: "private-notes", label: t("privateNotes") },
+    {
+      key: "private-notes",
+      label: t("privateNotes"),
+      indicator: hasPrivateNote,
+    },
     ...(hasSimilarQuestionsTab
       ? [
           {
@@ -149,9 +156,16 @@ const QuestionPageShellTabBar: FC<Props> = ({ post, variant, className }) => {
             scrollOnSelect={false}
             dynamicClassName={tabClassName}
           >
-            {tab.count !== undefined
-              ? `${tab.label} (${tab.count})`
-              : tab.label}
+            {tab.indicator ? (
+              <span className="inline-flex items-center gap-1.5">
+                <span className="size-2.5 shrink-0 rounded-full bg-orange-500 dark:bg-orange-500-dark" />
+                <span>{tab.label}</span>
+              </span>
+            ) : tab.count !== undefined ? (
+              `${tab.label} (${tab.count})`
+            ) : (
+              tab.label
+            )}
           </TabsTab>
         ))}
       </TabsList>

--- a/front_end/src/components/question/private_note.tsx
+++ b/front_end/src/components/question/private_note.tsx
@@ -74,7 +74,8 @@ const PrivateNote: FC<Props> = ({ post: { private_note, id }, hideToggle }) => {
   const latestValueRef = useRef(noteText);
   // Value of the most recent save request, kept apart from the displayed text so
   // that mirroring edits eagerly doesn't make the editor look already-saved.
-  const lastRequestedRef = useRef(noteText);
+  // null after a failed request, so retrying the same text isn't deduped away.
+  const lastRequestedRef = useRef<string | null>(noteText);
   const saveRequestIdRef = useRef(0);
 
   const noteStatusDetails = useMemo(() => {
@@ -106,14 +107,29 @@ const PrivateNote: FC<Props> = ({ post: { private_note, id }, hideToggle }) => {
 
     const requestId = ++saveRequestIdRef.current;
     setIsLoading(true);
-    await savePrivateNote(id, value);
+
+    try {
+      await savePrivateNote(id, value);
+    } catch (error) {
+      logError(error);
+
+      // Nothing reached the server, so let an identical retry through — unless a
+      // newer request has already claimed the ref.
+      if (lastRequestedRef.current === value) {
+        lastRequestedRef.current = null;
+      }
+      return;
+    } finally {
+      if (requestId === saveRequestIdRef.current) {
+        setIsLoading(false);
+      }
+    }
 
     if (requestId !== saveRequestIdRef.current) {
       // Superseded while in flight — the newest request reports the final status.
       return;
     }
 
-    setIsLoading(false);
     setSavedAt(new Date());
   };
 

--- a/front_end/src/components/question/private_note.tsx
+++ b/front_end/src/components/question/private_note.tsx
@@ -5,6 +5,7 @@ import { isNil } from "lodash";
 import { useLocale, useTranslations } from "next-intl";
 import { FC, useEffect, useMemo, useRef, useState } from "react";
 
+import { useQuestionLayoutSafe } from "@/app/(main)/questions/[id]/components/question_layout/question_layout_context";
 import { savePrivateNote } from "@/app/(main)/questions/actions";
 import MarkdownEditor from "@/components/markdown_editor";
 import LoadingSpinner from "@/components/ui/loading_spiner";
@@ -59,7 +60,12 @@ const PrivateNote: FC<Props> = ({ post: { private_note, id }, hideToggle }) => {
   const t = useTranslations();
   const locale = useLocale();
   const { text, updated_at } = private_note || {};
-  const [noteText, setNoteText] = useState(text || "");
+  const questionLayout = useQuestionLayoutSafe();
+  // Seed from context first so the note survives Private Notes tab-panel remounts
+  // (context persists the latest edit; the `post` prop stays at its page-load value).
+  const [noteText, setNoteText] = useState(
+    () => questionLayout?.privateNoteText ?? text ?? ""
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [savedAt, setSavedAt] = useState<undefined | Date>();
   const { user } = useAuth();
@@ -87,9 +93,12 @@ const PrivateNote: FC<Props> = ({ post: { private_note, id }, hideToggle }) => {
     setIsLoading(false);
 
     setSavedAt(new Date());
+    questionLayout?.setPrivateNoteText(value);
   };
 
   const saveNoteDebounced = useDebouncedCallback(saveNote, 1500);
+
+  const hasNoteContent = noteText.trim().length > 0;
 
   if (!user) {
     return null;
@@ -124,19 +133,18 @@ const PrivateNote: FC<Props> = ({ post: { private_note, id }, hideToggle }) => {
         <div className="scroll-mt-24 border border-gray-500 bg-gray-0 dark:border-gray-500-dark dark:bg-gray-0-dark">
           {editorBody}
         </div>
-        {(noteStatusDetails || updated_at) && (
-          <div className="text-right text-xs">
-            {noteStatusDetails ??
-              (updated_at &&
-                t.rich("privateNoteUpdatedFrom", {
+        <div className="text-right text-xs">
+          {noteStatusDetails ??
+            (updated_at
+              ? t.rich("privateNoteUpdatedFrom", {
                   date: () => (
                     <RelativeTime datetime={updated_at} format="relative">
                       {formatDate(locale, new Date(updated_at))}
                     </RelativeTime>
                   ),
-                }))}
-          </div>
-        )}
+                })
+              : t("privateNoteAutosaveHint"))}
+        </div>
       </div>
     );
   }
@@ -145,23 +153,25 @@ const PrivateNote: FC<Props> = ({ post: { private_note, id }, hideToggle }) => {
     <SectionToggle
       title={t("privateNote")}
       variant={text ? "orange" : "primary"}
-      detailElement={(isOpen) => {
-        if (isOpen) {
-          return <div className="ml-auto text-xs">{noteStatusDetails}</div>;
-        } else if (updated_at) {
-          return (
-            <div className="ml-auto text-xs">
-              {t.rich("privateNoteUpdatedFrom", {
-                date: () => (
-                  <RelativeTime datetime={updated_at} format="relative">
-                    {formatDate(locale, new Date(updated_at))}
-                  </RelativeTime>
-                ),
-              })}
-            </div>
-          );
-        }
-      }}
+      titleSuffix={
+        hasNoteContent ? (
+          <span className="size-2.5 shrink-0 rounded-full bg-orange-500 dark:bg-orange-500-dark" />
+        ) : null
+      }
+      detailElement={(isOpen) => (
+        <div className="ml-auto text-xs">
+          {(isOpen ? noteStatusDetails : undefined) ??
+            (updated_at
+              ? t.rich("privateNoteUpdatedFrom", {
+                  date: () => (
+                    <RelativeTime datetime={updated_at} format="relative">
+                      {formatDate(locale, new Date(updated_at))}
+                    </RelativeTime>
+                  ),
+                })
+              : t("privateNoteAutosaveHint"))}
+        </div>
+      )}
     >
       {editor}
     </SectionToggle>

--- a/front_end/src/components/question/private_note.tsx
+++ b/front_end/src/components/question/private_note.tsx
@@ -14,6 +14,7 @@ import SectionToggle from "@/components/ui/section_toggle";
 import { useAuth } from "@/contexts/auth_context";
 import { useDebouncedCallback } from "@/hooks/use_debounce";
 import { Post } from "@/types/post";
+import { logError } from "@/utils/core/errors";
 import { formatDate } from "@/utils/formatters/date";
 
 type Props = {
@@ -70,6 +71,11 @@ const PrivateNote: FC<Props> = ({ post: { private_note, id }, hideToggle }) => {
   const [savedAt, setSavedAt] = useState<undefined | Date>();
   const { user } = useAuth();
   const editorRef = useRef<MDXEditorMethods>(null);
+  const latestValueRef = useRef(noteText);
+  // Value of the most recent save request, kept apart from the displayed text so
+  // that mirroring edits eagerly doesn't make the editor look already-saved.
+  const lastRequestedRef = useRef(noteText);
+  const saveRequestIdRef = useRef(0);
 
   const noteStatusDetails = useMemo(() => {
     if (isLoading) {
@@ -81,22 +87,46 @@ const PrivateNote: FC<Props> = ({ post: { private_note, id }, hideToggle }) => {
     }
   }, [savedAt, isLoading]);
 
-  const saveNote = async (value: string) => {
-    if (value === noteText) {
-      return;
-    }
-
+  // Publish every edit right away: the debounce and the request that follow can
+  // outlive this component (switching tabs unmounts the panel), and the context
+  // is what the next mount reads from.
+  const syncValue = (value: string) => {
+    latestValueRef.current = value;
     setNoteText(value);
-
-    setIsLoading(true);
-    await savePrivateNote(id, value);
-    setIsLoading(false);
-
-    setSavedAt(new Date());
     questionLayout?.setPrivateNoteText(value);
   };
 
+  const saveNote = async (value: string) => {
+    syncValue(value);
+
+    if (value === lastRequestedRef.current) {
+      return;
+    }
+    lastRequestedRef.current = value;
+
+    const requestId = ++saveRequestIdRef.current;
+    setIsLoading(true);
+    await savePrivateNote(id, value);
+
+    if (requestId !== saveRequestIdRef.current) {
+      // Superseded while in flight — the newest request reports the final status.
+      return;
+    }
+
+    setIsLoading(false);
+    setSavedAt(new Date());
+  };
+
   const saveNoteDebounced = useDebouncedCallback(saveNote, 1500);
+
+  // The debounce timer is dropped on unmount, so hand off anything still pending.
+  useEffect(() => {
+    return () => {
+      if (latestValueRef.current !== lastRequestedRef.current) {
+        savePrivateNote(id, latestValueRef.current).catch(logError);
+      }
+    };
+  }, [id]);
 
   const hasNoteContent = noteText.trim().length > 0;
 
@@ -110,6 +140,7 @@ const PrivateNote: FC<Props> = ({ post: { private_note, id }, hideToggle }) => {
       markdown={noteText}
       mode="write"
       onChange={(val) => {
+        syncValue(val);
         saveNoteDebounced(val);
       }}
       onBlur={() => {

--- a/front_end/src/components/ui/section_toggle.tsx
+++ b/front_end/src/components/ui/section_toggle.tsx
@@ -159,6 +159,7 @@ type Props = {
   variant?: SectionVariant;
   id?: string;
   detailElement?: ((isOpen: boolean) => ReactNode) | ReactNode | null;
+  titleSuffix?: ReactNode;
   hiddenUntilFound?: boolean;
 };
 
@@ -172,6 +173,7 @@ const SectionToggle: FC<PropsWithChildren<Props>> = ({
   contentWrapperClassName,
   children,
   detailElement,
+  titleSuffix,
   hiddenUntilFound,
 }) => {
   const isPrintMode = usePrintOverride();
@@ -197,6 +199,7 @@ const SectionToggle: FC<PropsWithChildren<Props>> = ({
           className={iconVariants({ variant, open })}
         />
         <span>{title}</span>
+        {titleSuffix}
         {typeof detailElement === "function"
           ? detailElement(open)
           : detailElement}


### PR DESCRIPTION
Two enhancements to the Private Notes experience, plus a bug fix.

### Features
- **Empty-state autosave hint** — the note editor now shows _"changes are saved automatically"_ where the "saved just now" status appears, instead of a blank line when there's no note yet. New `privateNoteAutosaveHint` key added to all six locale files (`en, es, cs, pt, zh, zh-TW`).
- **Note indicator dot** — a 10×10 `orange-500` dot marks questions that already have a note:
  - **left** of the "Private Notes" tab label on the question page, and
  - **right** of the "Private Note" title in the prediction-flow collapsible section (via a new optional `titleSuffix` prop on `SectionToggle`).

### Bug fix (tab remount)
The Private Notes tab panel unmounts when you switch tabs, so returning remounted the editor and re-seeded `noteText` from the stale page-load prop — a just-written note vanished until refresh. The note text is now persisted in the `QuestionLayout` context (`privateNoteText`), so the editor and the dot survive tab switches and update live as the note is created/cleared.

## Notes for reviewers
- The prediction-flow `PrivateNote` renders **outside** `QuestionLayoutProvider`; it uses `useQuestionLayoutSafe()` and falls back to server data, so its behavior is unchanged aside from the new dot + hint.
- `SectionToggle` change is a backward-compatible optional prop (`titleSuffix`), no impact on existing usages.
- Known minor cosmetic edge: a note *created in the current session* shows the resting hint (not "from <time>") after a tab switch, since the server `updated_at` isn't refreshed without a reload — the note content itself is correct.

## Verification
- `bun run lint:types` passes; lint/format clean on changed files.
- Interactive check requires a **Forecaster**-view session (Consumer view has no Private Notes tab).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Private notes now remain available when switching between question tabs.
  - An orange indicator appears on the private-notes tab and toggle when note content exists.
  - Private-note status displays include an autosave hint when no timestamp is available.
  - Note edits are preserved and saved reliably when navigating away.

- **Localization**
  - Added the private-note autosave hint in English, Czech, Spanish, Portuguese, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->