### PR TITLE
fix: labor hub commentary — Jobs Monitor and State-Level ranking drift

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -18,10 +18,10 @@ export const JOBS_INSIGHTS = {
     positive: (
       <>
         By 2030, <strong>nurses</strong>, <strong>construction workers</strong>,
-        and <strong>engineers</strong> are expected to see the largest gains,
+        and <strong>physicians</strong> are expected to see the largest gains,
         driven by an aging population, infrastructure buildouts, and continued
-        demand for technical expertise that AI is unlikely to fully displace in
-        the short term.
+        demand for in-person service that AI is unlikely to displace in the
+        short term.
       </>
     ),
     negative: (

--- a/front_end/src/app/(main)/labor-hub/page.tsx
+++ b/front_end/src/app/(main)/labor-hub/page.tsx
@@ -780,7 +780,7 @@ export default function LaborAutomationHubPage() {
             <ContentParagraph>
               The healthcare sector (employing 13% of Washington residents) is
               forecasted to grow through 2027, largely unaffected by AI in this
-              timeframe. Aerospace (employing 2%) is expected to see minor
+              timeframe. Aerospace (employing 2%) is expected to see similar
               growth in the short-term, while technology (employing 10%) is
               expected to stay roughly flat, largely consistent with historical
               trends. These forecasts are short-term, leading to minimal

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-08-20">Aug 20</time>
+              Commentary last updated: <time dateTime="2026-08-24">Aug 24</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Routine QA pass on the Labor Automation Forecasting Hub (`/labor-hub`), cross-referencing chart/table data against the surrounding commentary text. Live forecast data has shifted slightly since the last pass, causing two commentary mismatches:

- **Jobs Monitor — 2030 gains callout**: Physicians (+2.19%) now edge out engineers (+2.17%) as the third-largest 2030 gainer (behind nurses and construction workers), reversing the ranking from the Aug 20 fix (#5144). Swapped the named occupation back to physicians and restored the matching driver text ("continued demand for in-person service" instead of "technical expertise").
- **State-Level View — Washington sector growth**: Aerospace (+1.9%) and healthcare (+2.0%) are nearly identical in magnitude, but the commentary described aerospace growth as "minor" while healthcare's growth had no such qualifier — implying a magnitude difference the data doesn't support. Changed "minor growth" to "similar growth" for aerospace.

All other sections (Overall Employment, Wages, Graduates, Economy, Research comparison table) were checked and found consistent with their underlying chart/table data as of this pass.

Also bumped "Commentary last updated" to today's date.

## Changes

| Section | Before | After |
|---|---|---|
| Jobs Monitor (2030 gains) | "nurses, construction workers, and **engineers** ... continued demand for **technical expertise** that AI is unlikely to fully displace" | "nurses, construction workers, and **physicians** ... continued demand for **in-person service** that AI is unlikely to displace" |
| State-Level View | "Aerospace (employing 2%) is expected to see **minor** growth in the short-term" | "Aerospace (employing 2%) is expected to see **similar** growth in the short-term" |
| Hero | Commentary last updated: Aug 20 | Commentary last updated: Aug 24 |

## Test plan

- [x] `npx prettier --write` on all edited files (no changes needed)
- [x] `npx eslint` on all edited files (clean)
- [x] Verified new copy against live chart data extracted from the page's RSC payload (Jobs Monitor per-occupation values, Washington sector table)
- [x] Confirmed no other open PR exists with this title prefix

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGPyP91d5BmCWZNm1MrD5C)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated job outlook messaging to highlight physician demand and in-person services less likely to be displaced by AI.
  * Revised Washington aerospace employment projections to indicate similar short-term growth.
  * Updated the displayed commentary date to August 24, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->