### PR TITLE
Hide email/password change for bots without credentials

### DIFF
--- a/front_end/src/app/(main)/accounts/settings/account/components/api_access.tsx
+++ b/front_end/src/app/(main)/accounts/settings/account/components/api_access.tsx
@@ -20,9 +20,13 @@ import { rotateApiKeyAction } from "../../actions";
 
 type Props = {
   apiKey: string | null;
+  withDivider?: boolean;
 };
 
-const ApiAccess: FC<Props> = ({ apiKey: initialApiKey }) => {
+const ApiAccess: FC<Props> = ({
+  apiKey: initialApiKey,
+  withDivider = true,
+}) => {
   const t = useTranslations();
   const [apiKey, setApiKey] = useState<string | null>(initialApiKey);
   const [isVisible, setIsVisible] = useState(false);
@@ -70,7 +74,9 @@ const ApiAccess: FC<Props> = ({ apiKey: initialApiKey }) => {
 
   return (
     <section id="api-access">
-      <hr className="my-6 border-gray-400 dark:border-gray-400-dark" />
+      {withDivider && (
+        <hr className="my-6 border-gray-400 dark:border-gray-400-dark" />
+      )}
       <div className="mb-4 text-gray-500 dark:text-gray-500-dark">
         {t("apiAccess")}
       </div>

--- a/front_end/src/app/(main)/accounts/settings/account/components/api_access.tsx
+++ b/front_end/src/app/(main)/accounts/settings/account/components/api_access.tsx
@@ -23,10 +23,7 @@ type Props = {
   withDivider?: boolean;
 };
 
-const ApiAccess: FC<Props> = ({
-  apiKey: initialApiKey,
-  withDivider = true,
-}) => {
+const ApiAccess: FC<Props> = ({ apiKey: initialApiKey }) => {
   const t = useTranslations();
   const [apiKey, setApiKey] = useState<string | null>(initialApiKey);
   const [isVisible, setIsVisible] = useState(false);
@@ -74,9 +71,6 @@ const ApiAccess: FC<Props> = ({
 
   return (
     <section id="api-access">
-      {withDivider && (
-        <hr className="my-6 border-gray-400 dark:border-gray-400-dark" />
-      )}
       <div className="mb-4 text-gray-500 dark:text-gray-500-dark">
         {t("apiAccess")}
       </div>

--- a/front_end/src/app/(main)/accounts/settings/account/components/api_access.tsx
+++ b/front_end/src/app/(main)/accounts/settings/account/components/api_access.tsx
@@ -20,7 +20,6 @@ import { rotateApiKeyAction } from "../../actions";
 
 type Props = {
   apiKey: string | null;
-  withDivider?: boolean;
 };
 
 const ApiAccess: FC<Props> = ({ apiKey: initialApiKey }) => {

--- a/front_end/src/app/(main)/accounts/settings/account/page.tsx
+++ b/front_end/src/app/(main)/accounts/settings/account/page.tsx
@@ -36,6 +36,7 @@ export default async function Settings() {
           <>
             <EmailEdit user={currentUser} />
             <ChangePassword hasPassword={currentUser.has_password} />
+            <hr className="my-6 border-gray-400 dark:border-gray-400-dark" />
           </>
         )}
         <ApiAccess apiKey={apiKey} withDivider={hasCredentials} />

--- a/front_end/src/app/(main)/accounts/settings/account/page.tsx
+++ b/front_end/src/app/(main)/accounts/settings/account/page.tsx
@@ -22,14 +22,23 @@ export default async function Settings() {
 
   const { key: apiKey } = await ServerAuthApi.getApiKey();
 
+  // Bots created for API forecasting have neither an email nor a password, so
+  // there are no credentials to manage.
+  const hasCredentials =
+    !currentUser.is_bot || !!currentUser.email || currentUser.has_password;
+
   return (
     <div className="flex flex-col gap-6">
-      {!currentUser.has_password && <NoPasswordBanner />}
+      {hasCredentials && !currentUser.has_password && <NoPasswordBanner />}
       <PreferencesSection className="gap-0">
         <EmailChangeToast />
-        <EmailEdit user={currentUser} />
-        <ChangePassword hasPassword={currentUser.has_password} />
-        <ApiAccess apiKey={apiKey} />
+        {hasCredentials && (
+          <>
+            <EmailEdit user={currentUser} />
+            <ChangePassword hasPassword={currentUser.has_password} />
+          </>
+        )}
+        <ApiAccess apiKey={apiKey} withDivider={hasCredentials} />
         <ApiForecastingAccess access={currentUser.api_forecasting_access} />
         <EmailMeMyData />
       </PreferencesSection>

--- a/front_end/src/app/(main)/accounts/settings/account/page.tsx
+++ b/front_end/src/app/(main)/accounts/settings/account/page.tsx
@@ -39,7 +39,7 @@ export default async function Settings() {
             <hr className="my-6 border-gray-400 dark:border-gray-400-dark" />
           </>
         )}
-        <ApiAccess apiKey={apiKey} withDivider={hasCredentials} />
+        <ApiAccess apiKey={apiKey} />
         <ApiForecastingAccess access={currentUser.api_forecasting_access} />
         <EmailMeMyData />
       </PreferencesSection>


### PR DESCRIPTION
<img width="798" height="596" alt="image" src="https://github.com/user-attachments/assets/70a43956-4965-4a29-aa4e-a568b61048fd" />


https://metaculus.slack.com/archives/C01Q9AQBVHB/p1787721089296889

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Account settings now provide a cleaner experience for users without API credentials.
  * Credential-management options, including password and email controls, are hidden when unavailable.
  * Unnecessary dividers are removed when credential controls are not shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->