### PR TITLE
update csv_utils to use inbound_outcome_count

### DIFF
--- a/utils/csv_utils.py
+++ b/utils/csv_utils.py
@@ -438,7 +438,7 @@ def generate_data(
         if question.type in QUESTION_CONTINUOUS_TYPES:
             # locations where CDF is evaluated
             continuous_range = []
-            for x in np.linspace(0, 1, 201):
+            for x in np.linspace(0, 1, (question.inbound_outcome_count or 200) + 1):
                 val = unscaled_location_to_scaled_location(x, question)
                 continuous_range.append(format_value(val))
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exported continuous-question CDF locations now adapt to each question’s configured sample count, with a default fallback when none is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->