### PR TITLE
Fix tournament tile timeline state in Tournaments Hub

### DIFF
--- a/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/live_tournament_card.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/live_tournament_card.tsx
@@ -21,13 +21,13 @@ import GradientProgressLine from "../../../tournament/components/gradient_progre
 
 type Props = {
   item: TournamentPreview;
-  nowTs?: number;
+  nowTs: number;
   hideTimeline?: boolean;
 };
 
 const LiveTournamentCard: React.FC<Props> = ({
   item,
-  nowTs = 0,
+  nowTs,
   hideTimeline = false,
 }) => {
   const t = useTranslations();
@@ -111,7 +111,7 @@ function TournamentTimelineBar({
   closeDate,
   isOngoing,
 }: {
-  nowTs: number | null;
+  nowTs: number;
   timeline: TournamentTimeline | null;
   startDate?: string | null;
   forecastingEndDate?: string | null;
@@ -122,18 +122,16 @@ function TournamentTimelineBar({
   const closedTs = safeTs(forecastingEndDate ?? closeDate ?? null);
   if (!startTs || !closedTs) return null;
 
-  const now = nowTs ?? Date.now();
-
   const rawClosed =
     timeline?.all_questions_closed != null
       ? Boolean(timeline.all_questions_closed)
       : !isOngoing;
 
-  const isClosed = rawClosed && now >= closedTs;
+  const isClosed = rawClosed && nowTs >= closedTs;
   const isResolved = Boolean(timeline?.all_questions_resolved);
 
   if (!isClosed) {
-    return <ActiveMiniBar nowTs={now} startTs={startTs} endTs={closedTs} />;
+    return <ActiveMiniBar nowTs={nowTs} startTs={startTs} endTs={closedTs} />;
   }
 
   return <ClosedStatus isResolved={isResolved} />;
@@ -144,17 +142,15 @@ function ActiveMiniBar({
   startTs,
   endTs,
 }: {
-  nowTs: number | null;
+  nowTs: number;
   startTs: number;
   endTs: number;
 }) {
   const t = useTranslations();
-  let label = t("tournamentTimelineOngoing");
+  let label: string;
   let p = 0;
 
-  if (nowTs == null) {
-    label = t("tournamentTimelineOngoing");
-  } else if (nowTs < startTs) {
+  if (nowTs < startTs) {
     label = t("tournamentTimelineStarts", {
       when: formatTournamentRelativeDelta(t, startTs - nowTs, {
         fromNow: true,

--- a/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/search_results_grid.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_grid/search_results_grid.tsx
@@ -27,7 +27,14 @@ const SearchResultsGrid: React.FC = () => {
           return <QuestionSeriesCard key={item.id} item={item} showTypeLabel />;
         }
 
-        return <LiveTournamentCard key={item.id} item={item} nowTs={nowTs} />;
+        return (
+          <LiveTournamentCard
+            key={item.id}
+            item={item}
+            nowTs={nowTs}
+            hideTimeline={!item.is_ongoing}
+          />
+        );
       }}
     />
   );

--- a/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_provider.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_provider.tsx
@@ -18,7 +18,7 @@ type TournamentsSectionCtxValue = {
   current: TournamentsSection;
   items: TournamentPreview[];
   count: number;
-  nowTs?: number;
+  nowTs: number;
   defaultSort: TournamentsSortBy;
   isSearching: boolean;
   infoOpen: boolean;
@@ -34,7 +34,7 @@ export function TournamentsSectionProvider(props: {
   tournaments: TournamentPreview[];
   current: TournamentsSection;
   children: React.ReactNode;
-  nowTs?: number;
+  nowTs: number;
 }) {
   const { tournaments, current, children, nowTs } = props;
   const [infoOpen, setInfoOpen] = useState(true);

--- a/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_screen.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/components/tournaments_screen.tsx
@@ -14,7 +14,7 @@ type Props = {
   current: TournamentsSection;
   tournaments: TournamentPreview[];
   children: React.ReactNode;
-  nowTs?: number;
+  nowTs: number;
 };
 
 const TournamentsScreen: React.FC<Props> = ({

--- a/front_end/src/app/(main)/(tournaments)/tournaments/indexes/page.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/indexes/page.tsx
@@ -5,9 +5,14 @@ import TournamentsScreen from "../components/tournaments_screen";
 
 const IndexesPage: React.FC = async () => {
   const tournaments = await ServerProjectsApi.getTournaments();
+  const nowTs = Date.now();
 
   return (
-    <TournamentsScreen current="indexes" tournaments={tournaments}>
+    <TournamentsScreen
+      current="indexes"
+      tournaments={tournaments}
+      nowTs={nowTs}
+    >
       <IndexTournamentsGrid />
     </TournamentsScreen>
   );

--- a/front_end/src/app/(main)/(tournaments)/tournaments/question-series/page.tsx
+++ b/front_end/src/app/(main)/(tournaments)/tournaments/question-series/page.tsx
@@ -5,9 +5,10 @@ import TournamentsScreen from "../components/tournaments_screen";
 
 const QuestionSeriesPage: React.FC = async () => {
   const tournaments = await ServerProjectsApi.getTournaments();
+  const nowTs = Date.now();
 
   return (
-    <TournamentsScreen current="series" tournaments={tournaments}>
+    <TournamentsScreen current="series" tournaments={tournaments} nowTs={nowTs}>
       <SeriesTournamentsGrid />
     </TournamentsScreen>
   );


### PR DESCRIPTION
### Summary

Fixes tournament tiles displaying an incorrect timeline state in the Question Series, Indexes, and cross-tab search views.

The issue was reported in this [Slack thread](https://metaculus.slack.com/archives/C01Q9AQBVHB/p1787325761449639).

### Changes

- Pass `nowTs` from the Question Series and Indexes pages. Previously, tournament cards rendered from these views could fall back to `nowTs = 0` and incorrectly display “Starts in the far future”.
- Make `nowTs` required throughout the tournament screen/card flow to prevent the fallback from recurring.
- Hide timelines for non-ongoing tournaments in search results, matching their presentation in the Archived grid.

### Before

<img width="1593" height="833" alt="Tournament tiles incorrectly showing Starts in the far future" src="https://github.com/user-attachments/assets/480bb23f-9b3c-4db0-bd62-8a645eeebb06" />

### After

<img width="1115" height="674" alt="Tournament tiles showing the correct timeline state" src="https://github.com/user-attachments/assets/33d32f14-e9d4-42bf-9091-5f457f87dc2b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live tournament timeline accuracy by using a consistent current-time value.
  * Fixed timeline visibility so it is shown only for ongoing tournaments.
  * Improved tournament status labels before an event begins.
* **Consistency**
  * Tournament pages now provide consistent timing information for live status and progress displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->