### PR TITLE
Fix Pro Forecaster leaderboard link

### DIFF
--- a/front_end/src/app/(main)/(leaderboards)/ranking_categories.tsx
+++ b/front_end/src/app/(main)/(leaderboards)/ranking_categories.tsx
@@ -66,7 +66,7 @@ export const RANKING_CATEGORIES: Record<CategoryKey, RankingCategory> = {
           <Link href="/help/medals-faq/" className={smallLinkClassName}>
             Learn more about Metaculus Medals
           </Link>
-          <Link href="/pro-forecasters" className={smallLinkClassName}>
+          <Link href="/faq/#what-are-pros" className={smallLinkClassName}>
             Learn more about becoming a Pro Forecaster
           </Link>
         </div>


### PR DESCRIPTION
## Summary

Points the leaderboard’s Pro Forecaster link to the relevant FAQ section.

- Replaces the obsolete route with the “What are Metaculus Pro Forecasters?” FAQ anchor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Pro Forecaster information link in the “All” leaderboard category to direct users to the relevant FAQ section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->