### PR TITLE
fix: labor hub commentary — 2030 Jobs Monitor decline ranking

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -27,10 +27,11 @@ export const JOBS_INSIGHTS = {
     negative: (
       <>
         By 2030, <strong>software developers</strong>,{" "}
-        <strong>financial specialists</strong>, and <strong>sales</strong> are
-        expected to see the largest declines as AI absorbs coding, rules-based
-        analysis, and outreach. Software development leads the drop, with rapid
-        AI adoption and no legal protections.
+        <strong>financial specialists</strong>, and{" "}
+        <strong>lawyers and law clerks</strong> are expected to see the largest
+        declines as AI absorbs coding, rules-based analysis, and research work.
+        Software development leads the drop, with rapid AI adoption and no legal
+        protections.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-08-10">Aug 10</time>
+              Commentary last updated: <time dateTime="2026-08-18">Aug 18</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated QA pass on the [Labor Automation Forecasting Hub](https://www.metaculus.com/labor-hub) cross-referencing chart data against commentary text. Found one misalignment in the Jobs Monitor's 2030 forecast view.

## Fix

**Jobs Monitor — "by 2030" largest-declines callout**

- Before: "By 2030, **software developers**, **financial specialists**, and **sales** are expected to see the largest declines..."
- After: "By 2030, **software developers**, **financial specialists**, and **lawyers and law clerks** are expected to see the largest declines..."

The 2030 forecast data (from the underlying chart series) ranks declines as: Software Developers −7.4%, Financial Specialists −5.3%, **Lawyers and Law Clerks −5.2%**, then Services Sales Representatives −4.6%. Lawyers and Law Clerks decline more than Sales Representatives at the 2030 horizon, so the commentary's third-named occupation was wrong. (The 2035 version of this same callout already correctly names lawyers and law clerks, so this was specific to the 2030 view.)

Also bumped the "Commentary last updated" date shown in the hero section to reflect this pass.

## Files changed
- `front_end/src/app/(main)/labor-hub/jobs_insights.tsx`
- `front_end/src/app/(main)/labor-hub/sections/hero.tsx`

## Test plan
- [x] `npx prettier --write` on changed files
- [x] `npx eslint` on changed files — no errors
- [ ] Visual check of the Jobs Monitor "by 2030" view on deploy preview


---
_Generated by [Claude Code](https://claude.ai/code/session_01VVQ4oZAjkqkWsUe5MtftVP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the 2030 labor outlook to highlight lawyers and law clerks among occupations expected to decline.
  * Clarified that AI’s impact in this outlook relates to research work.
  * Continued to identify financial specialists separately.

* **Bug Fixes**
  * Updated the displayed commentary date to August 18, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->