### PR TITLE
fix: labor hub commentary — Jobs Monitor 2030/2035 occupation order drift

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -18,9 +18,9 @@ export const JOBS_INSIGHTS = {
   "2030": {
     positive: (
       <>
-        By 2030, <strong>nurses</strong>, <strong>physicians</strong>, and{" "}
-        <strong>construction workers</strong> are expected to see the largest
-        gains, driven by an aging population&apos;s growing healthcare needs and
+        By 2030, <strong>nurses</strong>, <strong>construction workers</strong>,
+        and <strong>physicians</strong> are expected to see the largest gains,
+        driven by an aging population&apos;s growing healthcare needs and
         continued infrastructure buildouts that AI is unlikely to fully displace
         in the short term.
       </>
@@ -47,8 +47,8 @@ export const JOBS_INSIGHTS = {
     ),
     negative: (
       <>
-        By 2035, <strong>lawyers and law clerks</strong>,{" "}
-        <strong>financial specialists</strong>, and{" "}
+        By 2035, <strong>financial specialists</strong>,{" "}
+        <strong>lawyers and law clerks</strong>, and{" "}
         <strong>software developers</strong> are expected to see sharp staff
         reductions as AI takes over legal research, analysis, and coding work.{" "}
         <strong>Sales representatives</strong> will also see reductions as AI

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-09-04">Sep 4</time>
+              Commentary last updated: <time dateTime="2026-09-06">Sep 6</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated QA pass over the [Labor Automation Forecasting Hub](https://www.metaculus.com/labor-hub) cross-referencing chart data against commentary text. Live forecast medians have shifted since the last commentary update, causing the Jobs Monitor callouts to list occupations in the wrong order relative to the current chart rankings.

## Fixes

**Jobs Monitor — 2030 growth callout**
- Before: "nurses, physicians, and construction workers are expected to see the largest gains"
- Chart data (2030): Registered Nurses +8.3%, Construction Workers +5.9%, Physicians +3.2% — construction workers now outrank physicians.
- After: "nurses, construction workers, and physicians are expected to see the largest gains"

**Jobs Monitor — 2035 decline callout**
- Before: "lawyers and law clerks, financial specialists, and software developers are expected to see sharp staff reductions"
- Chart data (2035): Financial Specialists -14.2%, Lawyers and Law Clerks -12.3%, Software Developers -12.2% — financial specialists now show the steepest decline.
- After: "financial specialists, lawyers and law clerks, and software developers are expected to see sharp staff reductions"

Also bumped the "Commentary last updated" date in the hero section.

No chart data, component structure, or unrelated code was changed — only the commentary copy in `jobs_insights.tsx` and the date in `hero.tsx`.

## Test plan
- [x] `prettier --write` on changed files
- [x] `eslint` on changed files (no errors)
- [x] Verified new occupation ordering against live chart data extracted from the production page's RSC payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dv76otmUDbfqgBbyVQcP8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dv76otmUDbfqgBbyVQcP8s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the ordering of occupations shown in the 2030 positive-growth and 2035 negative-growth insights.
  * Updated the displayed commentary date from September 4, 2026, to September 6, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->