### PR TITLE
Stop the autotranslation of new content

### DIFF
--- a/metaculus_web/settings.py
+++ b/metaculus_web/settings.py
@@ -611,6 +611,13 @@ GOOGLE_TRANSLATE_SERVICE_ACCOUNT_KEY = os.environ.get(
     "GOOGLE_TRANSLATE_SERVICE_ACCOUNT_KEY", None
 )
 
+# Machine translation of new/edited content. When disabled, the whole
+# translation machinery stays in place (already translated content is still
+# served), but no new content is sent to the translation service.
+AUTOMATIC_TRANSLATIONS_ENABLED = (
+    os.environ.get("AUTOMATIC_TRANSLATIONS_ENABLED", "false").lower() == "true"
+)
+
 CAMPAIGN_USER_REGISTRATION_HOOK_KEY_URL_PAIR = os.environ.get(
     "CAMPAIGN_USER_REGISTRATION_HOOK_KEY_URL_PAIR", None
 )

--- a/posts/admin.py
+++ b/posts/admin.py
@@ -17,6 +17,7 @@ from questions.models import Question
 from questions.services.forecasts import build_question_forecasts
 from utils.csv_utils import export_all_data_for_questions
 from utils.models import CustomTranslationAdmin
+from utils.translation import automatic_translations_enabled
 
 
 @admin.register(Post)
@@ -166,6 +167,12 @@ class PostAdmin(CustomTranslationAdmin):
         return self.export_selected_posts_data(request, queryset, anonymized=True)
 
     def update_translations(self, request, posts_qs):
+        if not automatic_translations_enabled():
+            messages.warning(
+                request, "Automatic translations are disabled, nothing was translated."
+            )
+            return
+
         for post in posts_qs:
             trigger_update_post_translations(post, with_comments=True, force=True)
 

--- a/posts/services/common.py
+++ b/posts/services/common.py
@@ -40,6 +40,7 @@ from utils.models import model_update
 from utils.the_math.aggregations import get_aggregations_at_time
 from utils.the_math.measures import prediction_difference_for_sorting
 from utils.translation import (
+    automatic_translations_enabled,
     detect_and_update_content_language,
     queryset_filter_outdated_translations,
     update_translations_for_model,
@@ -259,7 +260,7 @@ def trigger_update_post_translations(
     batch_size = 10
     comments_qs = get_comments_feed(qs=Comment.objects.filter(), post=post)
 
-    if with_comments:
+    if with_comments and automatic_translations_enabled():
         comments_qs = queryset_filter_outdated_translations(comments_qs)
         detect_and_update_content_language(comments_qs, batch_size)
         update_translations_for_model(comments_qs, batch_size)

--- a/utils/models.py
+++ b/utils/models.py
@@ -13,6 +13,7 @@ from rest_framework.generics import get_object_or_404
 
 from utils.tasks import update_translations_task
 from utils.translation import (
+    automatic_translations_enabled,
     get_translation_fields_for_model,
     build_supported_localized_fieldname,
     is_translation_dirty,
@@ -82,6 +83,13 @@ class CustomTranslationAdmin(admin.ModelAdmin):
 
     @admin.action(description="Update translations")
     def update_translations(self, request, queryset):
+        if not automatic_translations_enabled():
+            messages.warning(
+                request,
+                "Automatic translations are disabled, nothing was translated.",
+            )
+            return
+
         for obj in queryset:
             obj.update_and_maybe_translate()
         messages.success(request, "Translations update triggered")
@@ -196,7 +204,8 @@ class TranslatedModel(models.Model):
         # The function does the following:
         # 1. Copies the truth content from the field mentioned above to the field
         #    with the _original suffix (corresponding to the Untranslated option)
-        # 2. Resets the value to None for all the other language specific fields, because:
+        # 2. If the original content changed, resets the value to None for all the
+        #    other language specific fields, because:
         #    - if the content is not supposed to be translated None is fine (it will default to the _original field)
         #    - if the content is supposed to be translated, it will be translated and set by the translation task
         # 3. If the content is dirty and the content is supposed to be translated (not private, not bot)
@@ -207,15 +216,20 @@ class TranslatedModel(models.Model):
             self.update_fields_with_original_content()
         )
 
-        # 2. Reset the other language specific fields
-        reset_fields = self.reset_localised_fields(all_update_fields)
+        # 2. Reset the other language specific fields.
+        # Untouched content keeps its existing translations, which matters when
+        # automatic translations are off, as nothing would regenerate them.
+        is_dirty = is_translation_dirty(self)
+        reset_fields = (
+            self.reset_localised_fields(all_update_fields) if is_dirty else []
+        )
 
         update_fields = list(set(all_update_fields_localised + reset_fields))
 
         self.save(update_fields=update_fields)
 
         # 3. If the content is dirty and the content is supposed to be translated
-        if should_translate_if_dirty and is_translation_dirty(self):
+        if should_translate_if_dirty and is_dirty and automatic_translations_enabled():
             app_label, model_name = model._meta.app_label, model._meta.model_name
             update_translations_task.send(app_label, model_name, self.pk)
 

--- a/utils/tasks.py
+++ b/utils/tasks.py
@@ -9,6 +9,7 @@ from django.core.mail import EmailMessage
 from questions.types import AggregationMethod
 from utils.dramatiq import task_concurrent_limit
 from utils.translation import (
+    automatic_translations_enabled,
     detect_and_update_content_language,
     queryset_filter_outdated_translations,
     update_translations_for_model,
@@ -28,7 +29,7 @@ logger = logging.getLogger(__name__)
     ttl=60_000,
 )
 def update_translations_task(app_label, model_name, pk):
-    if not settings.GOOGLE_TRANSLATE_SERVICE_ACCOUNT_KEY:
+    if not automatic_translations_enabled():
         return
 
     content_type = ContentType.objects.get(app_label=app_label, model=model_name)

--- a/utils/translation.py
+++ b/utils/translation.py
@@ -117,6 +117,13 @@ async def agoogle_translate_text(source_language, target_language, text):
 
 
 # Other utils
+def automatic_translations_enabled():
+    return bool(
+        settings.AUTOMATIC_TRANSLATIONS_ENABLED
+        and settings.GOOGLE_TRANSLATE_SERVICE_ACCOUNT_KEY
+    )
+
+
 def get_translation_fields_for_model(model):
     opts = translator.get_options_for_model(model)
     return sorted(list(opts.all_fields.keys()))


### PR DESCRIPTION
Adds an `AUTOMATIC_TRANSLATIONS_ENABLED` setting (env var, off by default) that gates every automatic call to the translation service.

All the translation machinery is kept intact (models, localized fields, admin actions, management command, frontend features) and already translated content is still served — only new/edited content is no longer sent to Google Translate. Setting the env var to `true` restores the previous behaviour.

Gated call sites:
- `TranslatedModel.update_and_maybe_translate` no longer enqueues `update_translations_task`
- `update_translations_task` early-returns (also drains already-queued jobs)
- `trigger_update_post_translations` skips the comments translation batch
- Admin "Update translations" actions warn instead of silently doing nothing

Also fixes a related issue: `update_and_maybe_translate` used to null out every localized field on every save, relying on the translation task to refill them. With translations off that would erase existing translations on unrelated edits, so the reset now only happens when the original content actually changed.

Note: the test suite could not be run in the automation job (no PostgreSQL available); ruff format/check pass.

Closes #5172

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable or disable automatic translations.
  * Automatic translations now require both the feature setting and translation service credentials.

* **Bug Fixes**
  * Preserved existing translations when source content is unchanged.
  * Translation updates and queued translation tasks now respect the automatic translation setting.
  * Admin translation actions provide a warning when automatic translations are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->