### PR TITLE
Add Jacob Schaal to Labor Hub acknowledgements

### DIFF
--- a/front_end/src/app/(main)/labor-hub/sections/methodology.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/methodology.tsx
@@ -113,6 +113,7 @@ export function MethodologySection({ ...props }: ComponentProps<"section">) {
                 <li>Cheryl Oldham (Bipartisan Policy Center)</li>
                 <li>Brent Orrell (American Enterprise Institute)</li>
                 <li>Sneha Revanur (Encode AI)</li>
+                <li>Jacob Schaal (King&apos;s College London)</li>
                 <li>Philipp Schmitt (Axim Collaborative)</li>
                 <li>Dane Stangler (Bipartisan Policy Center)</li>
                 <li>Shayna Strom (Washington Center for Equitable Growth)</li>


### PR DESCRIPTION
Adds Jacob Schaal (King’s College London) to the Acknowledgements section of the Labor Automation Forecasting Hub.

Added as plain text (no hyperlink) to match the other entries, inserted in alphabetical-by-surname order between Sneha Revanur and Philipp Schmitt.

Fixes #5134

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Jacob Schaal of King’s College London to the Labor Automation Forecasting Hub acknowledgements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->