### PR TITLE
Metaculus Site Stats Warmup Cache

### DIFF
--- a/misc/management/commands/cron.py
+++ b/misc/management/commands/cron.py
@@ -13,6 +13,7 @@ from comments.tasks import (
     job_finalize_and_send_weekly_top_comments,
 )
 from misc.jobs import sync_itn_articles
+from misc.tasks import warm_cache_site_stats
 from notifications.jobs import (
     job_send_notification_groups,
     job_send_open_status_notifications,
@@ -256,6 +257,13 @@ class Command(BaseCommand):
             close_old_connections(warm_cache_metaculus_stats.send),
             trigger=CronTrigger.from_crontab("0 */12 * * *"),  # Every 12 hours
             id="warm_cache_metaculus_stats",
+            max_instances=1,
+            replace_existing=True,
+        )
+        scheduler.add_job(
+            close_old_connections(warm_cache_site_stats.send),
+            trigger=CronTrigger.from_crontab("30 */12 * * *"),  # Every 12 hours
+            id="warm_cache_site_stats",
             max_instances=1,
             replace_existing=True,
         )

--- a/misc/services/stats.py
+++ b/misc/services/stats.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from questions.constants import UnsuccessfulResolutionType
+from questions.models import Forecast, Question
+from utils.cache import cached_singleton
+
+
+@cached_singleton(timeout=60 * 60 * 24)
+def get_cached_site_stats() -> dict:
+    now_year = datetime.now().year
+    public_questions = Question.objects.filter_public()
+
+    return {
+        "predictions": (
+            Forecast.objects.filter(question__in=public_questions)
+            .exclude(source=Forecast.SourceChoices.AUTOMATIC)
+            .count()
+        ),
+        "questions": public_questions.count(),
+        "resolved_questions": (
+            public_questions.filter(actual_resolve_time__isnull=False)
+            .exclude(resolution__in=UnsuccessfulResolutionType)
+            .count()
+        ),
+        "years_of_predictions": now_year - 2015 + 1,
+    }

--- a/misc/tasks.py
+++ b/misc/tasks.py
@@ -3,6 +3,8 @@ import logging
 import dramatiq
 from django.core.mail import send_mail
 
+from .services.stats import get_cached_site_stats
+
 logger = logging.getLogger(__name__)
 
 
@@ -10,3 +12,8 @@ logger = logging.getLogger(__name__)
 def send_email_async(*args, recipient_list: list[str], **kwargs):
     if recipient_list:
         send_mail(*args, recipient_list=recipient_list, **kwargs)
+
+
+@dramatiq.actor
+def warm_cache_site_stats() -> None:
+    get_cached_site_stats.refresh_cache()

--- a/misc/views.py
+++ b/misc/views.py
@@ -1,10 +1,8 @@
-from datetime import datetime
-
 from django.conf import settings
 from django.core.mail import EmailMessage
 from django.http import JsonResponse
 from django.utils import timezone
-from django.views.decorators.cache import cache_page
+from django.views.decorators.cache import cache_control, cache_page
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import PermissionDenied
@@ -12,9 +10,6 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
-
-from questions.constants import UnsuccessfulResolutionType
-from questions.models import Forecast, Question
 
 from .models import Bulletin, BulletinViewedBy, ITNArticle, SidebarItem
 from .serializers import (
@@ -28,6 +23,7 @@ from .services.ad_tiles import (
     get_tile_object_by_id,
 )
 from .services.itn import remove_article
+from .services.stats import get_cached_site_stats
 from .utils import get_data_access_status
 
 
@@ -138,23 +134,11 @@ def get_dismissed_bulletin_ids(request):
     return Response({"dismissed_bulletin_ids": dismissed_bulletin_ids})
 
 
-@cache_page(60 * 60 * 24)
+@cache_control(public=True, max_age=60 * 60)
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def get_site_stats(request):
-    now_year = datetime.now().year
-    public_questions = Question.objects.filter_public()
-    stats = {
-        "predictions": Forecast.objects.filter(question__in=public_questions)
-        .exclude(source=Forecast.SourceChoices.AUTOMATIC)
-        .count(),
-        "questions": public_questions.count(),
-        "resolved_questions": public_questions.filter(actual_resolve_time__isnull=False)
-        .exclude(resolution__in=UnsuccessfulResolutionType)
-        .count(),
-        "years_of_predictions": now_year - 2015 + 1,
-    }
-    return JsonResponse(stats)
+    return JsonResponse(get_cached_site_stats())
 
 
 @api_view(["POST"])

--- a/misc/views.py
+++ b/misc/views.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.mail import EmailMessage
 from django.utils import timezone
-from django.views.decorators.cache import cache_control, cache_page
+from django.views.decorators.cache import cache_page
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import PermissionDenied

--- a/misc/views.py
+++ b/misc/views.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.core.mail import EmailMessage
-from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.cache import cache_control, cache_page
 from rest_framework import status
@@ -134,11 +133,10 @@ def get_dismissed_bulletin_ids(request):
     return Response({"dismissed_bulletin_ids": dismissed_bulletin_ids})
 
 
-@cache_control(public=True, max_age=60 * 60)
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def get_site_stats(request):
-    return JsonResponse(get_cached_site_stats())
+    return Response(get_cached_site_stats())
 
 
 @api_view(["POST"])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Site statistics are now served from a cached result, improving response times.
  * Statistics refresh automatically every 12 hours to keep displayed data current.
* **Bug Fixes**
  * Public site statistics now use consistent caching behavior and updated cache-control settings.
  * Statistics calculations exclude automated forecasts and unsuccessful resolutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->