### PR TITLE
decrease max label count to avoid overlapping date labels

### DIFF
--- a/front_end/src/utils/charts/axis.ts
+++ b/front_end/src/utils/charts/axis.ts
@@ -1354,7 +1354,7 @@ export function generateScale({
   } else if (axisLength < 800) {
     maxLabelCount = direction === ScaleDirection.Horizontal ? 7 : 21;
   } else if (axisLength < 1200) {
-    maxLabelCount = direction === ScaleDirection.Horizontal ? 11 : 21;
+    maxLabelCount = direction === ScaleDirection.Horizontal ? 9 : 21;
   } else {
     maxLabelCount = direction === ScaleDirection.Horizontal ? 21 : 26;
   }


### PR DESCRIPTION
potential for more elegant solution where label length is taken into account like for discrete horizontal axis labels. But saving that for another time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal chart axis readability on medium-sized displays by reducing the maximum number of labels shown from 11 to 9.
  * Vertical axes continue to support up to 21 labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->