### PR TITLE
feat: add GPT-6 Astra to labor hub Activity Monitor

### DIFF
--- a/front_end/src/app/(main)/labor-hub/activity_data.tsx
+++ b/front_end/src/app/(main)/labor-hub/activity_data.tsx
@@ -340,4 +340,20 @@ export const RAW_ACTIVITY_MONITOR_DATA: RawActivityMonitorEntry[] = [
       </>
     ),
   },
+  {
+    date: "2026-09-03",
+    type: "news",
+    content: (
+      <>
+        OpenAI announces the release of GPT-6 Astra. -{" "}
+        <a
+          href="https://openai.com/index/gpt-6-astra/"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          OpenAI
+        </a>
+      </>
+    ),
+  },
 ];


### PR DESCRIPTION
Adds a new Activity Monitor entry to the labor hub:

> September 3, 2026: OpenAI announces the release of GPT-6 Astra. - [OpenAI](https://openai.com/index/gpt-6-astra/)

The entry is typed as `news`, so it appears in the card list and as a timeline marker on the chart.

Closes #5175

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a September 3, 2026 news item announcing OpenAI’s release of GPT-6 Astra, including a link to the original source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->