### PR TITLE
feat(labor-hub): add July 30 Pro Forecasting update to activity monitor

### DIFF
--- a/front_end/src/app/(main)/labor-hub/activity_data.tsx
+++ b/front_end/src/app/(main)/labor-hub/activity_data.tsx
@@ -322,4 +322,22 @@ export const RAW_ACTIVITY_MONITOR_DATA: RawActivityMonitorEntry[] = [
       </>
     ),
   },
+  {
+    date: "2026-07-30",
+    type: "insight",
+    content: (
+      <>
+        Metaculus Pro Forecasters completed a quarterly forecasting update, with
+        the biggest moves on the number of humanities and STEM degrees awarded,
+        as well as lower unemployment disruption for 2030. -{" "}
+        <a
+          href="https://www.metaculus.com/notebooks/44978/labor-hub-updates-july-2026/"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          Metaculus
+        </a>
+      </>
+    ),
+  },
 ];


### PR DESCRIPTION
Adds the Labor Hub Pro Forecasting quarterly update (July 30, 2026) to the Labor Hub Activity Monitor, linking to the [notebook](https://www.metaculus.com/notebooks/44978/labor-hub-updates-july-2026/).

Entry text: "Metaculus Pro Forecasters completed a quarterly forecasting update, with the biggest moves on the number of humanities and STEM degrees awarded, as well as lower unemployment disruption for 2030."

The entry uses type `insight` so it appears in the activity card list (not as a timeline marker on the chart, which is reserved for `news` entries).

Resolves #5157

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new activity update highlighting the latest quarterly forecasting contribution from Metaculus Pro Forecasters.
  * Included a link to the related Metaculus notebook for additional details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->