### PR TITLE
fix: labor hub commentary — Jobs Monitor 2027/2030 occupation rankings

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -9,29 +9,30 @@ export const JOBS_INSIGHTS = {
     negative: (
       <>
         By 2027, <strong>designers</strong> and{" "}
-        <strong>software developers</strong> are expected to see early declines
-        as AI begins to automate creative and coding work.
+        <strong>services sales representatives</strong> are expected to see
+        early declines as AI begins to automate creative work and outreach
+        tasks.
       </>
     ),
   },
   "2030": {
     positive: (
       <>
-        By 2030, <strong>nurses</strong>, <strong>construction workers</strong>,
-        and <strong>engineers</strong> are expected to see the largest gains,
-        driven by an aging population, infrastructure buildouts, and continued
-        demand for technical expertise that AI is unlikely to fully displace in
-        the short term.
+        By 2030, <strong>nurses</strong>, <strong>physicians</strong>, and{" "}
+        <strong>construction workers</strong> are expected to see the largest
+        gains, driven by an aging population&apos;s growing healthcare needs and
+        continued infrastructure buildouts that AI is unlikely to fully displace
+        in the short term.
       </>
     ),
     negative: (
       <>
         By 2030, <strong>software developers</strong>,{" "}
-        <strong>financial specialists</strong>, and{" "}
-        <strong>lawyers and law clerks</strong> are expected to see the largest
-        declines as AI absorbs coding, rules-based analysis, and legal research
-        work. Software development leads the drop, with rapid AI adoption and no
-        legal protections.
+        <strong>services sales representatives</strong>, and{" "}
+        <strong>financial specialists</strong> are expected to see the largest
+        declines as AI absorbs coding, customer outreach, and rules-based
+        analysis work. Software development leads the drop, with rapid AI
+        adoption and no legal protections.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-08-27">Aug 27</time>
+              Commentary last updated: <time dateTime="2026-09-04">Sep 4</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated QA pass on the [Labor Automation Forecasting Hub](https://www.metaculus.com/labor-hub) found the Jobs Monitor's per-year callout text naming the wrong occupations as top gainers/decliners when the underlying forecast data is ranked. Fixed the copy in `front_end/src/app/(main)/labor-hub/jobs_insights.tsx` to match the actual ranked values, and bumped the "commentary last updated" date in `hero.tsx`.

## Fixes

**Section: Jobs Monitor — 2027 tab (decline callout)**
- Before: *"By 2027, **designers** and **software developers** are expected to see early declines as AI begins to automate creative and coding work."*
- Chart data contradicting it: Software Developers' 2027 forecast (-0.9%) is smaller than Services Sales Representatives' 2027 forecast (-1.4%), which was omitted.
- After: *"By 2027, **designers** and **services sales representatives** are expected to see early declines as AI begins to automate creative work and outreach tasks."*

**Section: Jobs Monitor — 2030 tab (growth callout)**
- Before: *"By 2030, **nurses**, **construction workers**, and **engineers** are expected to see the largest gains, driven by an aging population, infrastructure buildouts, and continued demand for technical expertise..."*
- Chart data contradicting it: Engineers' 2030 forecast (+1.5%) ranks below Physicians' 2030 forecast (+3.2%), which was omitted.
- After: *"By 2030, **nurses**, **physicians**, and **construction workers** are expected to see the largest gains, driven by an aging population's growing healthcare needs and continued infrastructure buildouts..."*

**Section: Jobs Monitor — 2030 tab (decline callout)**
- Before: *"By 2030, **software developers**, **financial specialists**, and **lawyers and law clerks** are expected to see the largest declines..."*
- Chart data contradicting it: Lawyers and Law Clerks' 2030 forecast (-5.1%) ranks below Services Sales Representatives' 2030 forecast (-6.0%), which was omitted.
- After: *"By 2030, **software developers**, **services sales representatives**, and **financial specialists** are expected to see the largest declines as AI absorbs coding, customer outreach, and rules-based analysis work..."*

All other sections (Overall Employment, By Job Vulnerability, Wages, Graduates, Economy, State-Level View, and the Research comparison table) were cross-checked against their underlying data and found consistent — no changes made there.

## Test plan
- [x] `prettier --write` on changed files
- [x] `eslint` on changed files — no errors
- [x] `tsc --noEmit` — no type errors
- [ ] Visual check of the Jobs Monitor 2027/2030/2035 tabs on a deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXQKuwYcSdeZAaJzTPWnTP

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXQKuwYcSdeZAaJzTPWnTP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Updated job outlook examples and explanatory text for 2027 and 2030.
  - Refreshed the Labor Hub commentary date to September 4, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->