### PR TITLE
`send_email_async` empty address safeguard

### DIFF
--- a/misc/tasks.py
+++ b/misc/tasks.py
@@ -10,8 +10,17 @@ logger = logging.getLogger(__name__)
 
 @dramatiq.actor
 def send_email_async(*args, recipient_list: list[str], **kwargs):
-    if recipient_list:
-        send_mail(*args, recipient_list=recipient_list, **kwargs)
+    recipient_list = recipient_list or []
+    recipients = [email for email in recipient_list if email and email.strip()]
+
+    if excluded := len(recipient_list) - len(recipients):
+        logger.warning(
+            f"send_email_async: excluded {excluded} empty recipient(s), "
+            f"subject: {kwargs.get('subject')}"
+        )
+
+    if recipients:
+        send_mail(*args, recipient_list=recipients, **kwargs)
 
 
 @dramatiq.actor


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email delivery handling by excluding blank or whitespace-only recipient addresses.
  * Prevented email attempts when no valid recipients remain.
  * Added clearer logging for excluded recipients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->