### PR TITLE
fix: labor hub commentary — 2030 Jobs Monitor decline ranking

### DIFF
--- a/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
+++ b/front_end/src/app/(main)/labor-hub/jobs_insights.tsx
@@ -28,11 +28,11 @@ export const JOBS_INSIGHTS = {
     negative: (
       <>
         By 2030, <strong>software developers</strong>,{" "}
-        <strong>services sales representatives</strong>, and{" "}
-        <strong>financial specialists</strong> are expected to see the largest
-        declines as AI absorbs coding, customer outreach, and rules-based
-        analysis work. Software development leads the drop, with rapid AI
-        adoption and no legal protections.
+        <strong>financial specialists</strong>, and{" "}
+        <strong>services sales representatives</strong> are expected to see the
+        largest declines as AI absorbs coding, rules-based analysis, and
+        customer outreach work. Software development leads the drop, with rapid
+        AI adoption and no legal protections.
       </>
     ),
   },

--- a/front_end/src/app/(main)/labor-hub/sections/hero.tsx
+++ b/front_end/src/app/(main)/labor-hub/sections/hero.tsx
@@ -35,7 +35,7 @@ export function HeroSection({
               </span>
             </div>
             <div className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-500-dark">
-              Commentary last updated: <time dateTime="2026-09-06">Sep 6</time>
+              Commentary last updated: <time dateTime="2026-09-12">Sep 12</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Automated QA pass cross-referencing Labor Hub chart/forecast data against commentary copy. One misalignment found and fixed:

**Jobs Monitor — 2030 decline ranking**
- **Before:** "By 2030, software developers, services sales representatives, and financial specialists are expected to see the largest declines... AI absorbs coding, customer outreach, and rules-based analysis work."
- **Data:** Financial Specialists (−6.1%) has a larger 2030 decline than Services Sales Representatives (−6.0%), so the copy had the second and third occupations swapped relative to the chart's actual ranking (Software Developers −7.3%, Financial Specialists −6.1%, Services Sales Representatives −6.0%).
- **After:** "By 2030, software developers, financial specialists, and services sales representatives are expected to see the largest declines... AI absorbs coding, rules-based analysis, and customer outreach work."

Also bumped the "Commentary last updated" date on the hub.

All other sections checked (Overall Employment, By Job Vulnerability, Key Insights, Wages, Graduates, Economy, State-Level View, Research comparison table, and Jobs Monitor for 2027/2030/2035) were consistent with their underlying forecast data — no other changes made.

## Test plan
- [x] `prettier --write` on changed files
- [x] `eslint` on changed files (clean)
- [x] `tsc --noEmit` — no new errors in changed files
- [x] Verified corrected occupation order and reasoning-clause order against extracted live forecast values (2027/2030/2035) for all 15 tracked occupations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiH5eUR6pD3Bj37EV289N7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiH5eUR6pD3Bj37EV289N7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Reworded the 2030 negative job outlook commentary, including the ordering of declining professions and AI-related work examples.
  - Updated the “Commentary last updated” date to September 12, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->