### PR TITLE
feat: add July 21, 2026 OpenAI security incident to labor hub activity monitor

### DIFF
--- a/front_end/src/app/(main)/labor-hub/activity_data.tsx
+++ b/front_end/src/app/(main)/labor-hub/activity_data.tsx
@@ -306,4 +306,20 @@ export const RAW_ACTIVITY_MONITOR_DATA: RawActivityMonitorEntry[] = [
       </>
     ),
   },
+  {
+    date: "2026-07-21",
+    type: "news",
+    content: (
+      <>
+        OpenAI announces major security incident during model evaluation. -{" "}
+        <a
+          href="https://openai.com/index/hugging-face-model-evaluation-security-incident/"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          OpenAI
+        </a>
+      </>
+    ),
+  },
 ];


### PR DESCRIPTION
Adds a new entry to the labor hub activity monitor:

> July 21, 2026: OpenAI announces major security incident during model evaluation. [link](https://openai.com/index/hugging-face-model-evaluation-security-incident/)

The entry is appended to `RAW_ACTIVITY_MONITOR_DATA` in `front_end/src/app/(main)/labor-hub/activity_data.tsx` as a `news` item, matching the format of surrounding entries.

Closes #5142

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a July 21, 2026 news activity entry covering an OpenAI security incident during model evaluation.
  * Included a link to the original OpenAI source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->