### PR TITLE
fix: labor hub commentary — Jobs Monitor ranking mismatches

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -18,18 +18,18 @@ export const JOBS_INSIGHTS = {
     positive: (
       <>
         By 2030, <strong>nurses</strong>, <strong>construction workers</strong>,
-        and <strong>physicians</strong> are expected to see the largest gains,
+        and <strong>engineers</strong> are expected to see the largest gains,
         driven by an aging population, infrastructure buildouts, and continued
-        demand for in-person service that AI is unlikely to displace in the
-        short term.
+        demand for technical expertise that AI is unlikely to fully displace in
+        the short term.
       </>
     ),
     negative: (
       <>
         By 2030, <strong>software developers</strong>,{" "}
         <strong>financial specialists</strong>, and{" "}
-        <strong>lawyers and law clerks</strong> are expected to see the largest
-        declines as AI absorbs coding, rules-based analysis, and research work.
+        <strong>sales representatives</strong> are expected to see the largest
+        declines as AI absorbs coding, rules-based analysis, and outreach work.
         Software development leads the drop, with rapid AI adoption and no legal
         protections.
       </>
@@ -48,10 +48,10 @@ export const JOBS_INSIGHTS = {
       <>
         By 2035, <strong>financial specialists</strong>,{" "}
         <strong>software developers</strong>, and{" "}
-        <strong>lawyers and law clerks</strong> are expected to see sharp staff
-        reductions as AI takes over coding, analysis, and research work.{" "}
-        <strong>Sales representatives</strong> will also see reductions as AI
-        automates outreach and client work.
+        <strong>sales representatives</strong> are expected to see sharp staff
+        reductions as AI takes over coding, analysis, and outreach work.{" "}
+        <strong>Lawyers and law clerks</strong> will also see reductions as AI
+        automates legal research and drafting.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-08-18">Aug 18</time>
+              Commentary last updated: <time dateTime="2026-08-20">Aug 20</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated QA pass over the [Labor Automation Forecasting Hub](https://www.metaculus.com/labor-hub) compared each chart's forecast data against the surrounding commentary. Since forecasts on this page are live and shift over time, three Jobs Monitor callouts had drifted out of sync with the current top-3 rankings.

## Fixes

**Section: Jobs Monitor — 2030 largest gains**
- Before: "By 2030, **nurses**, **construction workers**, and **physicians** are expected to see the largest gains..."
- Data: Engineers (+2.5%) now rank above Physicians (+2.2%) for 2030.
- After: "By 2030, **nurses**, **construction workers**, and **engineers** are expected to see the largest gains..."

**Section: Jobs Monitor — 2030 largest declines**
- Before: "By 2030, **software developers**, **financial specialists**, and **lawyers and law clerks** are expected to see the largest declines..."
- Data: Sales representatives now decline more than lawyers and law clerks by 2030.
- After: "By 2030, **software developers**, **financial specialists**, and **sales representatives** are expected to see the largest declines..."

**Section: Jobs Monitor — 2035 sharp staff reductions**
- Before: "By 2035, **financial specialists**, **software developers**, and **lawyers and law clerks** are expected to see sharp staff reductions... **Sales representatives** will also see reductions..."
- Data: Sales representatives (-11.6%) decline more than lawyers and law clerks (-11.2%) by 2035 — this also now matches the page's own Key Insights section, which already correctly names sales representatives in the top 3.
- After: "By 2035, **financial specialists**, **software developers**, and **sales representatives** are expected to see sharp staff reductions... **Lawyers and law clerks** will also see reductions..."

Also bumped the "Commentary last updated" date.

Note: the 2030-decline callout was previously fixed in #5141 based on data as of Aug 18 (lawyers and law clerks were the third-largest decliner at that time). The underlying community forecast has since shifted, moving sales representatives back into the top 3 — this PR re-aligns the copy with the current live data.

Only commentary text was changed; no chart data, component structure, or unrelated code was touched.

## Test plan
- [x] `prettier --check` on changed files
- [x] `eslint` on changed files
- [ ] Visual check on the deployed labor-hub page once merged

Claude-Session: https://claude.ai/code/session_01D7RLB4sBsqED3CtQg9wtKh


---
_Generated by [Claude Code](https://claude.ai/code/session_01D7RLB4sBsqED3CtQg9wtKh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Updated 2030 and 2035 labor projection highlights to reflect revised occupations with the largest growth and decline.
  - Refined the 2035 narrative to emphasize sales representatives, lawyers, and law clerks.
  - Updated the legal automation example to focus on legal research and drafting.
  - Refreshed the commentary timestamp to August 20, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->